### PR TITLE
Split apart datamodel.ts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ import {MuiThemeProvider} from '@material-ui/core/styles';
 // will be resolved in material-ui v5
 
 import {createdProjects} from './sync/state';
-import {ProjectsList} from './datamodel';
+import {ProjectsList} from './datamodel/database';
 import theme from './gui/theme';
 
 type AppProps = {};

--- a/src/actions.tsx
+++ b/src/actions.tsx
@@ -18,7 +18,8 @@
  *   TODO
  */
 
-import {ProjectObject, Observation} from './datamodel';
+import {ProjectObject} from './datamodel/database';
+import {Observation} from './datamodel/ui';
 import {Color} from '@material-ui/lab/Alert';
 
 export enum ActionType {

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -18,7 +18,7 @@
  *   TODO
  */
 
-import {ProjectID, ObservationID, RevisionID} from '../datamodel';
+import {ProjectID, ObservationID, RevisionID} from '../datamodel/core';
 
 export const INDEX = '/';
 export const SIGN_UP = '/signup';

--- a/src/data_storage.test.ts
+++ b/src/data_storage.test.ts
@@ -20,7 +20,8 @@
 
 import {testProp, fc} from 'jest-fast-check';
 import PouchDB from 'pouchdb';
-import {Observation, ProjectID} from './datamodel';
+import {ProjectID} from './datamodel/core';
+import {Observation} from './datamodel/ui';
 import {
   deleteFAIMSDataForID,
   generateFAIMSDataID,

--- a/src/data_storage/index.ts
+++ b/src/data_storage/index.ts
@@ -21,15 +21,9 @@
 import {v4 as uuidv4} from 'uuid';
 
 import {getDataDB} from '../sync';
-import {
-  Observation,
-  ObservationID,
-  ObservationMetadata,
-  ProjectID,
-  Revision,
-  RevisionID,
-  //  OBSERVATION_INDEX_NAME,
-} from '../datamodel';
+import {ObservationID, ProjectID, RevisionID} from '../datamodel/core';
+import {Revision} from '../datamodel/database';
+import {Observation, ObservationMetadata} from '../datamodel/ui';
 import {
   addNewRevisionFromForm,
   generateFAIMSRevisionID,

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -21,22 +21,17 @@
 import {v4 as uuidv4} from 'uuid';
 
 import {getDataDB} from '../sync';
+import {DatumID, ObservationID, ProjectID, RevisionID} from '../datamodel/core';
 import {
   Datum,
   DatumMap,
-  DatumID,
   DatumIDMap,
   EncodedObservation,
-  Observation,
-  ObservationID,
-  ObservationMetadataList,
   ObservationMap,
-  ProjectID,
   Revision,
-  RevisionID,
   RevisionMap,
-  //  OBSERVATION_INDEX_NAME,
-} from '../datamodel';
+} from '../datamodel/database';
+import {Observation, ObservationMetadataList} from '../datamodel/ui';
 
 type EncodedObservationMap = Map<ObservationID, EncodedObservation>;
 

--- a/src/data_storage/listeners.ts
+++ b/src/data_storage/listeners.ts
@@ -18,7 +18,9 @@
  *   TODO
  */
 
-import {ActiveDoc, ProjectID, ObservationMetadataList} from '../datamodel';
+import {ProjectID} from '../datamodel/core';
+import {ActiveDoc} from '../datamodel/database';
+import {ObservationMetadataList} from '../datamodel/ui';
 import {ExistingActiveDoc} from '../sync/databases';
 import {events} from '../sync/events';
 import {add_initial_listener} from '../sync/event-handler-registration';

--- a/src/databaseAccess.tsx
+++ b/src/databaseAccess.tsx
@@ -29,7 +29,8 @@
  *   (Sync refactor)
  */
 
-import {ProjectInformation, ProjectID} from './datamodel';
+import {ProjectID} from './datamodel/core';
+import {ProjectInformation} from './datamodel/ui';
 import {
   createdProjects,
   createdProjectsInterface,

--- a/src/datamodel.test.ts
+++ b/src/datamodel.test.ts
@@ -23,7 +23,7 @@ import {
   resolve_observation_id,
   split_full_observation_id,
   SplitObservationID,
-} from './datamodel';
+} from './datamodel/core';
 
 testProp('not a full observation id errors', [fc.fullUnicodeString()], id => {
   fc.pre(!id.includes('||'));

--- a/src/datamodel/core.ts
+++ b/src/datamodel/core.ts
@@ -18,7 +18,21 @@
  *   TODO
  */
 
+// There are two internal IDs for projects, the former is unique to the system
+// (i.e. includes the listing_id), the latter is unique only to the 'projects'
+// database it came from, for a FAIMS listing
+// (It is this way because the list of projects is decentralised and so we
+// cannot enforce system-wide unique project IDs without a 'namespace' listing id)
 export type ProjectID = string;
+export type NonUniqueProjectID = string;
+
+export function resolve_project_id(
+  listing_id: string,
+  nonunique_id: NonUniqueProjectID
+): ProjectID {
+  const cleaned_listing_id = listing_id.replace('||', '\\|\\|');
+  return cleaned_listing_id + '||' + nonunique_id;
+}
 
 // There are two internal ID for observations, the former is unique to a
 // project, the latter unique to the system (i.e. includes project_id)

--- a/src/datamodel/core.ts
+++ b/src/datamodel/core.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: core.ts
+ * Description:
+ *   TODO
+ */
+
+export type ProjectID = string;
+
+// There are two internal ID for observations, the former is unique to a
+// project, the latter unique to the system (i.e. includes project_id)
+export type ObservationID = string;
+export type FullyResolvedObservationID = string;
+export interface SplitObservationID {
+  project_id: string;
+  observation_id: ObservationID;
+}
+
+export function resolve_observation_id(
+  split_id: SplitObservationID
+): FullyResolvedObservationID {
+  const cleaned_project_id = split_id.project_id.replace('||', '\\|\\|');
+  return cleaned_project_id + '||' + split_id.observation_id;
+}
+
+export function split_full_observation_id(
+  full_proj_id: FullyResolvedObservationID
+): SplitObservationID {
+  const splitid = full_proj_id.split('||');
+  if (
+    splitid.length !== 2 ||
+    splitid[0].trim() === '' ||
+    splitid[1].trim() === ''
+  ) {
+    throw Error('Not a valid full observation id');
+  }
+  const cleaned_project_id = splitid[0].replace('\\|\\|', '||');
+  return {
+    project_id: cleaned_project_id,
+    observation_id: splitid[1],
+  };
+}
+
+export type RevisionID = string;
+export type DatumID = string;

--- a/src/datamodel/database.ts
+++ b/src/datamodel/database.ts
@@ -18,7 +18,13 @@
  *   TODO
  */
 
-import {ProjectID, ObservationID, RevisionID, DatumID} from './core';
+import {
+  NonUniqueProjectID,
+  ObservationID,
+  RevisionID,
+  DatumID,
+  ProjectID,
+} from './core';
 import {
   FAIMSConstantCollection,
   FAIMSTypeCollection,
@@ -71,9 +77,9 @@ export interface NonNullListingsObject extends ListingsObject {
 }
 
 export interface ActiveDoc {
-  _id: string;
+  _id: ProjectID;
   listing_id: string;
-  project_id: ProjectID;
+  project_id: NonUniqueProjectID;
   username: string | null;
   password: string | null;
   friendly_name?: string;

--- a/src/datamodel/index.ts
+++ b/src/datamodel/index.ts
@@ -13,25 +13,9 @@
  * See, the License, for the specific language governing permissions and
  * limitations under the License.
  *
- * Filename: users.ts
+ * Filename: index.ts
  * Description:
  *   TODO
  */
 
-import {active_db} from './sync/databases';
-import {ProjectID} from './datamodel/core';
-
-export async function getFriendlyUserName(
-  project_id: ProjectID
-): Promise<string> {
-  const doc = await active_db.get(project_id);
-  if (doc.friendly_name === undefined) {
-    return doc.username || 'Dummy User';
-  }
-  return doc.friendly_name;
-}
-
-export async function getCurrentUserId(project_id: ProjectID): Promise<string> {
-  const doc = await active_db.get(project_id);
-  return doc.username || 'Dummy User';
-}
+export {}; // Is there anything we should be exporting?

--- a/src/datamodel/staging.ts
+++ b/src/datamodel/staging.ts
@@ -13,25 +13,15 @@
  * See, the License, for the specific language governing permissions and
  * limitations under the License.
  *
- * Filename: users.ts
+ * Filename: staging.ts
  * Description:
  *   TODO
  */
 
-import {active_db} from './sync/databases';
-import {ProjectID} from './datamodel/core';
-
-export async function getFriendlyUserName(
-  project_id: ProjectID
-): Promise<string> {
-  const doc = await active_db.get(project_id);
-  if (doc.friendly_name === undefined) {
-    return doc.username || 'Dummy User';
-  }
-  return doc.friendly_name;
-}
-
-export async function getCurrentUserId(project_id: ProjectID): Promise<string> {
-  const doc = await active_db.get(project_id);
-  return doc.username || 'Dummy User';
+export interface SavedView {
+  // ID: active_id + '/' + view_name
+  // OR: active_id + '/' + view_name + '/' + existing.observation + '/' + existing.revision
+  _id: string;
+  // Fields
+  [key: string]: unknown;
 }

--- a/src/datamodel/typesystem.ts
+++ b/src/datamodel/typesystem.ts
@@ -13,25 +13,31 @@
  * See, the License, for the specific language governing permissions and
  * limitations under the License.
  *
- * Filename: users.ts
+ * Filename: typesystem.ts
  * Description:
  *   TODO
  */
 
-import {active_db} from './sync/databases';
-import {ProjectID} from './datamodel/core';
-
-export async function getFriendlyUserName(
-  project_id: ProjectID
-): Promise<string> {
-  const doc = await active_db.get(project_id);
-  if (doc.friendly_name === undefined) {
-    return doc.username || 'Dummy User';
-  }
-  return doc.friendly_name;
+export interface FAIMSType {
+  [key: string]: any; // any for now until we lock down the json
 }
 
-export async function getCurrentUserId(project_id: ProjectID): Promise<string> {
-  const doc = await active_db.get(project_id);
-  return doc.username || 'Dummy User';
+export interface FAIMSTypeCollection {
+  [key: string]: FAIMSType;
+}
+
+export interface FAIMSConstant {
+  [key: string]: any; // any for now until we lock down the json
+}
+
+export interface FAIMSConstantCollection {
+  [key: string]: FAIMSConstant;
+}
+
+export interface ProjectUIFields {
+  [key: string]: any;
+}
+
+export interface ProjectUIViews {
+  [key: string]: any;
 }

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: ui.ts
+ * Description:
+ *   TODO
+ */
+
+/**
+ * User readable information about a project
+ * Do not use with sync code; UI code only
+ */
+
+import {ProjectID, ObservationID, RevisionID, DatumID} from './core';
+import {ProjectUIFields, ProjectUIViews} from './typesystem';
+
+export interface ProjectInformation {
+  project_id: ProjectID;
+  name: string;
+  description?: string;
+  last_updated?: string;
+  created?: string;
+  status?: string;
+}
+
+export interface ProjectUIModel {
+  _id?: string; // optional as we may want to include the raw json in places
+  _rev?: string; // optional as we may want to include the raw json in places
+  fields: ProjectUIFields;
+  views: ProjectUIViews;
+  start_view: string;
+}
+
+export interface ObservationMetadata {
+  project_id: ProjectID;
+  observation_id: ObservationID;
+  revision_id: RevisionID;
+  created: Date;
+  created_by: string;
+  updated: Date;
+  updated_by: string;
+  conflicts: boolean;
+}
+
+export type ObservationMetadataList = {
+  [key: string]: ObservationMetadata;
+};
+
+// This is used within the form/ui subsystem, do not use with pouch
+export interface Observation {
+  project_id?: ProjectID;
+  observation_id: ObservationID;
+  revision_id: RevisionID | null;
+  type: string;
+  data: {[field_name: string]: any};
+  updated: Date;
+  updated_by: string;
+  /*
+  created{_by} are optional as we don't need to track them with the actual data.
+  If you need creation information, then use observation metadata
+  */
+  created?: Date;
+  created_by?: string;
+}
+
+export type ObservationList = {
+  [key: string]: Observation;
+};

--- a/src/dummyData.ts
+++ b/src/dummyData.ts
@@ -21,13 +21,12 @@
 import {setUiSpecForProject} from './uiSpecification';
 import {
   ActiveDoc,
-  Observation,
   ListingsObject,
   ProjectMetaObject,
   ProjectObject,
   ProjectsList,
-  ProjectUIModel,
-} from './datamodel';
+} from './datamodel/database';
+import {Observation, ProjectUIModel} from './datamodel/ui';
 import {setProjectMetadata} from './projectMetadata';
 import {upsertFAIMSData} from './data_storage';
 

--- a/src/gui/components/dashboard/actions.tsx
+++ b/src/gui/components/dashboard/actions.tsx
@@ -25,7 +25,7 @@ import {Grid, Button, TextField} from '@material-ui/core';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 // import Skeleton from '@material-ui/lab/Skeleton';
 import * as ROUTES from '../../../constants/routes';
-import {ProjectInformation} from '../../../datamodel';
+import {ProjectInformation} from '../../../datamodel/ui';
 type DashboardActionProps = {
   pouchProjectList: ProjectInformation[];
 };

--- a/src/gui/components/metadataRenderer.tsx
+++ b/src/gui/components/metadataRenderer.tsx
@@ -21,7 +21,7 @@
 import React, {useEffect, useState} from 'react';
 import {CircularProgress, Chip} from '@material-ui/core';
 import {getProjectMetadata} from '../../projectMetadata';
-import {ProjectID} from '../../datamodel';
+import {ProjectID} from '../../datamodel/core';
 
 type MetadataProps = {
   project_id: ProjectID;

--- a/src/gui/components/navbar.tsx
+++ b/src/gui/components/navbar.tsx
@@ -51,7 +51,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import * as ROUTES from '../../constants/routes';
 import {getProjectList} from '../../databaseAccess';
 import SystemAlert from './alert';
-import {ProjectInformation} from '../../datamodel';
+import {ProjectInformation} from '../../datamodel/ui';
 
 // type NavBarState = {
 //   topMenuItems: any;

--- a/src/gui/components/observation/delete.tsx
+++ b/src/gui/components/observation/delete.tsx
@@ -35,7 +35,7 @@ import {Alert} from '@material-ui/lab';
 import {ActionType} from '../../../actions';
 import * as ROUTES from '../../../constants/routes';
 import {store} from '../../../store';
-import {ProjectID, ObservationID, RevisionID} from '../../../datamodel';
+import {ProjectID, ObservationID, RevisionID} from '../../../datamodel/core';
 import {getCurrentUserId} from '../../../users';
 import {setObservationAsDeleted} from '../../../data_storage';
 

--- a/src/gui/components/observation/form.tsx
+++ b/src/gui/components/observation/form.tsx
@@ -35,12 +35,8 @@ import {getComponentByName} from '../../ComponentRegistry';
 import {getUiSpecForProject} from '../../../uiSpecification';
 import {ViewComponent} from '../../view';
 import {upsertFAIMSData, getFullObservationData} from '../../../data_storage';
-import {
-  ProjectUIModel,
-  ProjectID,
-  ObservationID,
-  RevisionID,
-} from '../../../datamodel';
+import {ProjectID, ObservationID, RevisionID} from '../../../datamodel/core';
+import {ProjectUIModel} from '../../../datamodel/ui';
 import {getStagedData, setStagedData} from '../../../sync/staging';
 import {getCurrentUserId} from '../../../users';
 import BoxTab from '../ui/boxTab';

--- a/src/gui/components/observation/meta.tsx
+++ b/src/gui/components/observation/meta.tsx
@@ -28,7 +28,7 @@ import {
 } from '@material-ui/core';
 
 import {getObservationMetadata} from '../../../data_storage';
-import {ProjectID, ObservationID, RevisionID} from '../../../datamodel';
+import {ProjectID, ObservationID, RevisionID} from '../../../datamodel/core';
 
 type ObservationMetaProps = {
   project_id: ProjectID;

--- a/src/gui/components/observation/table.tsx
+++ b/src/gui/components/observation/table.tsx
@@ -32,7 +32,8 @@ import Link from '@material-ui/core/Link';
 import {useTheme} from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
-import {ObservationMetadata, ProjectID} from '../../../datamodel';
+import {ProjectID} from '../../../datamodel/core';
+import {ObservationMetadata} from '../../../datamodel/ui';
 import * as ROUTES from '../../../constants/routes';
 import {listenObservationsList} from '../../../data_storage/listeners';
 

--- a/src/gui/components/project/card.tsx
+++ b/src/gui/components/project/card.tsx
@@ -44,7 +44,7 @@ import {
 import {Link as RouterLink} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
 import {makeStyles} from '@material-ui/core/styles';
-import {ProjectInformation} from '../../../datamodel';
+import {ProjectInformation} from '../../../datamodel/ui';
 import ObservationsTable from '../observation/table';
 import MetadataRenderer from '../metadataRenderer';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';

--- a/src/gui/components/project/cardHeaderAction.tsx
+++ b/src/gui/components/project/cardHeaderAction.tsx
@@ -16,7 +16,7 @@ import * as ROUTES from '../../../constants/routes';
 import {useTheme} from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
-import {ProjectInformation} from '../../../datamodel';
+import {ProjectInformation} from '../../../datamodel/ui';
 
 type ProjectCardActionProps = {
   project: ProjectInformation;

--- a/src/gui/components/project/sync.tsx
+++ b/src/gui/components/project/sync.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Box, Switch, FormControlLabel, Typography} from '@material-ui/core';
 
-import {ProjectInformation} from '../../../datamodel';
+import {ProjectInformation} from '../../../datamodel/ui';
 import {
   isSyncingProject,
   setSyncingProject,

--- a/src/gui/pages/observation-create.tsx
+++ b/src/gui/pages/observation-create.tsx
@@ -26,7 +26,7 @@ import Breadcrumbs from '../components/ui/breadcrumbs';
 import {generateFAIMSDataID} from '../../data_storage';
 import ObservationForm from '../components/observation/form';
 import {getProjectInfo} from '../../databaseAccess';
-import {ProjectID} from '../../datamodel';
+import {ProjectID} from '../../datamodel/core';
 
 export default function ObservationCreate() {
   const {project_id} = useParams<{

--- a/src/gui/pages/observation.tsx
+++ b/src/gui/pages/observation.tsx
@@ -35,7 +35,7 @@ import TabPanel from '@material-ui/lab/TabPanel';
 import grey from '@material-ui/core/colors/grey';
 
 import * as ROUTES from '../../constants/routes';
-import {ProjectID, ObservationID, RevisionID} from '../../datamodel';
+import {ProjectID, ObservationID, RevisionID} from '../../datamodel/core';
 import {getProjectInfo} from '../../databaseAccess';
 import {listFAIMSObservationRevisions} from '../../data_storage';
 

--- a/src/gui/pages/project-list.tsx
+++ b/src/gui/pages/project-list.tsx
@@ -26,7 +26,7 @@ import ProjectCard from '../components/project/card';
 import * as ROUTES from '../../constants/routes';
 // import {store} from '../../store';
 import {listenProjectList} from '../../databaseAccess';
-import {ProjectInformation} from '../../datamodel';
+import {ProjectInformation} from '../../datamodel/ui';
 import {useState} from 'react';
 import {useEffect} from 'react';
 import {CircularProgress} from '@material-ui/core';

--- a/src/gui/pages/project.tsx
+++ b/src/gui/pages/project.tsx
@@ -26,7 +26,7 @@ import ProjectCard from '../components/project/card';
 import * as ROUTES from '../../constants/routes';
 
 import {getProjectInfo} from '../../databaseAccess';
-import {ProjectID} from '../../datamodel';
+import {ProjectID} from '../../datamodel/core';
 
 export default function Project() {
   const {project_id} = useParams<{project_id: ProjectID}>();

--- a/src/gui/validationHelpers.ts
+++ b/src/gui/validationHelpers.ts
@@ -20,7 +20,7 @@
 
 /* eslint-disable */
 import {createTypeContext,lookupFAIMSType} from '../projectSpecification';
-import {ProjectID} from '../datamodel';
+import {ProjectID} from '../datamodel/core';
 
 type validationResult = {
   err: boolean;

--- a/src/projectMetadata.test.ts
+++ b/src/projectMetadata.test.ts
@@ -21,7 +21,7 @@
 import {testProp, fc} from 'jest-fast-check';
 import PouchDB from 'pouchdb';
 import {getProjectMetadata, setProjectMetadata} from './projectMetadata';
-import {ProjectID} from './datamodel';
+import {ProjectID} from './datamodel/core';
 import {equals} from './utils/eqTestSupport';
 
 import {getProjectDB} from './sync/index';

--- a/src/projectMetadata.ts
+++ b/src/projectMetadata.ts
@@ -18,11 +18,11 @@
  *   TODO
  */
 import {getProjectDB} from './sync/index';
+import {ProjectID} from './datamodel/core';
 import {
   PROJECT_METADATA_PREFIX,
   EncodedProjectMetadata,
-  ProjectID,
-} from './datamodel';
+} from './datamodel/database';
 
 export async function getProjectMetadata(
   project_id: ProjectID,

--- a/src/projectSpecification.test.ts
+++ b/src/projectSpecification.test.ts
@@ -29,7 +29,7 @@ import {
   upsertFAIMSConstant,
   clearAllCaches,
 } from './projectSpecification';
-import {ProjectID} from './datamodel';
+import {ProjectID} from './datamodel/core';
 import {equals} from './utils/eqTestSupport';
 
 import {getProjectDB} from './sync/index';

--- a/src/projectSpecification.ts
+++ b/src/projectSpecification.ts
@@ -20,13 +20,12 @@
 
 import {getProjectDB} from './sync/index';
 import PouchDB from 'pouchdb';
+import {ProjectID} from './datamodel/core';
 import {
   PROJECT_SPECIFICATION_PREFIX,
   ProjectSchema,
-  FAIMSType,
-  FAIMSConstant,
-  ProjectID,
-} from './datamodel';
+} from './datamodel/database';
+import {FAIMSType, FAIMSConstant} from './datamodel/typesystem';
 
 export const FAIMS_NAMESPACES = [
   'faims-core',

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -19,7 +19,12 @@
  */
 
 import React, {createContext, useReducer, Dispatch, useEffect} from 'react';
-import {Observation, ProjectObject} from './datamodel';
+import {Color} from '@material-ui/lab/Alert';
+
+import {v4 as uuidv4} from 'uuid';
+
+import {ProjectObject} from './datamodel/database';
+import {Observation} from './datamodel/ui';
 import {
   ProjectActions,
   ObservationActions,
@@ -27,10 +32,8 @@ import {
   AlertActions,
   ActionType,
 } from './actions';
-import {Color} from '@material-ui/lab/Alert';
 import LoadingApp from './gui/components/loadingApp';
 import {initialize} from './sync/initialize';
-import {v4 as uuidv4} from 'uuid';
 
 interface InitialStateProps {
   initialized: boolean;

--- a/src/sync/connection.ts
+++ b/src/sync/connection.ts
@@ -20,7 +20,7 @@
 
 import PouchDB from 'pouchdb';
 import {RUNNING_UNDER_TEST} from '../buildconfig';
-import {ConnectionInfo, PossibleConnectionInfo} from '../datamodel';
+import {ConnectionInfo, PossibleConnectionInfo} from '../datamodel/database';
 import PouchDBAdaptorMemory from 'pouchdb-adapter-memory';
 
 /**

--- a/src/sync/databases.ts
+++ b/src/sync/databases.ts
@@ -33,7 +33,7 @@ import {
   ProjectMetaObject,
   ProjectDataObject,
   ProjectObject,
-} from '../datamodel';
+} from '../datamodel/database';
 import {
   ConnectionInfo_create_pouch,
   local_pouch_options,

--- a/src/sync/events.ts
+++ b/src/sync/events.ts
@@ -29,6 +29,7 @@ import {
   ConnectionInfo,
 } from '../datamodel/database';
 import {ExistingActiveDoc, LocalDB} from './databases';
+import {ProjectID} from '../datamodel/core';
 
 export class DebugEmitter extends EventEmitter {
   constructor(opts?: {captureRejections?: boolean}) {
@@ -152,7 +153,7 @@ export interface DirectoryEmitter extends EventEmitter {
 
   on(
     event: 'projects_known',
-    listener: (projects: Set<string>) => unknown
+    listener: (projects: Set<ProjectID>) => unknown
   ): this;
 
   on(
@@ -234,7 +235,7 @@ export interface DirectoryEmitter extends EventEmitter {
   emit(event: 'directory_active', listings: Set<string>): boolean;
   emit(event: 'directory_error', err: unknown): boolean;
   emit(event: 'listings_known', listings: Set<string>): boolean;
-  emit(event: 'projects_known', projects: Set<string>): boolean;
+  emit(event: 'projects_known', projects: Set<ProjectID>): boolean;
   emit(event: 'metas_complete', metas: MetasCompleteType): boolean;
   emit(event: 'projects_created'): boolean;
 }

--- a/src/sync/events.ts
+++ b/src/sync/events.ts
@@ -27,7 +27,7 @@ import {
   ProjectDataObject,
   PeopleDoc,
   ConnectionInfo,
-} from '../datamodel';
+} from '../datamodel/database';
 import {ExistingActiveDoc, LocalDB} from './databases';
 
 export class DebugEmitter extends EventEmitter {

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -20,13 +20,14 @@
 
 import PouchDB from 'pouchdb';
 import PouchDBFind from 'pouchdb-find';
+import {ProjectID} from '../datamodel/core';
 import {ProjectDataObject, ProjectMetaObject} from '../datamodel/database';
 import {data_dbs, metadata_dbs} from './databases';
 
 PouchDB.plugin(PouchDBFind);
 
 export function getDataDB(
-  active_id: string
+  active_id: ProjectID
 ): PouchDB.Database<ProjectDataObject> {
   if (data_dbs[active_id] !== undefined) {
     return data_dbs[active_id].local;
@@ -37,7 +38,7 @@ export function getDataDB(
 }
 
 export function getProjectDB(
-  active_id: string
+  active_id: ProjectID
 ): PouchDB.Database<ProjectMetaObject> {
   if (metadata_dbs[active_id] !== undefined) {
     return metadata_dbs[active_id].local;

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -20,7 +20,7 @@
 
 import PouchDB from 'pouchdb';
 import PouchDBFind from 'pouchdb-find';
-import {ProjectDataObject, ProjectMetaObject} from '../datamodel';
+import {ProjectDataObject, ProjectMetaObject} from '../datamodel/database';
 import {data_dbs, metadata_dbs} from './databases';
 
 PouchDB.plugin(PouchDBFind);

--- a/src/sync/process-initialization.ts
+++ b/src/sync/process-initialization.ts
@@ -26,7 +26,7 @@ import {
   PeopleDoc,
   ProjectMetaObject,
   ProjectObject,
-} from '../datamodel';
+} from '../datamodel/database';
 import {
   setupExampleDirectory,
   setupExampleListing,

--- a/src/sync/process-initialization.ts
+++ b/src/sync/process-initialization.ts
@@ -50,12 +50,12 @@ import {
   metadata_dbs,
   data_dbs,
   DEFAULT_LISTING_ID,
-  POUCH_SEPARATOR,
 } from './databases';
 import {events} from './events';
 import {createdProjects} from './state';
 import {setLocalConnection} from './databases';
 import {SyncHandler} from './sync-handler';
+import {NonUniqueProjectID, resolve_project_id} from '../datamodel/core';
 const METADATA_DBNAME_PREFIX = 'metadata-';
 const DATA_DBNAME_PREFIX = 'data-';
 const DIRECTORY_TIMEOUT = 2000;
@@ -325,13 +325,13 @@ async function process_listing(listing_object: ListingsObject) {
 
 async function autoactivate_projects(
   listing_id: string,
-  project_ids: string[]
+  project_ids: NonUniqueProjectID[]
 ) {
   for (const project_id of project_ids) {
     try {
       await activate_project(listing_id, project_id, null, null);
     } catch (err) {
-      const active_id = listing_id + POUCH_SEPARATOR + project_id;
+      const active_id = resolve_project_id(listing_id, project_id);
       console.debug('Unable to autoactivate', active_id);
     }
   }
@@ -339,7 +339,7 @@ async function autoactivate_projects(
 
 async function activate_project(
   listing_id: string,
-  project_id: string,
+  project_id: NonUniqueProjectID,
   username: string | null,
   password: string | null,
   is_sync = true
@@ -350,7 +350,7 @@ async function activate_project(
   if (project_id.startsWith('_')) {
     console.error('Projects should not start with a underscore: ', project_id);
   }
-  const active_id = listing_id + POUCH_SEPARATOR + project_id;
+  const active_id = resolve_project_id(listing_id, project_id);
   try {
     await active_db.get(active_id);
     console.debug('Have already activated', active_id);

--- a/src/sync/staging.ts
+++ b/src/sync/staging.ts
@@ -19,7 +19,8 @@
  */
 
 import PouchDB from 'pouchdb';
-import {SavedView, ObservationID, RevisionID} from '../datamodel';
+import {ObservationID, RevisionID} from '../datamodel/core';
+import {SavedView} from '../datamodel/staging';
 
 export type StagingDB = PouchDB.Database<SavedView>;
 

--- a/src/sync/staging.ts
+++ b/src/sync/staging.ts
@@ -19,7 +19,7 @@
  */
 
 import PouchDB from 'pouchdb';
-import {ObservationID, RevisionID} from '../datamodel/core';
+import {ObservationID, ProjectID, RevisionID} from '../datamodel/core';
 import {SavedView} from '../datamodel/staging';
 
 export type StagingDB = PouchDB.Database<SavedView>;
@@ -27,7 +27,7 @@ export type StagingDB = PouchDB.Database<SavedView>;
 export const staging_db: StagingDB = new PouchDB('staging');
 
 export async function getStagedData(
-  active_id: string,
+  active_id: ProjectID,
   view_name: string,
   // Revision & observation from data db.
   existing_observation_id: ObservationID | null,
@@ -65,7 +65,7 @@ export async function getStagedData(
 export async function setStagedData(
   new_data: {[key_not_underscore_id: string]: unknown},
   _rev: string | null,
-  active_id: string,
+  active_id: ProjectID,
   view_name: string,
   existing_observation_id: ObservationID | null,
   existing_revision_id: RevisionID | null
@@ -121,7 +121,7 @@ export async function setStagedData(
  * @returns {string} _id field for pouch SavedView
  */
 function determineId(
-  active_id: string,
+  active_id: ProjectID,
   view_name: string,
   existing_observation_id: ObservationID | null,
   existing_revision_id: RevisionID | null

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -23,7 +23,7 @@ import {
   ProjectMetaObject,
   ProjectDataObject,
   ActiveDoc,
-} from '../datamodel';
+} from '../datamodel/database';
 import {ExistingActiveDoc, LocalDB} from './databases';
 import {add_initial_listener} from './event-handler-registration';
 import {DirectoryEmitter} from './events';

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -18,6 +18,7 @@
  *   TODO
  */
 
+import {ProjectID} from '../datamodel/core';
 import {
   ProjectObject,
   ProjectMetaObject,
@@ -51,7 +52,7 @@ function register_listings_known(initializeEvents: DirectoryEmitter) {
  *
  * This is set to just before 'projects_known' event is emitted.
  */
-export let projects_known: null | Set<string> = null;
+export let projects_known: null | Set<ProjectID> = null;
 /**
  * Adds event handlers to initializeEvents to:
  * Enable 'Propagation' of completion of all known projects meta & other databases.
@@ -74,7 +75,7 @@ function register_projects_known(initializeEvents: DirectoryEmitter) {
     listings_known && Array.from(listing_statuses.values()).every(v => v);
 
   // All projects accumulated here
-  const projects_known_acc = new Set<string>();
+  const projects_known_acc = new Set<ProjectID>();
 
   // Emits project_known if all listings have their projects added to known_projects.
   const emit_if_complete = () => {
@@ -170,7 +171,7 @@ function register_projects_created(initializeEvents: DirectoryEmitter) {
 add_initial_listener(register_projects_created);
 
 export type MetasCompleteType = {
-  [active_id: string]:
+  [active_id in ProjectID]:
     | [ActiveDoc, ProjectObject, LocalDB<ProjectMetaObject>]
     // Error'd out metadata db
     | [ActiveDoc, unknown];

--- a/src/sync/stateful-event-handling.ts
+++ b/src/sync/stateful-event-handling.ts
@@ -21,9 +21,13 @@
 import PouchDB from 'pouchdb';
 import EventEmitter from 'events';
 import {ProjectObject, ProjectMetaObject} from '../datamodel/database';
+import {ProjectID} from '../datamodel/core';
 
 export type ProjectMetaList = {
-  [active_id: string]: [ProjectObject, PouchDB.Database<ProjectMetaObject>];
+  [active_id in ProjectID]: [
+    ProjectObject,
+    PouchDB.Database<ProjectMetaObject>
+  ];
 };
 
 export const state = {

--- a/src/sync/stateful-event-handling.ts
+++ b/src/sync/stateful-event-handling.ts
@@ -20,7 +20,7 @@
 
 import PouchDB from 'pouchdb';
 import EventEmitter from 'events';
-import {ProjectObject, ProjectMetaObject} from '../datamodel';
+import {ProjectObject, ProjectMetaObject} from '../datamodel/database';
 
 export type ProjectMetaList = {
   [active_id: string]: [ProjectObject, PouchDB.Database<ProjectMetaObject>];

--- a/src/sync/sync-toggle.ts
+++ b/src/sync/sync-toggle.ts
@@ -18,6 +18,7 @@
  *   TODO
  */
 
+import {ProjectID} from '../datamodel/core';
 import {ProjectDataObject} from '../datamodel/database';
 import {
   data_dbs,
@@ -27,12 +28,12 @@ import {
 } from './databases';
 
 const syncingProjectListeners: (
-  | [string, (syncing: boolean) => unknown]
+  | [ProjectID, (syncing: boolean) => unknown]
   | undefined
 )[] = [];
 
 export function listenSyncingProject(
-  active_id: string,
+  active_id: ProjectID,
   callback: (syncing: boolean) => unknown
 ): () => void {
   const my_index = syncingProjectListeners.length;
@@ -42,7 +43,7 @@ export function listenSyncingProject(
   };
 }
 
-export function isSyncingProject(active_id: string) {
+export function isSyncingProject(active_id: ProjectID) {
   if (data_dbs[active_id] === undefined) {
     throw 'Projects not initialized yet';
   }
@@ -54,7 +55,7 @@ export function isSyncingProject(active_id: string) {
   return data_dbs[active_id].is_sync;
 }
 
-export function setSyncingProject(active_id: string, syncing: boolean) {
+export function setSyncingProject(active_id: ProjectID, syncing: boolean) {
   if (syncing === isSyncingProject(active_id)) {
     return; //Nothing to do, already same value
   }

--- a/src/sync/sync-toggle.ts
+++ b/src/sync/sync-toggle.ts
@@ -18,7 +18,7 @@
  *   TODO
  */
 
-import {ProjectDataObject} from '../datamodel';
+import {ProjectDataObject} from '../datamodel/database';
 import {
   data_dbs,
   LocalDB,

--- a/src/uiSpecification.test.ts
+++ b/src/uiSpecification.test.ts
@@ -21,7 +21,8 @@
 import {testProp, fc} from 'jest-fast-check';
 import PouchDB from 'pouchdb';
 import {getUiSpecForProject, setUiSpecForProject} from './uiSpecification';
-import {UI_SPECIFICATION_NAME, ProjectID} from './datamodel';
+import {ProjectID} from './datamodel/core';
+import {UI_SPECIFICATION_NAME} from './datamodel/database';
 import {equals} from './utils/eqTestSupport';
 
 import {getProjectDB} from './sync/index';

--- a/src/uiSpecification.ts
+++ b/src/uiSpecification.ts
@@ -20,12 +20,13 @@
 
 import {getProjectDB} from './sync';
 import PouchDB from 'pouchdb';
-import {ProjectMetaObject, ProjectID} from './datamodel';
+import {ProjectID} from './datamodel/core';
 import {
+  ProjectMetaObject,
   UI_SPECIFICATION_NAME,
-  ProjectUIModel,
   EncodedProjectUIModel,
-} from './datamodel';
+} from './datamodel/database';
+import {ProjectUIModel} from './datamodel/ui';
 
 export async function getUiSpecForProject(
   project_id: ProjectID


### PR DESCRIPTION
This splits datamodel.ts into mainly database and ui focused parts, with
the remainder either being widely shared (and so go to core.ts), or a
for a specific subsystem (types, staging).

@aidanfar0 I think there a few bits in the ActiveDoc and ListingDoc which should use ProjectID rather than string, can you have a quick look at those?