### PR TITLE
Tell serve to rewrite urls and not use clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postintegration": "npm run lint",
     "eject": "react-scripts eject",
     "preserve": "npm run build",
-    "serve": "npx serve build",
+    "serve": "npx serve --single --no-clipboard build",
     "prewebapp-build": "npm run build",
     "webapp-build": "cap copy",
     "app-update": "cap update",


### PR DESCRIPTION
This means that serve behaves like the old `npx cap serve`, by rewriting
urls to the app when needed, and not copying the url to the clipboard.

This is needed for the testing with
https://github.com/nolanlawson/fuite.