### PR TITLE
Catch and log automerge errors

### DIFF
--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -239,7 +239,11 @@ function start_listening_for_changes(proj_id: ProjectID) {
       const pdoc = doc.doc;
 
       if (pdoc !== undefined && isRecord(pdoc)) {
-        await mergeHeads(proj_id, doc.id);
+        try {
+          await mergeHeads(proj_id, doc.id);
+        } catch (err) {
+          console.error('Automerge errored', err);
+        }
       }
     }
   });


### PR DESCRIPTION
It appears sometimes we're too quick with the automerger so we don't
always have all the required information on hand. Catch and log the
errors for now, to see if we can pick up any patterns that could help
with pre-checks.