### PR TITLE
List revisions via map-reduce

### DIFF
--- a/src/dataStorage.test.ts
+++ b/src/dataStorage.test.ts
@@ -5,6 +5,7 @@ import {
   generateFAIMSDataID,
   upsertFAIMSData,
   lookupFAIMSDataID,
+  listFAIMSProjectRevisions,
 } from './dataStorage';
 import {equals} from './utils/eqTestSupport';
 
@@ -67,6 +68,76 @@ describe('roundtrip reading and writing to db', () => {
 
       return upsertFAIMSData(project_name, doc)
         .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return lookupFAIMSDataID(project_name, dataid);
+        })
+        .then(result => {
+          return upsertFAIMSData(project_name, result);
+        })
+        .then(result => {
+          return listFAIMSProjectRevisions(project_name);
+        })
+        .then(result => {
+          console.log(result);
           return lookupFAIMSDataID(project_name, dataid);
         })
         .then(result => {

--- a/src/dataStorage.ts
+++ b/src/dataStorage.ts
@@ -3,11 +3,24 @@ import {v4 as uuidv4} from 'uuid';
 import {getDataDB} from './sync/index';
 import {Observation, EncodedObservation} from './datamodel';
 
+export interface DataListing {
+  [_id: string]: string[];
+}
+
 export function generateFAIMSDataID(): string {
   return uuidv4();
 }
 
 function convertFromFormToDB(doc: Observation): EncodedObservation {
+  if (doc._rev !== undefined) {
+    return {
+      _id: doc._id,
+      _rev: doc._rev,
+      type: doc.type,
+      data: doc.data,
+      format_version: 1,
+    };
+  }
   return {
     _id: doc._id,
     type: doc.type,
@@ -21,6 +34,7 @@ function convertFromDBToForm(doc: EncodedObservation): Observation {
     _id: doc._id,
     type: doc.type,
     data: doc.data,
+    _rev: doc._rev,
   };
 }
 
@@ -40,10 +54,54 @@ export async function lookupFAIMSDataID(
 ): Promise<Observation> {
   const datadb = getDataDB(project_name);
   try {
-    const doc = await datadb.get(dataid);
+    const doc: EncodedObservation = await datadb.get(dataid);
     return convertFromDBToForm(doc);
   } catch (err) {
     console.warn(err);
     throw Error('failed to find data with id');
+  }
+}
+
+async function ensureListDDocExists(project_name: string) {
+  const datadb = getDataDB(project_name);
+  const ddoc = {
+    _id: '_design/list_all_data_rev',
+    views: {
+      list_all_data_rev: {
+        map: 'function mapFun(doc) {emit(doc._id, doc._rev);}',
+      },
+    },
+  };
+  try {
+    await datadb.put(ddoc);
+  } catch (err) {
+    if (err.name !== 'conflict') {
+      throw err;
+    }
+    // skip existing doc - we should work out how best to handle updating it
+  }
+}
+
+export async function listFAIMSProjectRevisions(
+  project_name: string
+): Promise<DataListing> {
+  const datadb = getDataDB(project_name);
+  try {
+    await ensureListDDocExists(project_name);
+    const result = await datadb.query('list_all_data_rev');
+    const rows = result.rows;
+    const revmap: DataListing = {};
+    for (const row of rows) {
+      const _id: string = row.key;
+      const _rev: string = row.value;
+      if (revmap[_id] === undefined) {
+        revmap[_id] = [];
+      }
+      revmap[_id].push(_rev);
+    }
+    return revmap;
+  } catch (err) {
+    console.warn(err);
+    throw Error('failed to list data in project');
   }
 }

--- a/src/datamodel.ts
+++ b/src/datamodel.ts
@@ -119,6 +119,18 @@ export interface EncodedObservation {
   data: any;
 }
 
+// TODO: This needs tightening up
+export interface DesignDocument {
+  _id: string;
+  [x: string]: any;
+}
+
+/*
+ * Elements of a Project's dataDB can be any one of these,
+ * discriminated by the prefix of the object's id
+ */
+export type ProjectDataObject = EncodedObservation | DesignDocument;
+
 /*
  * Elements of a Project's metadataDB can be any one of these,
  * discriminated by the prefix of the object's id

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -75,7 +75,7 @@ export const people_dbs: LocalDBList<DataModel.PeopleDoc> = {};
  * Contain in these databases (indexed by the active_db id's)
  * is project data.
  */
-export const data_dbs: LocalDBList<DataModel.EncodedObservation> = {};
+export const data_dbs: LocalDBList<DataModel.ProjectDataObject> = {};
 
 /**
  * Synced from the project metadatabase for each active project,
@@ -390,7 +390,7 @@ export const createdProjects: {
     project: DataModel.ProjectObject;
     active: ExistingActiveDoc;
     meta: LocalDB<DataModel.ProjectMetaObject>;
-    data: LocalDB<DataModel.EncodedObservation>;
+    data: LocalDB<DataModel.ProjectDataObject>;
   };
 } = {};
 
@@ -409,7 +409,7 @@ export const createdListings: {
 
 export function getDataDB(
   active_id: string
-): PouchDB.Database<DataModel.EncodedObservation> {
+): PouchDB.Database<DataModel.ProjectDataObject> {
   if (data_dbs[active_id] !== undefined) {
     return data_dbs[active_id].local;
   } else {
@@ -465,7 +465,7 @@ interface DirectoryEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -475,7 +475,7 @@ interface DirectoryEmitter extends EventEmitter {
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -484,7 +484,7 @@ interface DirectoryEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -494,7 +494,7 @@ interface DirectoryEmitter extends EventEmitter {
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -565,7 +565,7 @@ interface DirectoryEmitter extends EventEmitter {
     listing: DataModel.ListingsObject,
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_complete',
@@ -573,14 +573,14 @@ interface DirectoryEmitter extends EventEmitter {
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_created',
     listing: DataModel.ListingsObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_error',
@@ -750,7 +750,7 @@ interface ListingEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -760,7 +760,7 @@ interface ListingEmitter extends EventEmitter {
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -769,7 +769,7 @@ interface ListingEmitter extends EventEmitter {
       listing: DataModel.ListingsObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -779,7 +779,7 @@ interface ListingEmitter extends EventEmitter {
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -836,7 +836,7 @@ interface ListingEmitter extends EventEmitter {
     listing: DataModel.ListingsObject,
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_complete',
@@ -844,14 +844,14 @@ interface ListingEmitter extends EventEmitter {
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_created',
     listing: DataModel.ListingsObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_syncing',
@@ -859,7 +859,7 @@ interface ListingEmitter extends EventEmitter {
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'project_error',
@@ -1025,7 +1025,7 @@ interface ProjectEmitter extends EventEmitter {
     listener: (
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -1034,7 +1034,7 @@ interface ProjectEmitter extends EventEmitter {
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -1042,7 +1042,7 @@ interface ProjectEmitter extends EventEmitter {
     listener: (
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -1051,7 +1051,7 @@ interface ProjectEmitter extends EventEmitter {
       project: DataModel.ProjectObject,
       active: ExistingActiveDoc,
       meta: LocalDB<DataModel.ProjectMetaObject>,
-      data: LocalDB<DataModel.EncodedObservation>
+      data: LocalDB<DataModel.ProjectDataObject>
     ) => unknown
   ): this;
   on(
@@ -1069,27 +1069,27 @@ interface ProjectEmitter extends EventEmitter {
     event: 'data_complete',
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'complete',
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'created',
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(
     event: 'syncing',
     project: DataModel.ProjectObject,
     active: ExistingActiveDoc,
     meta: LocalDB<DataModel.ProjectMetaObject>,
-    data: LocalDB<DataModel.EncodedObservation>
+    data: LocalDB<DataModel.ProjectDataObject>
   ): boolean;
   emit(event: 'error', active: ExistingActiveDoc, err: unknown): boolean;
 }


### PR DESCRIPTION
This shouldn't be used, but there's likely some stuff we want to extract for design docs and/or map-reduce usage elsewhere.

Creating this PR to document the existence and purpose of this old branch.