### PR TITLE
Close the in app browser when done

### DIFF
--- a/src/gui/components/authentication/login_form.tsx
+++ b/src/gui/components/authentication/login_form.tsx
@@ -75,6 +75,7 @@ function LoginButton(props: LoginButtonProps) {
               console.error('token is', token);
               props.setToken(token);
               reprocess_listing(props.listing_id);
+              oauth_window.close(); // We cannot close the iab inside the iab
             })
             .catch(err => {
               console.warn('Failed to get token for: ', props.listing_id, err);


### PR DESCRIPTION
Due to the way the in app browser works, we cannot close it from within the in app browser. Hence we call close once we've processed the token.