### PR TITLE
Add a button to dump the contents of all pouchdbs

### DIFF
--- a/src/gui/pages/about-build.tsx
+++ b/src/gui/pages/about-build.tsx
@@ -23,6 +23,8 @@ import {Box, Container} from '@mui/material';
 import Button from '@mui/material/Button';
 import * as ROUTES from '../../constants/routes';
 import {unregister as unregisterServiceWorker} from '../../serviceWorkerRegistration';
+import {downloadBlob} from '../../utils';
+import {getFullDBSystemDump} from '../../sync/data-dump';
 import {
   DIRECTORY_PROTOCOL,
   DIRECTORY_HOST,
@@ -113,6 +115,17 @@ export default function AboutBuild() {
           Open MiniFauxton
         </Button>
       )}
+      <Button
+        variant="outlined"
+        color={'primary'}
+        onClick={async () => {
+          const b = await getFullDBSystemDump();
+          downloadBlob(b, 'faims3-dump.json');
+        }}
+        style={{marginRight: '10px'}}
+      >
+        Download local database contents
+      </Button>
     </Container>
   );
 }

--- a/src/sync/data-dump.ts
+++ b/src/sync/data-dump.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: src/sync/data-dump.ts
+ * Description:
+ *   Wrapper around local databases to preform a device-level dump.
+ */
+import PouchDB from 'pouchdb';
+
+import {draft_db} from './draft-storage';
+import {
+  directory_db,
+  active_db,
+  local_auth_db,
+  local_state_db,
+  projects_dbs,
+  metadata_dbs,
+  data_dbs,
+} from './databases';
+
+interface DumpObject {
+  [name: string]: unknown;
+}
+
+async function dumpDatabase(db: PouchDB.Database<any>): Promise<unknown> {
+  return await db.allDocs({
+    attachments: true, // We want base64 strings so we can get JSON
+    conflicts: true, // We want to see conflict information
+    include_docs: true, // We want the actual data
+    update_seq: true,
+    // This may help with debugging and with tracking multiple dumps
+  });
+}
+
+export async function getFullDBSystemDump(): Promise<Blob> {
+  const dump: DumpObject = {};
+  dump['directory'] = await dumpDatabase(directory_db.local);
+  dump['active'] = await dumpDatabase(active_db);
+  dump['local_state'] = await dumpDatabase(local_state_db);
+  dump['local_auth'] = await dumpDatabase(local_auth_db);
+  dump['draft'] = await dumpDatabase(draft_db);
+
+  for (const [name, db] of Object.entries(projects_dbs)) {
+    dump['proj' + name] = await dumpDatabase(db.local);
+  }
+
+  for (const [name, db] of Object.entries(metadata_dbs)) {
+    dump['meta' + name] = await dumpDatabase(db.local);
+  }
+
+  for (const [name, db] of Object.entries(data_dbs)) {
+    dump['data' + name] = await dumpDatabase(db.local);
+  }
+
+  return new Blob([JSON.stringify(dump)], {type: 'application/json'});
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: utils.ts
+ * Description:
+ *   Contains utility functions which lack a better location.
+ */
+
+/// Downloads a blob as a file onto a user's device
+export function downloadBlob(b: Blob, filename: string) {
+  const u = URL.createObjectURL(b);
+  const a = document.createElement('a');
+  a.href = u;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(u);
+}


### PR DESCRIPTION
This does not try to do things with visibilities, it simply dumps all
the databases we know about using allDocs.