### PR TITLE
Lock @material-ui/data-grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@capacitor/ios": "^2.4.7",
         "@demvsystems/yup-ast": "^1.2.0",
         "@material-ui/core": "^4.11.3",
-        "@material-ui/data-grid": "^4.0.0-alpha.28",
+        "@material-ui/data-grid": "4.0.0-alpha.28",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.57",
         "@testing-library/jest-dom": "^5.11.9",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@capacitor/ios": "^2.4.7",
     "@demvsystems/yup-ast": "^1.2.0",
     "@material-ui/core": "^4.11.3",
-    "@material-ui/data-grid": "^4.0.0-alpha.28",
+    "@material-ui/data-grid": "4.0.0-alpha.28",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@testing-library/jest-dom": "^5.11.9",


### PR DESCRIPTION
It looks like the interface keeps changing, so lock it down to that specific version.