### PR TITLE
Update bors for new CI

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,10 +1,10 @@
 status = [
-  "build (14.x, false)",
-  "test (14.x, false)",
+  "build (lts/*, false)",
+  "test (lts/*, false)",
   "license",
 #  "DCO",
 ]
 block_labels = [ "S-do-not-merge-yet" ]
 update_base_for_deletes = true
 cut_body_after = "<details>"
-timeout_sec = 36000 # ten hours
+#timeout_sec = 36000 # ten hours


### PR DESCRIPTION
Bors needed to be updated for the LTS switch.