### PR TITLE
Add missing check for annotation change

### DIFF
--- a/.faimsWords.txt
+++ b/.faimsWords.txt
@@ -492,3 +492,8 @@ obsid
 revids
 revid
 datadb
+avps
+docid
+recs
+anno
+eqfunc

--- a/.faimsWords.txt
+++ b/.faimsWords.txt
@@ -487,3 +487,8 @@ keychain
 browserstack
 ipas
 psmip
+frev
+obsid
+revids
+revid
+datadb

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -410,10 +410,14 @@ async function addNewAttributeValuePairs(
   const docs_to_dump: Array<AttributeValuePair | FAIMSAttachment> = [];
   for (const [field_name, field_value] of Object.entries(record.data)) {
     const stored_data = data.data[field_name];
+    const stored_anno = data.annotations[field_name];
     const eqfunc = getEqualityFunctionForType(record.field_types[field_name]);
     const has_data_changed =
       stored_data === undefined || !(await eqfunc(stored_data, field_value));
-    if (has_data_changed) {
+    const has_anno_changed =
+      stored_anno === undefined ||
+      !(await eqfunc(stored_anno, record.annotations[field_name]));
+    if (has_data_changed || has_anno_changed) {
       const new_avp_id = generateFAIMSAttributeValuePairID();
       const new_avp = {
         _id: new_avp_id,

--- a/src/data_storage/merging.test.ts
+++ b/src/data_storage/merging.test.ts
@@ -93,7 +93,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -141,7 +143,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -157,7 +161,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -173,7 +179,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -189,7 +197,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -237,7 +247,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -253,7 +265,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -269,7 +283,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -285,7 +301,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -342,7 +360,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -358,7 +378,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -374,7 +396,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -390,7 +414,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -437,7 +463,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -453,7 +481,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -469,7 +499,9 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -485,7 +517,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -535,7 +570,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -554,7 +592,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -573,7 +614,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -623,7 +667,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -642,7 +689,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -661,7 +711,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -680,7 +733,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -731,7 +787,11 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+        avp3: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -751,7 +811,11 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+        avp3: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -771,7 +835,11 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+        avp3: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -791,7 +859,11 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+        avp3: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -811,7 +883,11 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+        avp3: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -983,7 +1059,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -1021,7 +1100,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -1073,7 +1155,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -1092,7 +1177,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 
@@ -1111,7 +1199,10 @@ describe('test basic automerge', () => {
       updated_by: userid,
       created: time,
       updated: time,
-      annotations: {},
+      annotations: {
+        avp1: 1,
+        avp2: 1,
+      },
       field_types: {field_name: fulltype},
     };
 

--- a/src/sync/draft-state.ts
+++ b/src/sync/draft-state.ts
@@ -266,6 +266,11 @@ class RecordDraftState {
         this.data.fields = values;
       }
 
+      if (this.data.annotations === null) {
+        // 1st call to renderHook establishes the 'default' initial annotations
+        this.data.annotations = annotations;
+      }
+
       // Don't compare things that are in the staging area
       // but are completley absent from the form
       // as those components are just not in the current view
@@ -289,6 +294,11 @@ class RecordDraftState {
 
       if (this.touched_fields.size === 0) {
         return;
+      }
+      if (DEBUG_APP) {
+        console.debug('fields touched', this.touched_fields);
+        console.debug('data', this.data.fields, values);
+        console.debug('anno', this.data.annotations, annotations);
       }
 
       // If anything changed, we create the draft:


### PR DESCRIPTION
Previously we were not checking if the annotation changed value, so if
the annotation changed value but the data did not, that was not
identified as a change. This adds this check.