### PR TITLE
Add helper for creating a new local project

### DIFF
--- a/src/datamodel/database.ts
+++ b/src/datamodel/database.ts
@@ -40,6 +40,7 @@ export const PROJECT_METADATA_PREFIX = 'project-metadata';
 export const RECORD_INDEX_NAME = 'record-version-index';
 export const LOCAL_AUTOINCREMENT_PREFIX = 'local-autoincrement-state';
 export const LOCAL_AUTOINCREMENT_NAME = 'local-autoincrementers';
+export const LOCALLY_CREATED_PROJECT_PREFIX = 'locallycreatedproject';
 
 /*
  * This may already exist in pouchdb's typing, but lets make a temporary one for

--- a/src/sync/index.test.ts
+++ b/src/sync/index.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: index.test.js
+ * Description:
+ *   TODO
+ */
+
+import {testProp, fc} from 'jest-fast-check';
+import PouchDB from 'pouchdb';
+
+import {LOCALLY_CREATED_PROJECT_PREFIX} from '../datamodel/database';
+import {create_new_project_dbs} from './new-project';
+
+PouchDB.plugin(require('pouchdb-adapter-memory')); // enable memory adapter for testing
+
+describe('test project creation', () => {
+  testProp(
+    'test project creation',
+    [
+      fc.fullUnicodeString(), // project name
+    ],
+    async name => {
+      return create_new_project_dbs(name).then(proj_id => {
+        expect(proj_id).toEqual(
+          expect.stringContaining(LOCALLY_CREATED_PROJECT_PREFIX)
+        );
+      });
+    }
+  );
+});

--- a/src/sync/new-project.ts
+++ b/src/sync/new-project.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: new-project.ts
+ * Description:
+ *   TODO
+ */
+import {v4 as uuidv4} from 'uuid';
+
+import {
+  ListingsObject,
+  LOCALLY_CREATED_PROJECT_PREFIX,
+} from '../datamodel/database';
+import {ProjectID, NonUniqueProjectID} from '../datamodel/core';
+
+import {
+  active_db,
+  data_dbs,
+  directory_db,
+  ensure_local_db,
+  metadata_dbs,
+  projects_dbs,
+} from './databases';
+import {events} from './events';
+import {activate_project} from './process-initialization';
+import {createdProjects} from './state';
+
+export async function request_allocation_for_project(project_id: ProjectID) {
+  throw Error('not implemented yet');
+}
+
+/*
+ * This creates the project databases which are needed locally. This does not
+ * set up the remote databases, that will be the responsibility of other
+ * systems.
+ *
+ * The process is:
+ * 1. Create a listing for local-only projects (if it doesn't exist).
+ * 2. Create the projects_db for that new listing (if it doesn't exist).
+ * 3. Generate a new NonUniqueProjectID (uuidv4)
+ * 4. Activate the project (to check for local duplicates)
+ * 5. Create new meta/data db
+ * 6. Return new project id (for further usage)
+ */
+export async function create_new_project_dbs(name: string): Promise<ProjectID> {
+  const listing = await ensure_locally_created_project_listing();
+  const projects_db = ensure_locally_created_projects_db(listing._id);
+  const new_project_id = generate_non_unique_project_id();
+  const active_id = await activate_project(
+    listing._id,
+    new_project_id,
+    null,
+    null,
+    false
+  );
+  const active_project = await active_db.get(active_id);
+
+  const project_object = {
+    _id: active_id,
+    name: name,
+    status: 'new', // TODO: work out proper status
+  };
+  await projects_db.local.put(project_object);
+
+  const [, meta_db_local] = ensure_local_db(
+    'metadata',
+    active_id,
+    active_project.is_sync,
+    metadata_dbs
+  );
+  const [, data_db_local] = ensure_local_db(
+    'data',
+    active_id,
+    active_project.is_sync,
+    data_dbs
+  );
+
+  createdProjects[active_id] = {
+    project: project_object,
+    active: active_project,
+    meta: meta_db_local,
+    data: data_db_local,
+  };
+
+  events.emit(
+    'project_local',
+    listing,
+    active_project,
+    project_object,
+    meta_db_local,
+    data_db_local
+  );
+  return active_id;
+}
+
+function generate_non_unique_project_id(): NonUniqueProjectID {
+  return uuidv4();
+}
+
+async function ensure_locally_created_project_listing(): Promise<ListingsObject> {
+  try {
+    return await directory_db.local.get(LOCALLY_CREATED_PROJECT_PREFIX);
+  } catch (err: any) {
+    if (err.status === 404) {
+      const listing_object = {
+        _id: LOCALLY_CREATED_PROJECT_PREFIX,
+        name: 'Locally Created Projects',
+        description:
+          'Projects created on this device (have not been submitted).',
+      };
+      await directory_db.local.put(listing_object);
+      return listing_object;
+    } else {
+      throw err;
+    }
+  }
+}
+
+function ensure_locally_created_projects_db(projects_db_id: string) {
+  const [, local_projects_db] = ensure_local_db(
+    'projects',
+    projects_db_id,
+    true,
+    projects_dbs
+  );
+  return local_projects_db;
+}

--- a/src/sync/process-initialization.ts
+++ b/src/sync/process-initialization.ts
@@ -27,6 +27,7 @@ import {
   ProjectMetaObject,
   ProjectObject,
 } from '../datamodel/database';
+import {ProjectID} from '../datamodel/core';
 import {
   setupExampleDirectory,
   setupExampleListing,
@@ -393,23 +394,24 @@ async function autoactivate_projects(
   }
 }
 
-async function activate_project(
+export async function activate_project(
   listing_id: string,
   project_id: NonUniqueProjectID,
   username: string | null,
   password: string | null,
   is_sync = true
-) {
+): Promise<ProjectID> {
   if (project_id.startsWith('_design/')) {
     throw Error(`Cannot activate design document ${project_id}`);
   }
   if (project_id.startsWith('_')) {
-    console.error('Projects should not start with a underscore: ', project_id);
+    throw Error(`Projects should not start with a underscore: ${project_id}`);
   }
   const active_id = resolve_project_id(listing_id, project_id);
   try {
     await active_db.get(active_id);
     console.debug('Have already activated', active_id);
+    return active_id;
   } catch (err: any) {
     if (err.status === 404) {
       // TODO: work out a better way to do this
@@ -421,6 +423,7 @@ async function activate_project(
         password: password,
         is_sync: is_sync,
       });
+      return active_id;
     } else {
       throw err;
     }


### PR DESCRIPTION
@KateSHENG This should allow you to create local projects for use in the project builder.
@aidanfar0 Can you sanity check this and then merge? There's also a hook for writing up to the conductor, once that's read.