### PR TITLE
Hide deleted records by default

### DIFF
--- a/src/data_storage/index.ts
+++ b/src/data_storage/index.ts
@@ -259,6 +259,7 @@ export async function getRecordMetadata(
       updated: new Date(revision.created),
       updated_by: revision.created_by,
       conflicts: record.heads.length > 1,
+      deleted: revision.deleted ? true : false,
     };
   } catch (err) {
     console.error(err);

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -158,6 +158,7 @@ export async function listRecordMetadata(
         updated: new Date(revision.created),
         updated_by: revision.created_by,
         conflicts: record.heads.length > 1,
+        deleted: revision.deleted ? true : false,
       };
     });
     return out;

--- a/src/data_storage/listeners.ts
+++ b/src/data_storage/listeners.ts
@@ -51,10 +51,24 @@ add_initial_listener(initializeEvents => {
  */
 export function listenRecordsList(
   project_id: ProjectID,
-  callback: (recordList: RecordMetadataList) => unknown
+  callback: (recordList: RecordMetadataList) => unknown,
+  filter_deleted = true
 ): () => void {
   const runCallback = () =>
     listRecordMetadata(project_id)
+      .then(record_list => {
+        if (filter_deleted) {
+          const new_record_list: RecordMetadataList = {};
+          for (const [key, metadata] of Object.entries(record_list)) {
+            if (!metadata.deleted) {
+              new_record_list[key] = metadata;
+            }
+          }
+          return new_record_list;
+        } else {
+          return record_list;
+        }
+      })
       .then(callback)
       .catch(err => console.error('Uncaught record list error', err));
 

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -52,6 +52,7 @@ export interface RecordMetadata {
   updated: Date;
   updated_by: string;
   conflicts: boolean;
+  deleted: boolean;
 }
 
 export type RecordMetadataList = {

--- a/src/gui/components/record/table.tsx
+++ b/src/gui/components/record/table.tsx
@@ -44,6 +44,9 @@ type RecordsTableProps = {
 
 export default function RecordsTable(props: RecordsTableProps) {
   const {project_id, maxRows} = props;
+  // TODO: make this a prop and add logic around whether to display deleted or
+  // not
+  const filter_deleted = true;
   const [loading, setLoading] = useState(true);
   const theme = useTheme();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
@@ -97,7 +100,8 @@ export default function RecordsTable(props: RecordsTableProps) {
         if (!_.isEqual(Object.values(newPouchRecordList), rows)) {
           setRows(Object.values(newPouchRecordList));
         }
-      }
+      },
+      filter_deleted
     );
     return destroyListener; // destroyListener called when this component unmounts.
   }, [project_id, rows]);


### PR DESCRIPTION
Once the role-based access control is set up, we can look at configuring which roles see deleted records and which don't.

Closes FAIMS3-295.