### PR TITLE
Hide creation information for now

### DIFF
--- a/src/gui/components/observation/table.tsx
+++ b/src/gui/components/observation/table.tsx
@@ -67,8 +67,8 @@ export default function ObservationsTable(props: ObservationsTableProps) {
         </Link>
       ),
     },
-    {field: 'created', headerName: 'Created', type: 'dateTime', width: 200},
-    {field: 'created_by', headerName: 'Created by', type: 'string', width: 200},
+    //{field: 'created', headerName: 'Created', type: 'dateTime', width: 200},
+    //{field: 'created_by', headerName: 'Created by', type: 'string', width: 200},
     {field: 'updated', headerName: 'Updated', type: 'dateTime', width: 200},
     {
       field: 'updated_by',


### PR DESCRIPTION
There is a planned change in how we're going to store the data to handle
the ACLs and work with revisions in a more user-friendly way, but we're
holding that off to beta. That will make managing the creation
information easier (so we don't need to try to keep track of it via the
form), so we're going to hide the dummy data for now.