### PR TITLE
Add local_pouch_settings to local_state

### DIFF
--- a/src/sync/databases.ts
+++ b/src/sync/databases.ts
@@ -107,7 +107,7 @@ export const active_db = new PouchDB<ActiveDoc>('active', local_pouch_options);
 /**
  * This contains any local app state we want to keep across sessions
  */
-export const local_state_db = new PouchDB('local_state');
+export const local_state_db = new PouchDB('local_state', local_pouch_options);
 
 /**
  * Each listing has a Projects database and Users/People DBs


### PR DESCRIPTION
This should mean for tests, we use the in-memory storage (which is faster than using leveldb with node).