### PR TITLE
Comment out flaky test

### DIFF
--- a/src/data_storage/merging.test.ts
+++ b/src/data_storage/merging.test.ts
@@ -730,6 +730,11 @@ describe('test basic automerge', () => {
       });
   });
 
+  /*
+   * Commented as we need to be able to do value comparison to do this test all
+   * the time (this test depends on the order we work with the documents, which
+   * is set by their uuids. As we're using random uuids, we can end up with 3
+   * heads instead of 2, which is solvable only by the advanced automerger).
   test('changes to different avps AND different change 2 PAIRS', async () => {
     // This tests the case where there are 4 heads, but the merge this time is
     // as two pairs
@@ -845,6 +850,7 @@ describe('test basic automerge', () => {
         expect(record.revisions).toHaveLength(7); // 2 merges should happen
       });
   });
+  */
 
   test('merge deleted and non-deleted', async () => {
     // This tests the case where there are 2 heads, and one revision is marked


### PR DESCRIPTION
See test for details, but in simple terms this test has an implicit dependency on the values of the uuids generated. The test should be used for the advanced automerger, which should result in only one head.