### PR TITLE
Fix ObservationForm using 'new-observation' for existing observations

### DIFF
--- a/src/gui/pages/observation.tsx
+++ b/src/gui/pages/observation.tsx
@@ -51,6 +51,7 @@ export default function Observation() {
             <ObservationForm
               listing_id_project_id={listing_id_project_id}
               observation_id={observation_id}
+              is_fresh={observation_id === 'new-observation'}
             />
           </TabPanel>
           <TabPanel value="2">Revisions</TabPanel>


### PR DESCRIPTION
This properly utilizes the observation_id prop, changed from the
observation?: {_id, _rev} prop

Adds a is_fresh prop since for now, we don't have revision IDs
in the URL and so this allows us to on-demand get the latest revision ID
when it's needed by staging code.
TODO: Move lookup of latest revision to getStagedData/setStagedData

This change was required because 1) Revision ID's aren't always availble,
2) We decided to always generate a UUID, hence move the generation to the
observation page, 3) so there's no need for the separate newly-generated
'obsid', using just the props