### PR TITLE
a fix for photo scaling in take-photo, and the editing toggle

### DIFF
--- a/src/gui/fields/TakePhoto.tsx
+++ b/src/gui/fields/TakePhoto.tsx
@@ -77,8 +77,7 @@ export class TakePhoto extends React.Component<
   }
   render() {
     const images = this.props.field.value;
-    const error = this.props.form.errors[this.props.field.name];
-    console.log(images);
+    const error = this.props.form.errors[this.props.field.name];    
     const image_tag_list = [];
     if (images !== null && images !== undefined) {
       for (const image of images) {

--- a/src/gui/fields/TakePhoto.tsx
+++ b/src/gui/fields/TakePhoto.tsx
@@ -63,8 +63,9 @@ export class TakePhoto extends React.Component<
       const image = base64image_to_blob(
         await Camera.getPhoto({
           quality: 90,
-          allowEditing: true,
+          allowEditing: false,
           resultType: CameraResultType.Base64,
+          correctOrientation: true,
         })
       );
       console.log(image);
@@ -77,13 +78,17 @@ export class TakePhoto extends React.Component<
   render() {
     const images = this.props.field.value;
     const error = this.props.form.errors[this.props.field.name];
+    console.log(images);
     const image_tag_list = [];
     if (images !== null && images !== undefined) {
       for (const image of images) {
         const image_ref = URL.createObjectURL(image);
         const image_tag = (
-          <img className="faims-take-photo-img" src={image_ref} />
-        );
+          <img
+            style={{height: '200px', width: '100%', objectFit: 'cover'}}
+            src={image_ref}
+          />
+        ); // faims-take-photo-img"
         image_tag_list.push(image_tag);
       }
     }
@@ -91,6 +96,15 @@ export class TakePhoto extends React.Component<
     if (error) {
       error_text = <span {...this.props['ErrorTextProps']}>{error}</span>;
     }
+
+    // https://mui.com/components/image-list/#masonry-image-list
+    // Masonry image lists use dynamically sized container heights
+    // that reflect the aspect ratio of each image. This image list
+    // is best used for browsing uncropped peer content.
+    // But it doesn't look like we support masonry right now.
+    //
+    // It also looks like we don't have multiple photos being returned...
+
     return (
       <div>
         {this.props.helperText}
@@ -109,17 +123,18 @@ export class TakePhoto extends React.Component<
             ? this.props.label
             : 'Take Photo'}
         </Button>
-
         {image_tag_list ? (
-          <ImageList rowHeight={164}>
+          <ImageList cols={1} gap={8}>
             {image_tag_list.map((image_tag, index) => (
-              <ImageListItem key={index}>{image_tag}</ImageListItem>
-            ))}
+              <ImageListItem style={{width: '300', margin: '5px'}} key={index}>
+                {image_tag}
+              </ImageListItem>
+            ))}{' '}
           </ImageList>
         ) : (
           <span>No photo taken.</span>
         )}
-        {error_text}
+        {error_text}{' '}
       </div>
     );
   }

--- a/src/gui/fields/TakePhoto.tsx
+++ b/src/gui/fields/TakePhoto.tsx
@@ -77,7 +77,7 @@ export class TakePhoto extends React.Component<
   }
   render() {
     const images = this.props.field.value;
-    const error = this.props.form.errors[this.props.field.name];    
+    const error = this.props.form.errors[this.props.field.name];
     const image_tag_list = [];
     if (images !== null && images !== undefined) {
       for (const image of images) {


### PR DESCRIPTION
This should scale the photo taking thing correctly, as well as reduce a click from the android version of "editor"

There are bugs still about overwriting the field value instead of appending to it for multiple photos, as well as work needed to lightbox and be able to delete (and annotate) photos -- but that's for later.

Signed-off-by: Brian Ballsun-Stanton <denubis@noreply.users.github.com>