### PR TITLE
Add wrapper for project data db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/pouchdb": "^6.4.0",
         "@types/react": "^17.0.3",
         "@types/react-dom": "^17.0.3",
+        "@types/uuid": "^8.3.0",
         "jsonpointer": "^4.1.0",
         "pouchdb": "^7.2.2",
         "pouchdb-find": "^7.2.2",
@@ -27,6 +28,7 @@
         "react-dom": "^17.0.2",
         "react-scripts": "4.0.3",
         "typescript": "^4.2.3",
+        "uuid": "^8.1.0",
         "web-vitals": "^1.1.1"
       },
       "devDependencies": {
@@ -3362,6 +3364,11 @@
       "dependencies": {
         "source-map": "^0.6.1"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.27",
@@ -27354,6 +27361,11 @@
       "requires": {
         "source-map": "^0.6.1"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/webpack": {
       "version": "4.41.27",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/pouchdb": "^6.4.0",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
+    "@types/uuid": "^8.3.0",
     "jsonpointer": "^4.1.0",
     "pouchdb": "^7.2.2",
     "pouchdb-find": "^7.2.2",
@@ -55,6 +56,7 @@
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
     "typescript": "^4.2.3",
+    "uuid": "^8.1.0",
     "web-vitals": "^1.1.1"
   },
   "devDependencies": {

--- a/src/dataStorage.test.ts
+++ b/src/dataStorage.test.ts
@@ -1,0 +1,78 @@
+import {testProp, fc} from 'jest-fast-check';
+import PouchDB from 'pouchdb';
+import {Observation} from './datamodel';
+import {
+  generateFAIMSDataID,
+  upsertFAIMSData,
+  lookupFAIMSDataID,
+} from './dataStorage';
+import {equals} from './utils/eqTestSupport';
+
+import {getDataDB} from './sync/index';
+
+PouchDB.plugin(require('pouchdb-adapter-memory')); // enable memory adaptor for testing
+
+const projdbs: any = {};
+
+function mockDataDB(project_name: string) {
+  if (projdbs[project_name] === undefined) {
+    const db = new PouchDB(project_name, {adapter: 'memory'});
+    projdbs[project_name] = db;
+  }
+  return projdbs[project_name];
+}
+
+async function cleanDataDBS() {
+  let db;
+  for (const project_name in projdbs) {
+    db = projdbs[project_name];
+    delete projdbs[project_name];
+
+    if (db !== undefined) {
+      try {
+        await db.destroy();
+        //await db.close();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
+}
+
+jest.mock('./sync/index', () => ({
+  getDataDB: mockDataDB,
+}));
+
+describe('roundtrip reading and writing to db', () => {
+  testProp(
+    'types roundtrip',
+    [fc.string(), fc.string(), fc.string(), fc.jsonObject()],
+    async (project_name, namespace, name, data) => {
+      fc.pre(!namespace.includes(':'));
+      fc.pre(!name.includes(':'));
+      fc.pre(namespace.trim() !== '');
+      fc.pre(name.trim() !== '');
+      await cleanDataDBS();
+      fc.pre(projdbs !== {});
+
+      const fulltype = namespace + '::' + name;
+
+      const dataid = generateFAIMSDataID();
+
+      const doc: Observation = {
+        _id: dataid,
+        type: fulltype,
+        data: data,
+      };
+
+      return upsertFAIMSData(project_name, doc)
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          delete result['_rev'];
+          expect(equals(result, doc)).toBe(true);
+        });
+    }
+  );
+});

--- a/src/dataStorage.ts
+++ b/src/dataStorage.ts
@@ -1,0 +1,49 @@
+import {v4 as uuidv4} from 'uuid';
+
+import {getDataDB} from './sync/index';
+import {Observation, EncodedObservation} from './datamodel';
+
+export function generateFAIMSDataID(): string {
+  return uuidv4();
+}
+
+function convertFromFormToDB(doc: Observation): EncodedObservation {
+  return {
+    _id: doc._id,
+    type: doc.type,
+    data: doc.data,
+    format_version: 1,
+  };
+}
+
+function convertFromDBToForm(doc: EncodedObservation): Observation {
+  return {
+    _id: doc._id,
+    type: doc.type,
+    data: doc.data,
+  };
+}
+
+export async function upsertFAIMSData(project_name: string, doc: Observation) {
+  const datadb = getDataDB(project_name);
+  try {
+    return await datadb.put(convertFromFormToDB(doc));
+  } catch (err) {
+    console.warn(err);
+    throw Error('failed to save data');
+  }
+}
+
+export async function lookupFAIMSDataID(
+  project_name: string,
+  dataid: string
+): Promise<Observation> {
+  const datadb = getDataDB(project_name);
+  try {
+    const doc = await datadb.get(dataid);
+    return convertFromDBToForm(doc);
+  } catch (err) {
+    console.warn(err);
+    throw Error('failed to find data with id');
+  }
+}

--- a/src/datamodel.ts
+++ b/src/datamodel.ts
@@ -82,9 +82,21 @@ export interface ProjectPeople {
   _rev?: string; // optional as we may want to include the raw json in places
 }
 
+// This is used within the form/ui subsystem, do not use with pouch
 export interface Observation {
-  _id: string;
+  _id?: string; // optional as we may want to include the raw json in places
   _rev?: string; // optional as we may want to include the raw json in places
+  type: string;
+  data: any;
+}
+
+// This is used within the pouch/sync subsystem, do not use with form/ui
+export interface EncodedObservation {
+  _id?: string;
+  _rev?: string; // optional as we may want to include the raw json in places
+  format_version: number;
+  type: string;
+  data: any;
 }
 
 /*

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -57,7 +57,7 @@ export const people_dbs: LocalDBList<DataModel.PeopleDoc> = {};
  * Contain in these databases (indexed by the active_db id's)
  * is project data.
  */
-export const data_dbs: LocalDBList<DataModel.Observation> = {};
+export const data_dbs: LocalDBList<DataModel.EncodedObservation> = {};
 
 /**
  * Synced from the project metadatabase for each active project,
@@ -201,7 +201,7 @@ interface DirectoryEmitter extends EventEmitter {
     listener: (
       listing: DataModel.ListingsObject,
       project: ExistingActiveDoc,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -210,7 +210,7 @@ interface DirectoryEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       project: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -219,7 +219,7 @@ interface DirectoryEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       project: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -266,21 +266,21 @@ interface DirectoryEmitter extends EventEmitter {
     event: 'project_data_complete',
     listing: DataModel.ListingsObject,
     project: ExistingActiveDoc,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'project_complete',
     listing: DataModel.ListingsObject,
     project: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'project_processing',
     listing: DataModel.ListingsObject,
     project: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'project_error',
@@ -416,7 +416,7 @@ interface ListingEmitter extends EventEmitter {
     listener: (
       listing: DataModel.ListingsObject,
       project: ExistingActiveDoc,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -425,7 +425,7 @@ interface ListingEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       project: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -434,7 +434,7 @@ interface ListingEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       project: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -471,21 +471,21 @@ interface ListingEmitter extends EventEmitter {
     event: 'project_data_complete',
     listing: DataModel.ListingsObject,
     project: ExistingActiveDoc,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'project_complete',
     listing: DataModel.ListingsObject,
     project: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'project_processing',
     listing: DataModel.ListingsObject,
     project: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'project_error',
@@ -630,7 +630,7 @@ interface ProjectEmitter extends EventEmitter {
     event: 'data_complete',
     listener: (
       project: ExistingActiveDoc,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -638,7 +638,7 @@ interface ProjectEmitter extends EventEmitter {
     listener: (
       project: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(
@@ -646,7 +646,7 @@ interface ProjectEmitter extends EventEmitter {
     listener: (
       project: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.Observation>
+      data: LocalDB<DataModel.EncodedObservation>
     ) => unknown
   ): this;
   on(event: 'error', listener: (err: unknown) => unknown): this;
@@ -659,19 +659,19 @@ interface ProjectEmitter extends EventEmitter {
   emit(
     event: 'data_complete',
     project: ExistingActiveDoc,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'complete',
     project: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(
     event: 'processing',
     project: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.Observation>
+    data: LocalDB<DataModel.EncodedObservation>
   ): boolean;
   emit(event: 'error', err: unknown): boolean;
 }


### PR DESCRIPTION
This gets/puts data from the form to the db, converting between what the form wants and the db wants. Simple enough for now, but we're going to need this division to handle ACLs properly.