### PR TITLE
Fixes useEffect rendering depth issue by providing dependency arrays …

### DIFF
--- a/src/gui/components/observation/table.tsx
+++ b/src/gui/components/observation/table.tsx
@@ -19,6 +19,7 @@
  */
 
 import React, {useEffect, useState} from 'react';
+import _ from 'lodash';
 import {
   DataGrid,
   GridColDef,
@@ -43,7 +44,6 @@ type ObservationsTableProps = {
 export default function ObservationsTable(props: ObservationsTableProps) {
   const {project_id, maxRows} = props;
   const [loading, setLoading] = useState(true);
-  const pouchObservationList = {};
   const theme = useTheme();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
   const defaultMaxRowsMobile = 10;
@@ -77,18 +77,22 @@ export default function ObservationsTable(props: ObservationsTableProps) {
       width: 200,
     },
   ];
+
   useEffect(() => {
+    //  Dependency is only the project_id, ie., register one callback for this component
+    // on load - if the observation list is updated, the callback should be fired
     if (project_id === undefined) return; //dummy project
     const destroyListener = listenObservationsList(
       project_id,
-      newObservationList => {
+      newPouchObservationList => {
         setLoading(false);
-        Object.assign(pouchObservationList, newObservationList);
-        setRows(Object.values(pouchObservationList));
+        if (!_.isEqual(Object.values(newPouchObservationList), rows)) {
+          setRows(Object.values(newPouchObservationList));
+        }
       }
     );
     return destroyListener; // destroyListener called when this component unmounts.
-  }, []);
+  }, [project_id]);
 
   return (
     <div>

--- a/src/gui/pages/about-build.tsx
+++ b/src/gui/pages/about-build.tsx
@@ -19,7 +19,7 @@
  */
 
 import React from 'react';
-import {Container} from '@material-ui/core';
+import {Box, Container} from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import * as ROUTES from '../../constants/routes';
 import {
@@ -33,39 +33,48 @@ import {
 } from '../../buildconfig';
 import Breadcrumbs from '../components/ui/breadcrumbs';
 import {wipe_all_pouch_databases} from '../../sync';
+import grey from '@material-ui/core/colors/grey';
+import BoxTab from '../components/ui/boxTab';
 
 export default function AboutBuild() {
   const breadcrumbs = [
     {link: ROUTES.INDEX, title: 'Index'},
-    {title: 'About-Build'},
+    {title: 'about-build'},
   ];
   return (
     <Container maxWidth="lg">
       <Breadcrumbs data={breadcrumbs} />
-      <table>
-        <tr>
-          <td>Directory Server</td>
-          <td>
-            {DIRECTORY_PROTOCOL}://{DIRECTORY_HOST}:{DIRECTORY_PORT}/
-          </td>
-        </tr>
-        <tr>
-          <td>Commit Version</td>
-          <td>{COMMIT_VERSION}</td>
-        </tr>
-        <tr>
-          <td>Using real data</td>
-          <td>{USE_REAL_DATA ? 'True' : 'False'}</td>
-        </tr>
-        <tr>
-          <td>Running under test</td>
-          <td>{RUNNING_UNDER_TEST ? 'True' : 'False'}</td>
-        </tr>
-        <tr>
-          <td>Autoactivating projects</td>
-          <td>{AUTOACTIVATE_PROJECTS ? 'True' : 'False'}</td>
-        </tr>
-      </table>
+      <BoxTab title={'Developer tool: About the build'} bgcolor={grey[100]} />
+      <Box bgcolor={grey[100]} p={2} style={{overflowX: 'scroll'}} mb={2}>
+        <pre>
+          <table>
+            <tbody>
+              <tr>
+                <td>Directory Server</td>
+                <td>
+                  {DIRECTORY_PROTOCOL}://{DIRECTORY_HOST}:{DIRECTORY_PORT}/
+                </td>
+              </tr>
+              <tr>
+                <td>Commit Version</td>
+                <td>{COMMIT_VERSION}</td>
+              </tr>
+              <tr>
+                <td>Using real data</td>
+                <td>{USE_REAL_DATA ? 'True' : 'False'}</td>
+              </tr>
+              <tr>
+                <td>Running under test</td>
+                <td>{RUNNING_UNDER_TEST ? 'True' : 'False'}</td>
+              </tr>
+              <tr>
+                <td>Autoactivating projects</td>
+                <td>{AUTOACTIVATE_PROJECTS ? 'True' : 'False'}</td>
+              </tr>
+            </tbody>
+          </table>
+        </pre>
+      </Box>
       <Button
         variant="outlined"
         color={'secondary'}

--- a/src/gui/pages/project-list.tsx
+++ b/src/gui/pages/project-list.tsx
@@ -74,7 +74,7 @@ export default function ProjectList() {
 
   useEffect(() => {
     return listenProjectList(setProjectList);
-  });
+  }, []);
 
   return (
     <Container maxWidth="lg">


### PR DESCRIPTION
If you look at the JS console for the project-list page, you'll see the two errors described in FAIMS3-252. 

This PR checks for a change in rows in the observation table before calling setState, as well as adding the dependency array to the useEffect hook to only call e.g., when the project_id changes. @aidanfar0 can you verify these changes are compatible with your **listenObservationsList** and **listenProjectList** functions? (i.e., the syncing still works as you expect!)

Signed-off-by: Liz Mannering <elizabeth.mannering@mq.edu.au>