### PR TITLE
Fix notebook syncing when logging in

### DIFF
--- a/src/sync/process-initialization.ts
+++ b/src/sync/process-initialization.ts
@@ -181,6 +181,8 @@ export function reprocess_listing(listing_id: string) {
       // so it's an error if it doesn't exist.
       err => events.emit('listing_error', listing_id, err)
     );
+  // This is a workaround until we add notebook-level activation
+  window.location.reload();
 }
 
 /**


### PR DESCRIPTION
We need to recreate the replication connection when logging in, but this
requires notebook-level activation (not autoactivation), so refresh the
page which achieves the same thing for now as a workaround.