### PR TITLE
Variants

### DIFF
--- a/src/data_storage/merging.ts
+++ b/src/data_storage/merging.ts
@@ -201,6 +201,11 @@ export async function do3WayMerge(
     return await doFastForward(project_id, merge_result, base, them, us);
   }
 
+  if (them.type !== us.type) {
+    // Because changing types it unsupported:
+    throw Error('Merging of revisions with differing types is unsupported');
+  }
+
   const attrs = getAttributes(base, them, us);
   for (const attr of attrs) {
     const base_avp_id = base.avps[attr];

--- a/src/datamodel/database.ts
+++ b/src/datamodel/database.ts
@@ -29,6 +29,7 @@ import {
   FAIMSConstantCollection,
   FAIMSTypeCollection,
   ProjectUIFields,
+  ProjectUIViewsets,
   ProjectUIViews,
 } from './typesystem';
 
@@ -131,7 +132,8 @@ export interface EncodedProjectUIModel {
   _deleted?: boolean;
   fields: ProjectUIFields;
   fviews: ProjectUIViews; // conflicts with pouchdb views/indexes, hence fviews
-  start_view: string;
+  viewsets: ProjectUIViewsets;
+  visible_types: string[];
 }
 
 export interface EncodedProjectMetadata {

--- a/src/datamodel/typesystem.ts
+++ b/src/datamodel/typesystem.ts
@@ -38,6 +38,18 @@ export interface ProjectUIFields {
   [key: string]: any;
 }
 
+export interface ProjectUIViewsets {
+  [type: string]: {
+    label?: string;
+    views: string[];
+    submit_label?: string;
+  };
+}
+
 export interface ProjectUIViews {
-  [key: string]: any;
+  [key: string]: {
+    label?: string;
+    fields: string[];
+    next_label?: string;
+  };
 }

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -24,7 +24,7 @@
  */
 
 import {ProjectID, RecordID, RevisionID} from './core';
-import {ProjectUIFields, ProjectUIViews} from './typesystem';
+import {ProjectUIFields, ProjectUIViewsets, ProjectUIViews} from './typesystem';
 
 export interface ProjectInformation {
   project_id: ProjectID;
@@ -40,7 +40,8 @@ export interface ProjectUIModel {
   _rev?: string; // optional as we may want to include the raw json in places
   fields: ProjectUIFields;
   views: ProjectUIViews;
-  start_view: string;
+  viewsets: ProjectUIViewsets;
+  visible_types: string[];
 }
 
 export interface RecordMetadata {

--- a/src/dummyData.ts
+++ b/src/dummyData.ts
@@ -37,7 +37,7 @@ const example_records: {
     {
       record_id: '020948f4-79b8-435f-9db6-9c8ec7deab0a',
       revision_id: null,
-      type: '??:??',
+      type: 'astro_sky:main',
       created: randomDate(new Date(2012, 0, 1), new Date()),
       created_by: 'John Smith',
       updated: randomDate(new Date(2021, 0, 1), new Date()),
@@ -60,7 +60,7 @@ const example_records: {
     {
       record_id: '020948f4-79b8-435f-9db6-9clksjdf900a',
       revision_id: null,
-      type: '??:??',
+      type: 'astro_sky:main',
       created: randomDate(new Date(2012, 0, 1), new Date()),
       created_by: 'John Smith',
       updated: randomDate(new Date(2021, 0, 1), new Date()),
@@ -78,6 +78,20 @@ const example_records: {
         'multi-select-field': ['JPY'],
         'checkbox-field': true,
         'radio-group-field': '1',
+      },
+    },
+    {
+      record_id: '9a0782ba-937b-4f24-8489-58cd653eca88',
+      revision_id: null,
+      type: 'astro_sky:photolog',
+      created: randomDate(new Date(2012, 0, 1), new Date()),
+      created_by: 'Leia',
+      updated: randomDate(new Date(2021, 0, 1), new Date()),
+      updated_by: 'Luke',
+      data: {
+        'int-field': 20,
+        'select-field': ['EUR'],
+        'checkbox-field': true,
       },
     },
   ],
@@ -466,8 +480,18 @@ const example_ui_specs: {[key: string]: ProjectUIModel} = {
         initialValue: '',
       },
     },
+    viewsets: {
+      'astro_sky:main': {
+        views: ['start-view', 'next-view'],
+      },
+      'astro_sky:photolog': {
+        views: ['next-view', 'photo-view'],
+      },
+    },
+    visible_types: ['astro_sky:main', 'astro_sky:photolog'],
     views: {
       'start-view': {
+        label: 'Main',
         fields: [
           'hrid-field',
           'take-point-field',
@@ -477,23 +501,30 @@ const example_ui_specs: {[key: string]: ProjectUIModel} = {
           'str-field',
           'multi-str-field',
           'int-field',
-          'select-field',
           'multi-select-field',
           'checkbox-field',
           'radio-group-field',
-          // 'bool-field',
-          // 'date-field',
-          // 'time-field',
-        ], // ordering sets appearance order
+        ],
       },
-      'next-view': 'another-view-id', // either this gets handled by a component, or we stick it here
-      'next-view-label': 'Done!',
+      'next-view': {
+        label: 'Common',
+        next_label: 'Done!',
+        fields: ['int-field', 'select-field'],
+      },
+      'photo-view': {
+        label: 'Exclusive Photo view',
+        fields: ['checkbox-field'],
+      },
     },
-
-    start_view: 'start-view',
   },
   default_projectB: {
     fields: {},
+    viewsets: {
+      'projectB::default': {
+        views: ['start-view'],
+      },
+    },
+    visible_types: ['projectB::default'],
     views: {
       'start-view': {
         fields: [
@@ -505,13 +536,16 @@ const example_ui_specs: {[key: string]: ProjectUIModel} = {
           // 'time-field',
         ], // ordering sets appearance order
       },
-      'next-view': 'another-view-id', // either this gets handled by a component, or we stick it here
-      'next-view-label': 'Done!',
     },
-    start_view: 'start-view',
   },
   default_projectC: {
     fields: {},
+    viewsets: {
+      'projectC::default': {
+        views: ['start-view'],
+      },
+    },
+    visible_types: ['projectC::default'],
     views: {
       'start-view': {
         fields: [
@@ -523,10 +557,7 @@ const example_ui_specs: {[key: string]: ProjectUIModel} = {
           // 'time-field',
         ], // ordering sets appearance order
       },
-      'next-view': 'another-view-id', // either this gets handled by a component, or we stick it here
-      'next-view-label': 'Done!',
     },
-    start_view: 'start-view',
   },
 };
 

--- a/src/gui/pages/record-create.tsx
+++ b/src/gui/pages/record-create.tsx
@@ -49,6 +49,7 @@ export default function RecordCreate() {
 
   const project_info = getProjectInfo(project_id);
   const [uiSpec, setUISpec] = useState(null as null | ProjectUIModel);
+  const [type, setType] = useState(null as null | string);
   const [error, setError] = useState(null as null | {});
 
   const breadcrumbs = [
@@ -83,6 +84,24 @@ export default function RecordCreate() {
         <CircularProgress size={12} thickness={4} />
       </Container>
     );
+  } else if (type === null) {
+    // Pick a type after loading
+    return (
+      <Container maxWidth="lg">
+        {uiSpec.visible_types.map(type_name => {
+          const viewset_info = uiSpec.viewsets[type_name];
+          return (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => setType(type_name)}
+            >
+              {viewset_info.label || type_name}
+            </Button>
+          );
+        })}
+      </Container>
+    );
   } else {
     // Loaded, variant picked, show form:
     return (
@@ -102,6 +121,7 @@ export default function RecordCreate() {
             <RecordForm
               project_id={project_id}
               record_id={generateFAIMSDataID()}
+              type={type}
               uiSpec={uiSpec}
             />
           </Box>

--- a/src/sync/staging-observation.ts
+++ b/src/sync/staging-observation.ts
@@ -37,16 +37,17 @@ type RelevantProps = {
   // revision_id is null, since that would make a new draft every time
   // a draft is created
   record_id: RecordID;
-  revision_id: RevisionID | null;
 };
 
 /**
  * Important properties that might not be present
  * until .start() is called. This is mainly used
  * in _fetchData and _saveData
+ *
+ * revision_id can be null if this is a new record
  */
 type LoadableProps = {
-  revision_id: RevisionID;
+  revision_id: RevisionID | null;
   view_name: string;
 };
 

--- a/src/uiSpecification.test.ts
+++ b/src/uiSpecification.test.ts
@@ -66,10 +66,25 @@ describe('roundtrip reading and writing to db', () => {
     [
       fc.fullUnicodeString(),
       fc.dictionary(fc.fullUnicodeString(), fc.unicodeJsonObject()), // fields
-      fc.dictionary(fc.fullUnicodeString(), fc.unicodeJsonObject()), // views
-      fc.fullUnicodeString(), // start-view
+      fc.dictionary(
+        fc.fullUnicodeString(),
+        fc.record({
+          label: fc.fullUnicodeString(),
+          next_label: fc.fullUnicodeString(),
+          fields: fc.array(fc.fullUnicodeString()),
+        })
+      ), // views
+      fc.dictionary(
+        fc.fullUnicodeString(),
+        fc.record({
+          label: fc.fullUnicodeString(),
+          submit_label: fc.fullUnicodeString(),
+          views: fc.array(fc.fullUnicodeString()),
+        })
+      ), // viewsets
+      fc.array(fc.fullUnicodeString()), // visible_types
     ],
-    async (project_id, fields, views, start_view) => {
+    async (project_id, fields, views, viewsets, visible_types) => {
       await cleanProjectDBS();
       fc.pre(projdbs !== {});
 
@@ -77,7 +92,8 @@ describe('roundtrip reading and writing to db', () => {
         _id: UI_SPECIFICATION_NAME,
         fields: fields,
         views: views,
-        start_view: start_view,
+        viewsets: viewsets,
+        visible_types: visible_types,
       };
 
       const meta_db = getProjectDB(project_id);

--- a/src/uiSpecification.ts
+++ b/src/uiSpecification.ts
@@ -41,7 +41,8 @@ export async function getUiSpecForProject(
       _rev: encUIInfo._rev,
       fields: encUIInfo.fields,
       views: encUIInfo.fviews,
-      start_view: encUIInfo.start_view,
+      viewsets: encUIInfo.viewsets,
+      visible_types: encUIInfo.visible_types,
     };
   } catch (err) {
     console.warn(err);
@@ -57,7 +58,8 @@ export async function setUiSpecForProject(
     _id: UI_SPECIFICATION_NAME,
     fields: uiInfo.fields,
     fviews: uiInfo.views,
-    start_view: uiInfo.start_view,
+    viewsets: uiInfo.viewsets,
+    visible_types: uiInfo.visible_types,
   };
   try {
     const existing_encUIInfo = await projdb.get(encUIInfo._id);


### PR DESCRIPTION
This adds a layer on top of record views: variants
Each record can be only 1 of the variants, and records can't change what variant they are (yet)
A record being a different variant means it has a whole different set of fields and different views

Views can be shared between variants (like how components can be shared between views, i think)

In terms the database datamodel, the variant type of a record/revision is stored on the Revision,
This is because it's not an attribute-value-pair, but I still would like to allow changes to the variant type (so it can't go on the Record)

TODO: Better UI