### PR TITLE
Fix variants new record

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,12 @@
  */
 
 import React from 'react';
-import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Redirect,
+  Route,
+  Switch,
+} from 'react-router-dom';
 import './App.css';
 import * as ROUTES from './constants/routes';
 import NavBar from './gui/components/navbar';
@@ -50,6 +55,7 @@ import {MuiThemeProvider} from '@material-ui/core/styles';
 import {createdProjects} from './sync/state';
 import {ProjectsList} from './datamodel/database';
 import theme from './gui/theme';
+import {generateFAIMSDataID} from './data_storage';
 
 type AppProps = {};
 
@@ -87,7 +93,6 @@ export class App extends React.Component<AppProps, AppState> {
                 path={ROUTES.FORGOT_PASSWORD}
                 component={ForgotPassword}
               />
-
               <Route exact path={ROUTES.HOME} component={Home} />
               <Route exact path={ROUTES.RECORD_LIST} component={RecordList} />
               <Route exact path={ROUTES.PROJECT_LIST} component={ProjectList} />
@@ -101,6 +106,11 @@ export class App extends React.Component<AppProps, AppState> {
                 path={ROUTES.PROJECT + ':project_id' + ROUTES.PROJECT_SETTINGS}
                 component={ProjectSettings}
               />
+              /* Record creation happens by redirecting to a freshy minted UUID
+              This is to keep it stable until the user navigates away (As
+              opposed to keeping the UUID in RecordCreate, which means there's
+              no way to move on to a new UUID for a RecordCreate of the same
+              project and type) */
               <Route
                 exact
                 path={
@@ -108,9 +118,29 @@ export class App extends React.Component<AppProps, AppState> {
                   ':project_id' +
                   ROUTES.RECORD_CREATE +
                   ROUTES.RECORD_TYPE +
-                  ':type_name'
+                  ':type_name' +
+                  ROUTES.RECORD + //
+                  ':record_id'
                 }
                 component={RecordCreate}
+              />
+              <Redirect
+                from={
+                  ROUTES.PROJECT +
+                  ':project_id' +
+                  ROUTES.RECORD_CREATE +
+                  ROUTES.RECORD_TYPE +
+                  ':type_name'
+                }
+                to={
+                  ROUTES.PROJECT +
+                  ':project_id' +
+                  ROUTES.RECORD_CREATE +
+                  ROUTES.RECORD_TYPE +
+                  ':type_name' +
+                  ROUTES.RECORD + //
+                  generateFAIMSDataID()
+                }
               />
               <Route
                 exact

--- a/src/gui/components/project/cardHeaderAction.tsx
+++ b/src/gui/components/project/cardHeaderAction.tsx
@@ -143,15 +143,40 @@ export default function ProjectCardHeaderAction(props: ProjectCardActionProps) {
             open={Boolean(actionAnchor)}
             onClose={handleActionClose}
           >
-            <MenuItem
-              component={NavLink}
-              to={ROUTES.PROJECT + project.project_id + ROUTES.RECORD_CREATE}
-            >
-              <ListItemIcon>
-                <AddIcon fontSize="small" />
-              </ListItemIcon>
-              New Record
-            </MenuItem>
+            {viewSets[1].length === 1 ? (
+              <MenuItem
+                component={NavLink}
+                to={
+                  ROUTES.PROJECT +
+                  project.project_id +
+                  ROUTES.RECORD_CREATE +
+                  ROUTES.RECORD_TYPE +
+                  viewSets[1]
+                }
+              >
+                <ListItemIcon>
+                  <AddIcon fontSize="small" />
+                </ListItemIcon>
+                New Record
+              </MenuItem>
+            ) : (
+              <React.Fragment>
+                {viewSets[1].map(viewset_name => (
+                  <MenuItem
+                    component={RouterLink}
+                    to={
+                      ROUTES.PROJECT +
+                      project.project_id +
+                      ROUTES.RECORD_CREATE +
+                      ROUTES.RECORD_TYPE +
+                      viewset_name
+                    }
+                  >
+                    New {viewSets[0][viewset_name].label || viewset_name}
+                  </MenuItem>
+                ))}
+              </React.Fragment>
+            )}
             <MenuItem disabled={true}>
               <ListItemIcon>
                 <ShareIcon fontSize="small" />

--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -423,7 +423,11 @@ class RecordForm extends React.Component<
         // the user to rapidly add more records
         if (this.props.revision_id === undefined) {
           this.props.history.push(
-            ROUTES.PROJECT + this.props.project_id + ROUTES.RECORD_CREATE
+            ROUTES.PROJECT +
+              this.props.project_id +
+              ROUTES.RECORD_CREATE +
+              ROUTES.RECORD_TYPE +
+              this.state.type_cached
           );
           window.scrollTo(0, 0);
           // scroll to top of page, seems to be needed on mobile devices

--- a/src/gui/pages/record-create.tsx
+++ b/src/gui/pages/record-create.tsx
@@ -18,7 +18,7 @@
  *   TODO
  */
 
-import React, {useContext, useMemo, useState} from 'react';
+import React, {useContext, useState} from 'react';
 import {
   Box,
   Container,
@@ -29,10 +29,9 @@ import {
 import {useHistory, useParams} from 'react-router-dom';
 import * as ROUTES from '../../constants/routes';
 import Breadcrumbs from '../components/ui/breadcrumbs';
-import {generateFAIMSDataID} from '../../data_storage';
 import RecordForm from '../components/record/form';
 import {getProjectInfo} from '../../databaseAccess';
-import {ProjectID} from '../../datamodel/core';
+import {ProjectID, RecordID} from '../../datamodel/core';
 import {ProjectUIModel} from '../../datamodel/ui';
 import {useEffect} from 'react';
 import {getUiSpecForProject} from '../../uiSpecification';
@@ -40,9 +39,10 @@ import {ActionType} from '../../actions';
 import {store} from '../../store';
 
 export default function RecordCreate() {
-  const {project_id, type_name} = useParams<{
+  const {project_id, type_name, record_id} = useParams<{
     project_id: ProjectID;
     type_name: string;
+    record_id: RecordID;
   }>();
   const {dispatch} = useContext(store);
   const history = useHistory();
@@ -64,11 +64,6 @@ export default function RecordCreate() {
   useEffect(() => {
     getUiSpecForProject(project_id).then(setUISpec, setError);
   }, [project_id]);
-
-  const stable_record_id = useMemo(generateFAIMSDataID, [
-    project_id,
-    type_name,
-  ]);
 
   if (error !== null) {
     dispatch({
@@ -106,7 +101,7 @@ export default function RecordCreate() {
           <Box p={3}>
             <RecordForm
               project_id={project_id}
-              record_id={stable_record_id}
+              record_id={record_id}
               type={type_name}
               uiSpec={uiSpec}
             />

--- a/src/gui/pages/record-create.tsx
+++ b/src/gui/pages/record-create.tsx
@@ -18,7 +18,7 @@
  *   TODO
  */
 
-import React, {useContext, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import {
   Box,
   Container,
@@ -65,6 +65,11 @@ export default function RecordCreate() {
     getUiSpecForProject(project_id).then(setUISpec, setError);
   }, [project_id]);
 
+  const stable_record_id = useMemo(generateFAIMSDataID, [
+    project_id,
+    type_name,
+  ]);
+
   if (error !== null) {
     dispatch({
       type: ActionType.ADD_ALERT,
@@ -101,7 +106,7 @@ export default function RecordCreate() {
           <Box p={3}>
             <RecordForm
               project_id={project_id}
-              record_id={generateFAIMSDataID()}
+              record_id={stable_record_id}
               type={type_name}
               uiSpec={uiSpec}
             />

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -20,7 +20,7 @@
 import {ReportHandler} from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
+  if (onPerfEntry && typeof onPerfEntry === 'function') {
     import('web-vitals').then(({getCLS, getFID, getFCP, getLCP, getTTFB}) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);

--- a/src/utils/eqTestSupport.ts
+++ b/src/utils/eqTestSupport.ts
@@ -82,7 +82,10 @@ function eq(
     }
   }
 
-  if (a instanceof Error && b instanceof Error) {
+  // Equivalent to a instanceof Error && b instanceof Error
+  // however instanceof didn't seem to work
+  if (a !== null && typeof a === 'object' && 'name' in a && 'message' in a &&
+    b !== null && typeof b === 'object' && 'name' in b && 'message' in b) {
     return a.message == b.message;
   }
 


### PR DESCRIPTION
This fixes a lot of new 404s that were occuring when trying to create new records.
The 'Add' button on the homepage now separates into different buttons for each viewset,

Technical note on the issue I discussed with James: To fix it,
/new-record/type/:type_id has changed to /new-record/type/:type_id/record/:record_id,
Where there is a redirect from the former to the latter that is where the UUID is generated now (It's a prop in RecordCreate element)

 