### PR TITLE
Generate the record id on form creation, not save

### DIFF
--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -53,11 +53,7 @@ import {
   Annotations,
 } from '../../../datamodel/core';
 import {ProjectUIModel} from '../../../datamodel/ui';
-import {
-  upsertFAIMSData,
-  getFullRecordData,
-  generateFAIMSDataID,
-} from '../../../data_storage';
+import {upsertFAIMSData, getFullRecordData} from '../../../data_storage';
 import {getValidationSchemaForViewset} from '../../../data_storage/validation';
 import {store} from '../../../store';
 import RecordDraftState from '../../../sync/draft-state';
@@ -73,13 +69,13 @@ import {indexOf} from 'lodash';
 
 type RecordFormProps = {
   project_id: ProjectID;
+  record_id: RecordID;
   // Might be given in the URL:
   view_default?: string;
   ui_specification: ProjectUIModel;
 } & (
   | {
       // When editing existing record, we require the caller to know its revision
-      record_id: RecordID;
       revision_id: RevisionID;
       // The user can view records without editing them, and to facilitate this,
       // having a draft id is optional.
@@ -101,7 +97,6 @@ type RecordFormProps = {
 
       // To avoid 'revision_id' in this.props, and since in JS when a key is not set,
       // you get back undefined:
-      record_id?: undefined;
       revision_id?: undefined;
     }
 );
@@ -470,7 +465,7 @@ class RecordForm extends React.Component<
       .then(userid => {
         const now = new Date();
         const doc = {
-          record_id: this.props.record_id ?? generateFAIMSDataID(),
+          record_id: this.props.record_id,
           revision_id: this.props.revision_id ?? null,
           type: this.state.type_cached!,
           data: this.filterValues(values),

--- a/src/gui/pages/record-create.tsx
+++ b/src/gui/pages/record-create.tsx
@@ -18,7 +18,7 @@
  *   TODO
  */
 
-import React, {useContext, useState} from 'react';
+import React, {useContext, useState, useEffect} from 'react';
 import {
   Box,
   Container,
@@ -26,14 +26,14 @@ import {
   Paper,
   CircularProgress,
 } from '@material-ui/core';
-import {Redirect, useHistory, useParams} from 'react-router-dom';
+import {Redirect, useHistory, useParams, useLocation} from 'react-router-dom';
+
 import * as ROUTES from '../../constants/routes';
 import Breadcrumbs from '../components/ui/breadcrumbs';
 import RecordForm from '../components/record/form';
 import {getProjectInfo} from '../../databaseAccess';
 import {ProjectID} from '../../datamodel/core';
 import {ProjectInformation, ProjectUIModel} from '../../datamodel/ui';
-import {useEffect} from 'react';
 import {
   getUiSpecForProject,
   getReturnedTypesForViewSet,
@@ -41,7 +41,7 @@ import {
 import {ActionType} from '../../actions';
 import {store} from '../../store';
 import {newStagedData} from '../../sync/draft-storage';
-import {useLocation} from 'react-router-dom';
+import {generateFAIMSDataID} from '../../data_storage';
 interface DraftCreateProps {
   project_id: ProjectID;
   type_name: string;
@@ -118,6 +118,8 @@ function DraftEdit(props: DraftEditProps) {
   const [uiSpec, setUISpec] = useState(null as null | ProjectUIModel);
   const [error, setError] = useState(null as null | {});
 
+  const record_id = generateFAIMSDataID();
+
   useEffect(() => {
     getUiSpecForProject(project_id).then(setUISpec, setError);
   }, [project_id]);
@@ -155,6 +157,7 @@ function DraftEdit(props: DraftEditProps) {
               draft_id={draft_id}
               type={type_name}
               ui_specification={uiSpec}
+              record_id={record_id}
             />
           </Box>
         </Paper>

--- a/src/sync/draft-state.ts
+++ b/src/sync/draft-state.ts
@@ -44,10 +44,10 @@ const DRAFT_SAVE_CYCLE = 5000;
 
 type RelevantProps = {
   project_id: ProjectID;
+  record_id: RecordID;
 } & (
   | {
       // When editing existing record, we require the caller to know its revision
-      record_id: RecordID;
       revision_id: RevisionID;
       // This draft state usually requires a draft to keep
       // track of, BUT if the user is viewing an existing record,
@@ -67,7 +67,6 @@ type RelevantProps = {
 
       // To avoid 'revision_id' in this.props, and since in JS when a key is not set,
       // you get back undefined:
-      record_id?: undefined;
       revision_id?: undefined;
     }
 );


### PR DESCRIPTION
This should make working with relations much easier, as now we can pass around a record id.