### PR TITLE
Fix mime type in TakePhoto

### DIFF
--- a/src/gui/fields/TakePhoto.tsx
+++ b/src/gui/fields/TakePhoto.tsx
@@ -41,7 +41,7 @@ function base64image_to_blob(image: CameraPhoto): Blob {
     bytes[x] = rawData.charCodeAt(x);
   }
   const arr = new Uint8Array(bytes);
-  const blob = new Blob([arr], {type: image.format});
+  const blob = new Blob([arr], {type: 'image/' + image.format});
   return blob;
 }
 


### PR DESCRIPTION
Capacitor's camera plugin does not provide a mimetype, so we must create it from the information we receive.