### PR TITLE
Expose AVP IDs and metadata within merging helpers

### DIFF
--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -60,7 +60,7 @@ export function generateFAIMSRevisionID(): RevisionID {
   return 'frev-' + uuidv4();
 }
 
-function generateFAIMSAttributeValuePairID(): AttributeValuePairID {
+export function generateFAIMSAttributeValuePairID(): AttributeValuePairID {
   return 'avp-' + uuidv4();
 }
 

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -23,6 +23,7 @@ import {
   ProjectID,
   RecordID,
   RevisionID,
+  AttributeValuePairID,
   ListingID,
   FAIMSTypeName,
   Annotations,
@@ -88,6 +89,26 @@ export interface Record {
   */
   created?: Date;
   created_by?: string;
+}
+
+export interface FieldMergeInformation {
+  avp_id: AttributeValuePairID;
+  data: any;
+  type: FAIMSTypeName;
+  annotations: Annotations;
+  created: Date;
+  created_by: string;
+}
+
+export interface RecordMergeInformation {
+  project_id: ProjectID;
+  record_id: RecordID;
+  revision_id: RevisionID;
+  type: FAIMSTypeName;
+  updated: Date;
+  updated_by: string;
+  fields: {[field_name: string]: FieldMergeInformation};
+  deleted: boolean;
 }
 
 export type RecordList = {

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -117,8 +117,9 @@ export interface UserMergeResult {
   parents: RevisionID[];
   updated: Date;
   updated_by: string;
-  field_choices: {[field_name: string]: AttributeValuePairID | null};
   type: FAIMSTypeName;
+  field_choices: {[field_name: string]: AttributeValuePairID | null};
+  field_types: {[field_name: string]: FAIMSTypeName};
 }
 
 export type RecordList = {

--- a/src/datamodel/ui.ts
+++ b/src/datamodel/ui.ts
@@ -111,6 +111,16 @@ export interface RecordMergeInformation {
   deleted: boolean;
 }
 
+export interface UserMergeResult {
+  project_id: ProjectID;
+  record_id: RecordID;
+  parents: RevisionID[];
+  updated: Date;
+  updated_by: string;
+  field_choices: {[field_name: string]: AttributeValuePairID | null};
+  type: FAIMSTypeName;
+}
+
 export type RecordList = {
   [key: string]: Record;
 };

--- a/src/gui/pages/project-list.tsx
+++ b/src/gui/pages/project-list.tsx
@@ -24,7 +24,6 @@ import {Container, Grid} from '@mui/material';
 import Breadcrumbs from '../components/ui/breadcrumbs';
 import ProjectCard from '../components/project/card';
 import * as ROUTES from '../../constants/routes';
-// import {store} from '../../store';
 import {getProjectList, listenProjectList} from '../../databaseAccess';
 import {CircularProgress} from '@mui/material';
 import {useEventedPromise} from '../pouchHook';
@@ -73,7 +72,6 @@ type ProjectProps = {
 
 export default function ProjectList(props: ProjectProps) {
   const classes = useStyles();
-  // const globalState = useContext(store);
   const pouchProjectList = useEventedPromise(
     getProjectList,
     listenProjectList,


### PR DESCRIPTION
This allows comparing with the AVP ID, rather than the data itself
(which is more difficult to do on the fly).