### PR TITLE
Warn for unknown components, render remaining

### DIFF
--- a/src/dummyData.ts
+++ b/src/dummyData.ts
@@ -4,6 +4,33 @@ import {ProjectUIModel} from './datamodel';
 const example_ui_specs: {[key: string]: ProjectUIModel} = {
   'default/projectA': {
     fields: {
+      'bad-field': {
+        'component-namespace': 'fakefakefake', // this says what web component to use to render/acquire value from
+        'component-name': 'NotAComponent',
+        'type-returned': 'faims-core::Email', // matches a type in the Project Model
+        'component-parameters': {
+          fullWidth: true,
+          name: 'email-field',
+          id: 'email-field',
+          helperText: 'Some helper text for email field',
+          variant: 'outlined',
+          required: true,
+          InputProps: {
+            type: 'email',
+          },
+          SelectProps: {},
+          InputLabelProps: {
+            label: 'Email Address',
+          },
+          FormHelperTextProps: {},
+        },
+        validationSchema: [
+          ['yup.string'],
+          ['yup.email', 'Enter a valid email'],
+          ['yup.required'],
+        ],
+        initialValue: '',
+      },
       'email-field': {
         'component-namespace': 'formik-material-ui', // this says what web component to use to render/acquire value from
         'component-name': 'TextField',
@@ -223,6 +250,7 @@ const example_ui_specs: {[key: string]: ProjectUIModel} = {
     views: {
       'start-view': {
         fields: [
+          'bad-field',
           'email-field',
           'str-field',
           'int-field',

--- a/src/gui/form.tsx
+++ b/src/gui/form.tsx
@@ -74,10 +74,16 @@ export class FAIMSForm extends React.Component<FormProps, FormState> {
     fieldName: string
   ) {
     // console.log('getComponentFromFieldConfig');
-    const Component = getComponentByName(
-      fieldConfig['component-namespace'],
-      fieldConfig['component-name']
-    );
+    const namespace = fieldConfig['component-namespace'];
+    const name = fieldConfig['component-name'];
+    let Component;
+    try {
+      Component = getComponentByName(namespace, name);
+    } catch (err) {
+      console.debug(err);
+      console.warn(`Failed to load component ${namespace}::${name}`);
+      return undefined;
+    }
     const formProps = view.props.formProps;
     const errors = formProps.errors;
     return (


### PR DESCRIPTION
See FAIMS3-152, this allows "Hierarchical and image galleries" to be
contained within the specification, but not cause the form to break.
Currently there is no user feedback about the missing component, but
errors are fully exposed in the console for debugging.