### PR TITLE
Avoid using bind with evented hook

### DIFF
--- a/src/gui/components/metadataRenderer.tsx
+++ b/src/gui/components/metadataRenderer.tsx
@@ -24,7 +24,7 @@ import {CircularProgress, Chip} from '@mui/material';
 import {getProjectMetadata} from '../../projectMetadata';
 import {ProjectID} from '../../datamodel/core';
 import {listenProjectDB} from '../../sync';
-import {useEventedPromise} from '../pouchHook';
+import {useEventedPromise, constantArgsSplit} from '../pouchHook';
 import {DEBUG_APP} from '../../buildconfig';
 
 type MetadataProps = {
@@ -53,7 +53,11 @@ export default function MetadataRenderer(props: MetadataProps) {
         return '';
       }
     },
-    listenProjectDB.bind(null, project_id, {since: 'now', live: true}),
+    constantArgsSplit(
+      listenProjectDB,
+      [project_id, {since: 'now', live: true}],
+      [project_id, metadata_key]
+    ),
     true,
     [project_id, metadata_key],
     project_id,

--- a/src/gui/components/project/cardHeaderAction.tsx
+++ b/src/gui/components/project/cardHeaderAction.tsx
@@ -18,7 +18,7 @@ import * as ROUTES from '../../../constants/routes';
 import {ProjectInformation} from '../../../datamodel/ui';
 import {getUiSpecForProject} from '../../../uiSpecification';
 import {listenProjectDB} from '../../../sync';
-import {useEventedPromise} from '../../pouchHook';
+import {useEventedPromise, constantArgsSplit} from '../../pouchHook';
 
 type ProjectCardActionProps = {
   project: ProjectInformation;
@@ -162,7 +162,11 @@ export default function ProjectCardHeaderAction(props: ProjectCardActionProps) {
 
   const ui_spec = useEventedPromise(
     getUiSpecForProject,
-    listenProjectDB.bind(null, project_id, {since: 'now', live: true}),
+    constantArgsSplit(
+      listenProjectDB,
+      [project_id, {since: 'now', live: true}],
+      [project_id]
+    ),
     true,
     [project_id],
     project_id

--- a/src/gui/components/record/table.tsx
+++ b/src/gui/components/record/table.tsx
@@ -40,7 +40,7 @@ import {
   getMetadataForAllRecords,
   getRecordsWithRegex,
 } from '../../../data_storage/index';
-import {useEventedPromise} from '../../pouchHook';
+import {useEventedPromise, constantArgsSplit} from '../../pouchHook';
 import {listenDataDB} from '../../../sync';
 import {DEBUG_APP} from '../../../buildconfig';
 
@@ -299,7 +299,11 @@ export function RecordsBrowseTable(props: RecordsBrowseTableProps) {
       );
       return metadata;
     },
-    listenDataDB.bind(null, project_id, {since: 'now', live: true}),
+    constantArgsSplit(
+      listenDataDB,
+      [project_id, {since: 'now', live: true}],
+      [project_id]
+    ),
     false,
     [project_id],
     project_id
@@ -338,7 +342,11 @@ export function RecordsSearchTable(props: RecordsSearchTableProps) {
       );
       return metadata;
     },
-    listenDataDB.bind(null, project_id, {since: 'now', live: true}),
+    constantArgsSplit(
+      listenDataDB,
+      [project_id, {since: 'now', live: true}],
+      [project_id, query]
+    ),
     false,
     [project_id, query],
     project_id,

--- a/src/gui/pouchHook.ts
+++ b/src/gui/pouchHook.ts
@@ -152,6 +152,34 @@ export function constantArgsShared<FirstArgs extends unknown[]>(
 }
 
 /**
+ *
+ * @param attacher prototype of a common listen function that takes a set of A
+ *     arguments, then the OK & error callbacks. See databaseAccess.tsx for
+ *     examples.
+ * @param attach_args Arguments to pass as the first arguments to attacher but
+ *     NOT the callback.
+ * @param trigger_args Arguments to pass as the first arguments to the
+ *     trigger_callback, but NOT the attacher.
+ * @returns
+ */
+export function constantArgsSplit<
+  AttachArgs extends unknown[],
+  TrigArgs extends unknown[]
+>(
+  attacher: (
+    ...args: [...AttachArgs, () => void | (() => void), (err: {}) => void]
+  ) => () => void,
+  attach_args: AttachArgs,
+  trigger_args: TrigArgs
+): (
+  trigger_callback: (...args: TrigArgs) => void,
+  error_callback: (error: {}) => void
+) => void | (() => void) {
+  return (trig, err) =>
+    attacher(...attach_args, () => trig(...trigger_args), err);
+}
+
+/**
  * React hook abtracting the use of an EventEmitter combined with a Promise
  *
  * Allows you to wait for events to occur, then when they do occur, further


### PR DESCRIPTION
It looks like the hook with bind may be leaking memory, use a new
wrapper to avoid needing bind. Hopefully this change appears in fuite.

Don't merge until this has been tested in fuite.