### PR TITLE
Copy on from astropy CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,11 @@
 
 name: Node.js 14.x CI - Lint, build, test, cap doctor
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    tags:
+  pull_request:
 
 
 jobs:


### PR DESCRIPTION
For some reason the CI reports weren't showing, try copying the on key
from astropy's CI.