### PR TITLE
Fix issue of observation list sometimes not updating

### DIFF
--- a/src/gui/components/observation/table.tsx
+++ b/src/gui/components/observation/table.tsx
@@ -92,7 +92,7 @@ export default function ObservationsTable(props: ObservationsTableProps) {
       }
     );
     return destroyListener; // destroyListener called when this component unmounts.
-  }, [project_id]);
+  }, [project_id, rows]);
 
   return (
     <div>


### PR DESCRIPTION
This was caused by using the 'rows' state variable, but not having it
in the dependencies of useEffect makes it possible for rows to be out
of date.

Signed-off-by: Aidan Farrell <aidan.farrell@mq.edu.au>