### PR TITLE
2022 license update, post patch merge

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,6 +1,6 @@
 {
    "src/**/*.ts": [
-      " * Copyright 2021 Macquarie University",
+      " * Copyright 2021, 2022 Macquarie University",
       " *",
       " * Licensed under the Apache License Version 2.0 (the, \"License\");",
       " * you may not use, this file except in compliance with the License.",
@@ -15,7 +15,7 @@
       " * limitations under the License."
    ],
    "e2e/**/*.java": [
-      " * Copyright 2021 Macquarie University",
+      " * Copyright 2021, 2022 Macquarie University",
       " *",
       " * Licensed under the Apache License Version 2.0 (the, \"License\");",
       " * you may not use, this file except in compliance with the License.",

--- a/LICENSE-TEMPLATE-FOR-SRC
+++ b/LICENSE-TEMPLATE-FOR-SRC
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/AstroSky.java
+++ b/e2e/src/test/java/org/fedarch/faims3/AstroSky.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/E2ETest.java
+++ b/e2e/src/test/java/org/fedarch/faims3/E2ETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/TestIncompleteDraftObservation.java
+++ b/e2e/src/test/java/org/fedarch/faims3/TestIncompleteDraftObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/TestPopulateForm.java
+++ b/e2e/src/test/java/org/fedarch/faims3/TestPopulateForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/TestStagingForm.java
+++ b/e2e/src/test/java/org/fedarch/faims3/TestStagingForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/TestUtils.java
+++ b/e2e/src/test/java/org/fedarch/faims3/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/android/AndroidTest.java
+++ b/e2e/src/test/java/org/fedarch/faims3/android/AndroidTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/android/TestIncompleteDraftObservationAndroid.java
+++ b/e2e/src/test/java/org/fedarch/faims3/android/TestIncompleteDraftObservationAndroid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/android/TestPopulateFormAndroid.java
+++ b/e2e/src/test/java/org/fedarch/faims3/android/TestPopulateFormAndroid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/android/TestStagingFormAndroid.java
+++ b/e2e/src/test/java/org/fedarch/faims3/android/TestStagingFormAndroid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/android/TestUtils.java
+++ b/e2e/src/test/java/org/fedarch/faims3/android/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/chrome/ChromeTest.java
+++ b/e2e/src/test/java/org/fedarch/faims3/chrome/ChromeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/chrome/TestIncompleteDraftObservationChrome.java
+++ b/e2e/src/test/java/org/fedarch/faims3/chrome/TestIncompleteDraftObservationChrome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/chrome/TestPopulateFormChrome.java
+++ b/e2e/src/test/java/org/fedarch/faims3/chrome/TestPopulateFormChrome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/e2e/src/test/java/org/fedarch/faims3/chrome/TestStagingFormChrome.java
+++ b/e2e/src/test/java/org/fedarch/faims3/chrome/TestStagingFormChrome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/actions.tsx
+++ b/src/actions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/buildconfig.ts
+++ b/src/buildconfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage.test.ts
+++ b/src/data_storage.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/attachments.ts
+++ b/src/data_storage/attachments.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/index.ts
+++ b/src/data_storage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/merging.test.ts
+++ b/src/data_storage/merging.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/merging.ts
+++ b/src/data_storage/merging.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/queries.ts
+++ b/src/data_storage/queries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/data_storage/validation.ts
+++ b/src/data_storage/validation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/databaseAccess.tsx
+++ b/src/databaseAccess.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel.test.ts
+++ b/src/datamodel.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/autoincrement.ts
+++ b/src/datamodel/autoincrement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/core.ts
+++ b/src/datamodel/core.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/database.ts
+++ b/src/datamodel/database.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/drafts.ts
+++ b/src/datamodel/drafts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/geo.ts
+++ b/src/datamodel/geo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/index.ts
+++ b/src/datamodel/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/typesystem.ts
+++ b/src/datamodel/typesystem.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/drafts.ts
+++ b/src/drafts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/component_registry/ComponentRegistry.test.ts
+++ b/src/gui/component_registry/ComponentRegistry.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/component_registry/bundle_components.ts
+++ b/src/gui/component_registry/bundle_components.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/component_registry/defaults.tsx
+++ b/src/gui/component_registry/defaults.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/component_registry/index.ts
+++ b/src/gui/component_registry/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/component_registry/internals.ts
+++ b/src/gui/component_registry/internals.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/alert.tsx
+++ b/src/gui/components/alert.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/authentication/cluster_card.tsx
+++ b/src/gui/components/authentication/cluster_card.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/autoincrement/browse-form.tsx
+++ b/src/gui/components/autoincrement/browse-form.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/autoincrement/edit-form.tsx
+++ b/src/gui/components/autoincrement/edit-form.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/dashboard/actions.tsx
+++ b/src/gui/components/dashboard/actions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/footer.tsx
+++ b/src/gui/components/footer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/loadingApp.tsx
+++ b/src/gui/components/loadingApp.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/metadataRenderer.tsx
+++ b/src/gui/components/metadataRenderer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/navbar.tsx
+++ b/src/gui/components/navbar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/CreateProjectCard.tsx
+++ b/src/gui/components/project/CreateProjectCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/FormElement.tsx
+++ b/src/gui/components/project/FormElement.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/RangeHeader.tsx
+++ b/src/gui/components/project/RangeHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/card.tsx
+++ b/src/gui/components/project/card.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/data/ComponentSetting.tsx
+++ b/src/gui/components/project/data/ComponentSetting.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/data/componenentSetting.tsx
+++ b/src/gui/components/project/data/componenentSetting.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/data/uiFieldsRegistry.tsx
+++ b/src/gui/components/project/data/uiFieldsRegistry.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/FieldsListCard.tsx
+++ b/src/gui/components/project/tabs/FieldsListCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/PSettingCard.tsx
+++ b/src/gui/components/project/tabs/PSettingCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjctOverview.tsx
+++ b/src/gui/components/project/tabs/ProjctOverview.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectBehaviour.tsx
+++ b/src/gui/components/project/tabs/ProjectBehaviour.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectButton.tsx
+++ b/src/gui/components/project/tabs/ProjectButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectDesign.tsx
+++ b/src/gui/components/project/tabs/ProjectDesign.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectInfo.tsx
+++ b/src/gui/components/project/tabs/ProjectInfo.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectPreview.tsx
+++ b/src/gui/components/project/tabs/ProjectPreview.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectSubmit.tsx
+++ b/src/gui/components/project/tabs/ProjectSubmit.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/ProjectUser.tsx
+++ b/src/gui/components/project/tabs/ProjectUser.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/TabPanel.tsx
+++ b/src/gui/components/project/tabs/TabPanel.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/project/tabs/TabTab.tsx
+++ b/src/gui/components/project/tabs/TabTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/Annotation.tsx
+++ b/src/gui/components/record/Annotation.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/autosave.tsx
+++ b/src/gui/components/record/autosave.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/delete.tsx
+++ b/src/gui/components/record/delete.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/draft_table.tsx
+++ b/src/gui/components/record/draft_table.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/fields.tsx
+++ b/src/gui/components/record/fields.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/helpers.ts
+++ b/src/gui/components/record/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/meta.tsx
+++ b/src/gui/components/record/meta.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/table.tsx
+++ b/src/gui/components/record/table.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/record/view.tsx
+++ b/src/gui/components/record/view.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/ui/boxTab.tsx
+++ b/src/gui/components/ui/boxTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/components/ui/inProgress.tsx
+++ b/src/gui/components/ui/inProgress.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/ActionButton.tsx
+++ b/src/gui/fields/ActionButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/BasicAutoIncrementer.tsx
+++ b/src/gui/fields/BasicAutoIncrementer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/FileUploader.tsx
+++ b/src/gui/fields/FileUploader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/RelatedRecordSelector.tsx
+++ b/src/gui/fields/RelatedRecordSelector.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/TakePhoto.tsx
+++ b/src/gui/fields/TakePhoto.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/TakePoint.tsx
+++ b/src/gui/fields/TakePoint.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/TemplatedStringField.tsx
+++ b/src/gui/fields/TemplatedStringField.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/checkbox.test.tsx.broken
+++ b/src/gui/fields/checkbox.test.tsx.broken
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/checkbox.tsx
+++ b/src/gui/fields/checkbox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/radio.test.tsx.broken
+++ b/src/gui/fields/radio.test.tsx.broken
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/radio.tsx
+++ b/src/gui/fields/radio.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/select.test.tsx.broken
+++ b/src/gui/fields/select.test.tsx.broken
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/select.tsx
+++ b/src/gui/fields/select.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/fields/utils.tsx
+++ b/src/gui/fields/utils.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/404.tsx
+++ b/src/gui/pages/404.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/about-build.tsx
+++ b/src/gui/pages/about-build.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/autoincrement-browse.tsx
+++ b/src/gui/pages/autoincrement-browse.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/autoincrement-edit.tsx
+++ b/src/gui/pages/autoincrement-edit.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/home.tsx
+++ b/src/gui/pages/home.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/index.tsx
+++ b/src/gui/pages/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/project-create.tsx
+++ b/src/gui/pages/project-create.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/project-list.tsx
+++ b/src/gui/pages/project-list.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/project-search.tsx
+++ b/src/gui/pages/project-search.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/project-settings.tsx
+++ b/src/gui/pages/project-settings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/project.tsx
+++ b/src/gui/pages/project.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/record-create.tsx
+++ b/src/gui/pages/record-create.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/record-list.tsx
+++ b/src/gui/pages/record-list.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/record.tsx
+++ b/src/gui/pages/record.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/signin-return.tsx
+++ b/src/gui/pages/signin-return.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable node/no-unsupported-features/node-builtins */
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pages/signin.tsx
+++ b/src/gui/pages/signin.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/pouchHook.ts
+++ b/src/gui/pouchHook.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/theme/index.tsx
+++ b/src/gui/theme/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/theme/shadows.tsx
+++ b/src/gui/theme/shadows.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/gui/theme/typography.tsx
+++ b/src/gui/theme/typography.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/integration_tests/App.test.tsx
+++ b/src/integration_tests/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/integration_tests/new-project.test.ts.disable
+++ b/src/integration_tests/new-project.test.ts.disable
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/integration_tests/pouch_to_couch.test.ts
+++ b/src/integration_tests/pouch_to_couch.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/pouchdb_debug.d.ts
+++ b/src/pouchdb_debug.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/projectMetadata.test.ts
+++ b/src/projectMetadata.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/projectMetadata.ts
+++ b/src/projectMetadata.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/projectSpecification.test.ts
+++ b/src/projectSpecification.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/projectSpecification.ts
+++ b/src/projectSpecification.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/connection.ts
+++ b/src/sync/connection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/databases.ts
+++ b/src/sync/databases.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/draft-state.ts
+++ b/src/sync/draft-state.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/draft-storage.ts
+++ b/src/sync/draft-storage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/events.ts
+++ b/src/sync/events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/initialize.ts
+++ b/src/sync/initialize.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/new-project.ts
+++ b/src/sync/new-project.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/process-initialization.ts
+++ b/src/sync/process-initialization.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/stateful-event-handling.ts
+++ b/src/sync/stateful-event-handling.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/sync/sync-toggle.ts
+++ b/src/sync/sync-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/uiSpecification.test.ts
+++ b/src/uiSpecification.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/uiSpecification.ts
+++ b/src/uiSpecification.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Macquarie University
+ * Copyright 2021, 2022 Macquarie University
  *
  * Licensed under the Apache License Version 2.0 (the, "License");
  * you may not use, this file except in compliance with the License.


### PR DESCRIPTION
Regex performed again to get 2022 to all MQ license years as per GNU suggestions.

Signed-off-by: Brian Ballsun-Stanton <denubis@noreply.users.github.com>