### PR TITLE
Add filtering based on user

### DIFF
--- a/src/buildconfig.ts
+++ b/src/buildconfig.ts
@@ -209,6 +209,14 @@ function is_testing() {
   return jest_worker_is_running || jest_imported || test_node_env;
 }
 
+function cluster_admin_group_name(): string {
+  const name = process.env.REACT_APP_CLUSTER_ADMIN_GROUP_NAME;
+  if (name === '' || name === undefined) {
+    return 'cluster-admin';
+  }
+  return name;
+}
+
 export const USE_REAL_DATA = PROD_BUILD || use_real_data();
 export const DEBUG_POUCHDB = !PROD_BUILD && include_pouchdb_debugging();
 export const DEBUG_APP = !PROD_BUILD && include_app_debugging();
@@ -220,4 +228,5 @@ export const RUNNING_UNDER_TEST = is_testing();
 export const COMMIT_VERSION = commit_version();
 export const POUCH_BATCH_SIZE = pouch_batch_size();
 export const POUCH_BATCHES_LIMIT = pouch_batches_limit();
+export const CLUSTER_ADMIN_GROUP_NAME = cluster_admin_group_name();
 export const AUTOACTIVATE_PROJECTS = true; // for alpha, beta will change this

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -15,7 +15,7 @@
  *
  * Filename: internals.ts
  * Description:
- *   TODO
+ *   Helper functions to handle converting data between the GUI and pouchdb.
  */
 
 import {v4 as uuidv4} from 'uuid';

--- a/src/data_storage/queries.ts
+++ b/src/data_storage/queries.ts
@@ -15,7 +15,7 @@
  *
  * Filename: queries.ts
  * Description:
- *   TODO
+ *   Functions to query specific information from pouchdb
  */
 import {getDataDB} from '../sync';
 import {ProjectID, FAIMSTypeName, RecordID} from '../datamodel/core';

--- a/src/databaseAccess.tsx
+++ b/src/databaseAccess.tsx
@@ -29,8 +29,8 @@
  *   (Sync refactor)
  */
 
-import {ProjectID} from './datamodel/core';
 import {DEBUG_APP} from './buildconfig';
+import {ProjectID} from './datamodel/core';
 import {ProjectInformation, ListingInformation} from './datamodel/ui';
 import {all_projects_updated, createdProjects} from './sync/state';
 import {events} from './sync/events';
@@ -40,6 +40,7 @@ import {
   waitForStateOnce,
   getAllListings,
 } from './sync';
+import {shouldDisplayProject} from './users';
 
 export async function getProjectList(): Promise<ProjectInformation[]> {
   /**
@@ -54,14 +55,17 @@ export async function getProjectList(): Promise<ProjectInformation[]> {
 
   const output: ProjectInformation[] = [];
   for (const listing_id_project_id in createdProjects) {
-    output.push({
-      name: createdProjects[listing_id_project_id].project.name,
-      description: createdProjects[listing_id_project_id].project.description,
-      last_updated: createdProjects[listing_id_project_id].project.last_updated,
-      created: createdProjects[listing_id_project_id].project.created,
-      status: createdProjects[listing_id_project_id].project.status,
-      project_id: listing_id_project_id,
-    });
+    if (await shouldDisplayProject(listing_id_project_id)) {
+      output.push({
+        name: createdProjects[listing_id_project_id].project.name,
+        description: createdProjects[listing_id_project_id].project.description,
+        last_updated:
+          createdProjects[listing_id_project_id].project.last_updated,
+        created: createdProjects[listing_id_project_id].project.created,
+        status: createdProjects[listing_id_project_id].project.status,
+        project_id: listing_id_project_id,
+      });
+    }
   }
   return output;
 }

--- a/src/datamodel/core.ts
+++ b/src/datamodel/core.ts
@@ -15,7 +15,10 @@
  *
  * Filename: core.ts
  * Description:
- *   TODO
+ *   Core types/interfaces that are used throughout the codebase.
+ *   Types/interfaces that are only used within the GUI, or are what the GUI
+ *   sees should go in the gui file, whilst those types only used within the
+ *   databases should go in the database file.
  */
 
 // There are two internal IDs for projects, the former is unique to the system
@@ -112,4 +115,10 @@ export interface TokenContents {
   username: string;
   roles: string[];
   name?: string;
+}
+
+export type ProjectRole = string;
+
+export interface ClusterProjectRoles {
+  [key: string]: Array<ProjectRole>;
 }

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -15,13 +15,10 @@
  *
  * Filename: ui.ts
  * Description:
- *   TODO
+ *   Types/interfaces for the UI code.
+ *   Do not use with sync code; UI code only.
  */
 
-/**
- * User readable information about a project
- * Do not use with sync code; UI code only
- */
 import {
   ProjectID,
   RecordID,

--- a/src/gui/components/record/table.tsx
+++ b/src/gui/components/record/table.tsx
@@ -15,7 +15,7 @@
  *
  * Filename: table.tsx
  * Description:
- *   TODO
+ *   Components for displaying record metadata in a table.
  */
 
 import React from 'react';
@@ -36,8 +36,10 @@ import * as ROUTES from '../../../constants/routes';
 import {ProjectID} from '../../../datamodel/core';
 import {ProjectUIViewsets} from '../../../datamodel/typesystem';
 import {RecordMetadata} from '../../../datamodel/ui';
-import {getMetadataForAllRecords} from '../../../data_storage/index';
-import {getAllRecordsWithRegex} from '../../../data_storage/queries';
+import {
+  getMetadataForAllRecords,
+  getRecordsWithRegex,
+} from '../../../data_storage/index';
 import {useEventedPromise} from '../../pouchHook';
 import {listenDataDB} from '../../../sync';
 import {DEBUG_APP} from '../../../buildconfig';
@@ -61,6 +63,7 @@ type RecordsSearchTableProps = {
   project_id: ProjectID;
   maxRows: number | null;
   query: string;
+  filter_deleted: boolean;
   viewsets?: ProjectUIViewsets | null;
 };
 
@@ -320,11 +323,20 @@ RecordsBrowseTable.defaultProps = {
 };
 
 export function RecordsSearchTable(props: RecordsSearchTableProps) {
-  const {project_id, maxRows, query} = props;
+  const {project_id, maxRows, query, filter_deleted} = props;
 
   const rows = useEventedPromise(
-    async (project_id: ProjectID, query: string) =>
-      Object.values(await getAllRecordsWithRegex(project_id, query)),
+    async (project_id: ProjectID, query: string) => {
+      if (DEBUG_APP) {
+        console.log('RecordsSearchTable updating', project_id);
+      }
+      const metadata = await getRecordsWithRegex(
+        project_id,
+        query,
+        filter_deleted
+      );
+      return metadata;
+    },
     listenDataDB.bind(null, project_id, {since: 'now', live: true}),
     false,
     [project_id, query],
@@ -345,6 +357,7 @@ export function RecordsSearchTable(props: RecordsSearchTableProps) {
     />
   );
 }
-RecordsBrowseTable.defaultProps = {
+RecordsSearchTable.defaultProps = {
   maxRows: null,
+  filter_deleted: true,
 };

--- a/src/users.ts
+++ b/src/users.ts
@@ -34,7 +34,7 @@ import {
   TokenInfo,
   TokenContents,
 } from './datamodel/core';
-import {AuthInfo} from './datamodel/database';
+import {AuthInfo, LOCALLY_CREATED_PROJECT_PREFIX} from './datamodel/database';
 
 interface SplitCouchDBRole {
   project_id: ProjectID;
@@ -250,6 +250,9 @@ export async function shouldDisplayProject(
   full_proj_id: ProjectID
 ): Promise<boolean> {
   const split_id = split_full_project_id(full_proj_id);
+  if (split_id.listing_id === LOCALLY_CREATED_PROJECT_PREFIX) {
+    return true;
+  }
   const is_admin = await isClusterAdmin(split_id.listing_id);
   if (is_admin) {
     return true;

--- a/src/users.ts
+++ b/src/users.ts
@@ -15,19 +15,31 @@
  *
  * Filename: users.ts
  * Description:
- *   TODO
+ *   This contains the user/visibility control subsystem, and management/storage
+ *   of access tokens. This does not do access control (as that must be handled
+ *   by couchdb).but instead tries to avoid exposing information to keep users
+ *   on the happy path of not seeing access denied, or at least in ways the GUI
+ *   can meaningfully handle.
  */
 import {jwtVerify, importSPKI} from 'jose';
 import type {KeyLike} from 'jose';
 
+import {CLUSTER_ADMIN_GROUP_NAME} from './buildconfig';
 import {active_db, directory_db, local_auth_db} from './sync/databases';
 import {
+  ClusterProjectRoles,
   ProjectID,
+  ProjectRole,
   split_full_project_id,
   TokenInfo,
   TokenContents,
 } from './datamodel/core';
 import {AuthInfo} from './datamodel/database';
+
+interface SplitCouchDBRole {
+  project_id: ProjectID;
+  project_role: ProjectRole;
+}
 
 export async function getFriendlyUserName(
   project_id: ProjectID
@@ -180,4 +192,76 @@ export async function parseToken(
     roles: roles,
     name: name,
   };
+}
+
+export async function getUserProjectRolesForCluster(
+  cluster_id: string
+): Promise<ClusterProjectRoles | undefined> {
+  const token_contents = await getTokenContentsForCluster(cluster_id);
+  if (token_contents === undefined) {
+    return undefined;
+  }
+
+  const couch_roles = token_contents.roles;
+  const cluster_project_roles: ClusterProjectRoles = {};
+
+  for (const couch_role of couch_roles) {
+    const split_role = splitCouchDBRole(couch_role);
+    if (split_role === undefined) {
+      continue;
+    }
+    if (cluster_project_roles[split_role.project_id] === undefined) {
+      cluster_project_roles[split_role.project_id] = [];
+    }
+    cluster_project_roles[split_role.project_id].push(split_role.project_role);
+  }
+  return cluster_project_roles;
+}
+
+function splitCouchDBRole(couch_role: string): SplitCouchDBRole | undefined {
+  const split_role = couch_role.split('||');
+  if (
+    split_role.length !== 2 ||
+    split_role[0].trim() === '' ||
+    split_role[1].trim() === ''
+  ) {
+    // This is likely a role like admin that couchdb handles, or at least is not
+    // for access control within a project, so ignore it
+    return undefined;
+  }
+  const cleaned_project_id = split_role[0].replace('\\|\\|', '||');
+  return {
+    project_id: cleaned_project_id,
+    project_role: split_role[1],
+  };
+}
+
+export async function isClusterAdmin(cluster_id: string): Promise<boolean> {
+  const token_contents = await getTokenContentsForCluster(cluster_id);
+  if (token_contents === undefined) {
+    return false;
+  }
+
+  const couch_roles = token_contents.roles;
+  return couch_roles.includes(CLUSTER_ADMIN_GROUP_NAME);
+}
+
+export async function shouldDisplayProject(
+  full_proj_id: ProjectID
+): Promise<boolean> {
+  const split_id = split_full_project_id(full_proj_id);
+  const is_admin = await isClusterAdmin(split_id.listing_id);
+  if (is_admin) {
+    return true;
+  }
+  const roles = await getUserProjectRolesForCluster(split_id.listing_id);
+  if (roles === undefined) {
+    return false;
+  }
+  for (const role in roles) {
+    if (role === split_id.project_id) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
This will control the visibility of projects and records, there will need to be some (temporary) adjustments to the conductor to set up the couchdb roles, otherwise you won't see anything but your local projects (this will be draft until those are in the conductor).