### PR TITLE
Save draft when form unmounted

### DIFF
--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -334,7 +334,8 @@ class RecordForm extends React.Component<
     }
   }
 
-  componentWillUnmount() {
+  async componentWillUnmount() {
+    await this.draftState.forceSave();
     this._isMounted = false;
     for (const timeout_id of this.timeouts) {
       clearTimeout(

--- a/src/sync/draft-state.ts
+++ b/src/sync/draft-state.ts
@@ -514,6 +514,17 @@ class RecordDraftState {
   }
 
   /**
+   * Force pushes the currently touched values into the draft DB, needed when
+   * the user leaves the page.
+   *
+   * This is awaitable as a normal async function
+   */
+  async forceSave(): Promise<void> {
+    this.is_saving = false; // don't skip saving if we're still saving
+    await this._saveData();
+  }
+
+  /**
    * Called by setInitialValues, this function retrieves any existing
    * data from the draft storage for this current record/revision
    */


### PR DESCRIPTION
This should mean whenever the user moves away from the "page", a draft
is saved with the latest data in the form.

Closes FAIMS3-499.