### PR TITLE
Allow all 'ConnectionInfo' objects to omit hosts

### DIFF
--- a/src/datamodel.ts
+++ b/src/datamodel.ts
@@ -9,12 +9,22 @@ export interface ConnectionInfo {
   db_name: string;
 }
 
+export type PossibleConnectionInfo =
+  | undefined
+  | {
+      proto?: string | undefined;
+      host?: string | undefined;
+      port?: number | undefined;
+      lan?: boolean | undefined;
+      db_name?: string | undefined;
+    };
+
 export interface ListingsObject {
   _id: string;
   name: string;
   description: string;
-  projects_db?: ConnectionInfo;
-  people_db?: ConnectionInfo;
+  projects_db?: PossibleConnectionInfo;
+  people_db?: PossibleConnectionInfo;
 }
 
 export interface NonNullListingsObject extends ListingsObject {
@@ -39,8 +49,8 @@ export interface ProjectObject {
   _id: string;
   name: string;
   description: string;
-  data_db?: ConnectionInfo;
-  metadata_db?: ConnectionInfo;
+  data_db?: PossibleConnectionInfo;
+  metadata_db?: PossibleConnectionInfo;
 }
 
 export type ProjectsList = {


### PR DESCRIPTION
This removes the need for "host", "port" and "protocol" elements of things in the directory and projects DB.
When they're not present, the client falls back to whatever it got the ConnectionInfo from, 
i.e. if directory has a doc 
```json
  "id": "Test DB"
  "projects_db": {
    "db_name": "projects"
  }
```
The client uses the IP/port/protocol that the directory DB is hosted on
Similarly if projects db contains the following project doc:
```json
{
  "_id": "lake_mungo",
  "name": "Lake Mungo Archaeological Survey - 2018",
  "data_db": {
    "db_name": "lake_mungo"
  }
}
```
Then the client uses the IP/port/protocol that the projects DB is hosted on.
Of course they can still add IP/port/protocol 
```json
{
  "_id": "lake_mungo",
  "name": "Lake Mungo Archaeological Survey - 2018",
  "data_db": {
    "proto": "https",
    "host": "dev.db.faims.edu.au",
    "port": 443,
    "db_name": "lake_mungo"
  }
}
```

This change is mainly for us devs since we're using the same couchDB instance, and also means we can replicate across couch instances without the clients going to the wrong hostname