### PR TITLE
Add system to handle attachments

### DIFF
--- a/src/data_storage.test.ts
+++ b/src/data_storage.test.ts
@@ -132,6 +132,8 @@ describe('roundtrip reading and writing to db', () => {
         updated_by: userid,
         created: time,
         updated: time,
+        annotations: {},
+        field_types: {field_name: fulltype},
       };
 
       return upsertFAIMSData(project_id, doc)
@@ -189,6 +191,8 @@ describe('CRUD for data', () => {
         updated_by: userid,
         created: time,
         updated: time,
+        annotations: {},
+        field_types: {field_name: fulltype},
       };
 
       const new_doc: Record = {
@@ -201,6 +205,8 @@ describe('CRUD for data', () => {
         updated_by: userid,
         created: time,
         updated: time,
+        annotations: {},
+        field_types: {field_name: fulltype},
       };
 
       return upsertFAIMSData(project_id, doc)
@@ -285,6 +291,8 @@ describe('listing revisions', () => {
         updated_by: userid,
         created: time,
         updated: time,
+        annotations: {},
+        field_types: {field_name: fulltype},
       };
 
       return upsertFAIMSData(project_id, doc)

--- a/src/data_storage/index.ts
+++ b/src/data_storage/index.ts
@@ -107,11 +107,13 @@ export async function getFullRecordData(
     record_id: record_id,
     revision_id: revision_id,
     type: revision.type,
-    data: form_data,
+    data: form_data.data,
     updated_by: revision.created_by,
     updated: new Date(revision.created),
     created: new Date(record.created),
     created_by: record.created_by,
+    annotations: form_data.annotations,
+    field_types: form_data.types,
   };
 }
 

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -26,6 +26,8 @@ import {
   RecordID,
   ProjectID,
   RevisionID,
+  FAIMSTypeName,
+  Annotations,
 } from '../datamodel/core';
 import {
   AttributeValuePair,
@@ -37,8 +39,18 @@ import {
   RevisionMap,
 } from '../datamodel/database';
 import {Record, RecordMetadataList} from '../datamodel/ui';
+import {
+  getAttachmentLoaderForType,
+  getAttachmentDumperForType,
+} from '../datamodel/typesystem';
 
 type EncodedRecordMap = Map<RecordID, EncodedRecord>;
+
+interface FormData {
+  data: {[field_name: string]: any};
+  annotations: {[field_name: string]: Annotations};
+  types: {[field_name: string]: FAIMSTypeName};
+}
 
 export function generateFAIMSRevisionID(): RevisionID {
   return uuidv4();
@@ -182,7 +194,7 @@ export async function getAttributeValuePairs(
   rows.forEach(e => {
     if (e.doc !== undefined) {
       const doc = e.doc as AttributeValuePair;
-      mapping[doc._id] = doc;
+      mapping[doc._id] = loadAttributeValuePair(doc);
     }
   });
   return mapping;
@@ -248,14 +260,20 @@ export async function getAllRecords(
 export async function getFormDataFromRevision(
   project_id: ProjectID,
   revision: Revision
-): Promise<{[field_name: string]: any}> {
-  const data: {[field_name: string]: any} = {};
+): Promise<FormData> {
+  const form_data: FormData = {
+    data: {},
+    annotations: {},
+    types: {},
+  };
   const avp_ids = Object.values(revision.avps);
   const avps = await getAttributeValuePairs(project_id, avp_ids);
   for (const [name, avp_id] of Object.entries(revision.avps)) {
-    data[name] = avps[avp_id].data;
+    form_data.data[name] = avps[avp_id].data;
+    form_data.annotations[name] = avps[avp_id].annotations;
+    form_data.types[name] = avps[avp_id].type;
   }
-  return data;
+  return form_data;
 }
 
 export async function addNewRevisionFromForm(
@@ -297,22 +315,26 @@ async function addNewAttributeValuePairs(
     data = await getFormDataFromRevision(project_id, revision);
   } else {
     revision = {};
-    data = {};
+    data = {
+      data: {},
+      annotations: {},
+      types: {},
+    };
   }
   for (const [field_name, field_value] of Object.entries(record.data)) {
-    const stored_data = data[field_name];
+    const stored_data = data.data[field_name];
     if (stored_data === undefined || stored_data !== field_value) {
       const new_avp_id = generateFAIMSAttributeValuePairID();
       const new_avp = {
         _id: new_avp_id,
         avp_format_version: 1,
-        type: '??:??', // TODO: Add type handling
+        type: record.field_types[field_name] ?? '??:??',
         data: field_value,
         revision_id: new_revision_id,
         record_id: record.record_id,
-        annotations: [], // TODO: Add annotation handling
+        annotations: record.annotations[field_name],
       };
-      await datadb.put(new_avp);
+      await datadb.put(dumpAttributeValuePair(new_avp));
       avp_map[field_name] = new_avp_id;
     } else {
       if (revision.avps !== undefined) {
@@ -352,11 +374,29 @@ export async function createNewRecord(
   }
 }
 
-//function pouchAllDocsToMap(pouch_res: PouchDBAllDocsResult): FAIMSPouchDBMap {
-//    const rows = pouch_res.rows;
-//    let mapping: FAIMSPouchDBMap = {};
-//    rows.forEach(e => {
-//        mapping[e.doc._id] = e.doc;
-//    });
-//    return mapping;
-//}
+/*
+ * This handles converting attachments to data
+ */
+function loadAttributeValuePair(avp: AttributeValuePair): AttributeValuePair {
+  const attachments = avp._attachments;
+  if (attachments === null || attachments === undefined) {
+    // No attachments
+    return avp;
+  }
+  const loader = getAttachmentLoaderForType(avp.type);
+  if (loader === null) {
+    return avp;
+  }
+  return loader(avp);
+}
+
+/*
+ * This handles converting data to attachments
+ */
+function dumpAttributeValuePair(avp: AttributeValuePair): AttributeValuePair {
+  const dumper = getAttachmentDumperForType(avp.type);
+  if (dumper === null) {
+    return avp;
+  }
+  return dumper(avp);
+}

--- a/src/data_storage/merging.test.ts
+++ b/src/data_storage/merging.test.ts
@@ -88,6 +88,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc);
@@ -127,6 +129,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -141,6 +145,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id2 = await upsertFAIMSData(project_id, doc2);
@@ -155,6 +161,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id3 = await upsertFAIMSData(project_id, doc3);
@@ -169,6 +177,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc4);
@@ -210,6 +220,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -224,6 +236,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id2 = await upsertFAIMSData(project_id, doc2);
@@ -238,6 +252,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id3 = await upsertFAIMSData(project_id, doc3);
@@ -252,6 +268,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc4);
@@ -302,6 +320,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -316,6 +336,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc2);
@@ -330,6 +352,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id3 = await upsertFAIMSData(project_id, doc3);
@@ -344,6 +368,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc4);
@@ -384,6 +410,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -398,6 +426,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc2);
@@ -412,6 +442,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id3 = await upsertFAIMSData(project_id, doc3);
@@ -426,6 +458,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc4);
@@ -469,6 +503,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -486,6 +522,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc2);
@@ -503,6 +541,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc3);
@@ -546,6 +586,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -563,6 +605,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc2);
@@ -580,6 +624,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc3);
@@ -597,6 +643,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc4);
@@ -641,6 +689,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -659,6 +709,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc2);
@@ -677,6 +729,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc3);
@@ -695,6 +749,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc4);
@@ -713,6 +769,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc5);
@@ -878,6 +936,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -895,6 +955,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     await upsertFAIMSData(project_id, doc2);
@@ -912,6 +974,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id3 = await upsertFAIMSData(project_id, doc3);
@@ -966,6 +1030,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id1 = await upsertFAIMSData(project_id, doc1);
@@ -983,6 +1049,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id2 = await upsertFAIMSData(project_id, doc2);
@@ -1000,6 +1068,8 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
+      annotations: {},
+      field_types: {field_name: fulltype},
     };
 
     const revision_id3 = await upsertFAIMSData(project_id, doc3);

--- a/src/datamodel/core.ts
+++ b/src/datamodel/core.ts
@@ -72,3 +72,6 @@ export type RevisionID = string;
 export type AttributeValuePairID = string;
 
 export type FAIMSTypeName = string;
+
+// This should be locked down more
+export type Annotations = any;

--- a/src/datamodel/database.ts
+++ b/src/datamodel/database.ts
@@ -25,6 +25,7 @@ import {
   AttributeValuePairID,
   ProjectID,
   FAIMSTypeName,
+  Annotations,
 } from './core';
 import {
   FAIMSConstantCollection,
@@ -203,7 +204,7 @@ export interface AttributeValuePair {
   data: any;
   revision_id: RevisionID;
   record_id: RecordID;
-  annotations: any;
+  annotations: Annotations;
 }
 
 /*

--- a/src/datamodel/typesystem.ts
+++ b/src/datamodel/typesystem.ts
@@ -17,6 +17,8 @@
  * Description:
  *   TODO
  */
+import {FAIMSTypeName} from './core';
+import {AttributeValuePair} from './database';
 
 export interface FAIMSType {
   [key: string]: any; // any for now until we lock down the json
@@ -52,4 +54,49 @@ export interface ProjectUIViews {
     fields: string[];
     next_label?: string;
   };
+}
+
+type AttributeValuePairConverter = (
+  avp: AttributeValuePair
+) => AttributeValuePair;
+
+const attachment_dumpers: {
+  [typename: string]: AttributeValuePairConverter;
+} = {};
+const attachment_loaders: {
+  [typename: string]: AttributeValuePairConverter;
+} = {};
+
+export function getAttachmentLoaderForType(
+  type: FAIMSTypeName
+): AttributeValuePairConverter | null {
+  const loader = attachment_loaders[type];
+  if (loader === null || loader === undefined) {
+    return null;
+  }
+  return loader;
+}
+
+export function getAttachmentDumperForType(
+  type: FAIMSTypeName
+): AttributeValuePairConverter | null {
+  const dumper = attachment_dumpers[type];
+  if (dumper === null || dumper === undefined) {
+    return null;
+  }
+  return dumper;
+}
+
+export function setAttachmentLoaderForType(
+  type: FAIMSTypeName,
+  loader: AttributeValuePairConverter
+) {
+  attachment_loaders[type] = loader;
+}
+
+export function setAttachmentDumperForType(
+  type: FAIMSTypeName,
+  dumper: AttributeValuePairConverter
+) {
+  attachment_dumpers[type] = dumper;
 }

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -22,7 +22,13 @@
  * User readable information about a project
  * Do not use with sync code; UI code only
  */
-import {ProjectID, RecordID, RevisionID, FAIMSTypeName} from './core';
+import {
+  ProjectID,
+  RecordID,
+  RevisionID,
+  FAIMSTypeName,
+  Annotations,
+} from './core';
 import {ProjectUIFields, ProjectUIViewsets, ProjectUIViews} from './typesystem';
 
 export interface ProjectInformation {
@@ -67,6 +73,8 @@ export interface Record {
   data: {[field_name: string]: any};
   updated: Date;
   updated_by: string;
+  field_types: {[field_name: string]: FAIMSTypeName};
+  annotations: {[field_name: string]: Annotations};
   /*
   created{_by} are optional as we don't need to track them with the actual data.
   If you need creation information, then use record metadata

--- a/src/dummyData.ts
+++ b/src/dummyData.ts
@@ -65,6 +65,20 @@ const example_records: {
         'checkbox-field': true,
         'radio-group-field': '1',
       },
+      annotations: {},
+      field_types: {
+        'take-point-field': 'faims-pos::Location',
+        'bad-field': 'faims-core::String',
+        'action-field': 'faims-core::String',
+        'email-field': 'faims-core::Email',
+        'str-field': 'faims-core::String',
+        'multi-str-field': 'faims-core::String',
+        'int-field': 'faims-core::Integer',
+        'select-field': 'faims-core::String',
+        'multi-select-field': 'faims-core::String',
+        'checkbox-field': 'faims-core::Bool',
+        'radio-group-field': 'faims-core::String',
+      },
     },
     {
       record_id: '020948f4-79b8-435f-9db6-9clksjdf900a',
@@ -90,6 +104,20 @@ const example_records: {
         'checkbox-field': true,
         'radio-group-field': '1',
       },
+      annotations: {},
+      field_types: {
+        'take-point-field': 'faims-pos::Location',
+        'bad-field': 'faims-core::String',
+        'action-field': 'faims-core::String',
+        'email-field': 'faims-core::Email',
+        'str-field': 'faims-core::String',
+        'multi-str-field': 'faims-core::String',
+        'int-field': 'faims-core::Integer',
+        'select-field': 'faims-core::String',
+        'multi-select-field': 'faims-core::String',
+        'checkbox-field': 'faims-core::Bool',
+        'radio-group-field': 'faims-core::String',
+      },
     },
     {
       record_id: '9a0782ba-937b-4f24-8489-58cd653eca88',
@@ -103,6 +131,12 @@ const example_records: {
         'int-field': 20,
         'select-field': ['EUR'],
         'checkbox-field': true,
+      },
+      annotations: {},
+      field_types: {
+        'int-field': 'faims-core::Integer',
+        'select-field': 'faims-core::String',
+        'checkbox-field': 'faims-core::Bool',
       },
     },
   ],
@@ -132,7 +166,7 @@ const example_ui_specs: {[key: string]: ProjectUIModel} = {
       'bad-field': {
         'component-namespace': 'fakefakefake', // this says what web component to use to render/acquire value from
         'component-name': 'NotAComponent',
-        'type-returned': 'faims-core::Email', // matches a type in the Project Model
+        'type-returned': 'faims-core::String', // matches a type in the Project Model
         'component-parameters': {
           fullWidth: true,
           name: 'email-field',

--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -59,6 +59,7 @@ import RecordDraftState from '../../../sync/draft-state';
 import {
   getFieldsForViewSet,
   getFieldNamesFromFields,
+  getReturnedTypesForViewSet,
 } from '../../../uiSpecification';
 import {getCurrentUserId} from '../../../users';
 import {Link} from '@material-ui/core';
@@ -382,6 +383,8 @@ class RecordForm extends React.Component<
   }
 
   save(values: any) {
+    const ui_specification = this.props.ui_specification;
+    const viewsetName = this.requireViewsetName();
     getCurrentUserId(this.props.project_id)
       .then(userid => {
         const now = new Date();
@@ -392,6 +395,11 @@ class RecordForm extends React.Component<
           data: values,
           updated_by: userid,
           updated: now,
+          annotations: {},
+          field_types: getReturnedTypesForViewSet(
+            ui_specification,
+            viewsetName
+          ),
         };
         console.log(doc);
         return doc;

--- a/src/projectSpecification.ts
+++ b/src/projectSpecification.ts
@@ -20,10 +20,11 @@
 
 import {getProjectDB} from './sync/index';
 import PouchDB from 'pouchdb';
-import {ProjectID} from './datamodel/core';
+import {ProjectID, FAIMSTypeName} from './datamodel/core';
 import {
   PROJECT_SPECIFICATION_PREFIX,
   ProjectSchema,
+  AttributeValuePair,
 } from './datamodel/database';
 import {FAIMSType, FAIMSConstant} from './datamodel/typesystem';
 
@@ -63,7 +64,7 @@ export function createTypeContext(
   };
 }
 
-export function parseTypeName(typename: string): TypeReference {
+export function parseTypeName(typename: FAIMSTypeName): TypeReference {
   const splitname = typename.split('::');
   if (
     splitname.length !== 2 ||
@@ -77,7 +78,10 @@ export function parseTypeName(typename: string): TypeReference {
   return {namespace: splitname[0], name: splitname[1]};
 }
 
-export async function lookupFAIMSType(faimsType: string, context: TypeContext) {
+export async function lookupFAIMSType(
+  faimsType: FAIMSTypeName,
+  context: TypeContext
+) {
   if (context.use_cache && typeCache.has(faimsType)) {
     return typeCache.get(faimsType);
   }

--- a/src/uiSpecification.ts
+++ b/src/uiSpecification.ts
@@ -20,7 +20,7 @@
 
 import {getProjectDB} from './sync';
 import PouchDB from 'pouchdb';
-import {ProjectID} from './datamodel/core';
+import {ProjectID, FAIMSTypeName} from './datamodel/core';
 import {
   ProjectMetaObject,
   UI_SPECIFICATION_NAME,
@@ -96,4 +96,16 @@ export function getFieldNamesFromFields(fields: {
   [key: string]: {[key: string]: any};
 }): string[] {
   return Object.keys(fields);
+}
+
+export function getReturnedTypesForViewSet(
+  ui_specification: ProjectUIModel,
+  viewset_name: string
+): {[field_name: string]: FAIMSTypeName} {
+  const fields = getFieldsForViewSet(ui_specification, viewset_name);
+  const types: {[field_name: string]: FAIMSTypeName} = {};
+  for (const field_name in fields) {
+    types[field_name] = fields[field_name]['type-returned'];
+  }
+  return types;
 }


### PR DESCRIPTION
Add another plugin system to handle conversion between attachments and
form data. This should allow for transparent conversion between blobs in
attachments, and their copying to the form data.