### PR TITLE
Stop auto-ID generation running multiple times

### DIFF
--- a/src/gui/fields/BasicAutoIncrementer.tsx
+++ b/src/gui/fields/BasicAutoIncrementer.tsx
@@ -132,6 +132,7 @@ export class BasicAutoIncrementer extends React.Component<
     const current_value = this.props.form.values[this.props.field.name];
 
     if (!this.state.has_run) {
+      this.setState({has_run: true});
       console.debug('running autoinc');
       if (current_value === null) {
         const new_id = await this.compute_id(this.props.num_digits || 4);
@@ -146,7 +147,6 @@ export class BasicAutoIncrementer extends React.Component<
         } else {
           this.props.form.setFieldValue(this.props.field.name, new_id);
         }
-        this.setState({has_run: true});
       }
     }
   }


### PR DESCRIPTION
The state setting was too late in the call to prevent the ID from being generated multiple times (and hence creating conflicts at the pouch level). Moving right to the top ensures that only one call will be made.
