### PR TITLE
Request location permission in android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,4 +60,10 @@
     <!-- Audio -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <!-- Geolocation API -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- require hardware gps - commented for now
+    <uses-feature android:name="android.hardware.location.gps" />
+    -->
 </manifest>


### PR DESCRIPTION
This does not include the actual TakePoint button, I'm still playing with that. But this is needed to access location on android. Note we do not require a GPS to install the app (which @Denubis is what we want - I'm guessing some devices that we're targeting will not have a builtin GPS?).