### PR TITLE
Do an initial deep copy of the annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "react-router-dom": "5.2.0",
     "react-share": "4.4.0",
     "readline": "1.3.0",
-    "serve": "^13.0.2",
     "uuid": "8.3.2",
     "web-vitals": "2.1.4",
     "workbox-core": "6.5.3",
@@ -123,6 +122,7 @@
     "jest": "26.6.0",
     "jest-fast-check": "1.0.2",
     "react-scripts": "4.0.3",
+    "serve": "^14.0.1",
     "typescript": "4.7.4"
   }
 }

--- a/src/sync/draft-state.ts
+++ b/src/sync/draft-state.ts
@@ -263,18 +263,29 @@ class RecordDraftState {
 
       if (this.data.fields === null) {
         // 1st call to renderHook establishes the 'default' initial data
+        console.debug(
+          'Setting initial data for draft',
+          stable_stringify(values)
+        );
         this.data.fields = values;
       }
 
       if (this.data.annotations === null) {
         // 1st call to renderHook establishes the 'default' initial annotations
-        this.data.annotations = annotations;
+        console.debug(
+          'Setting initial annotations for draft',
+          stable_stringify(annotations)
+        );
+        // The JSON step here is to create a deep copy, to avoid both sets of
+        // data being modified at the same time.
+        this.data.annotations = JSON.parse(JSON.stringify(annotations));
       }
 
       // Don't compare things that are in the staging area
-      // but are completley absent from the form
+      // but are completely absent from the form
       // as those components are just not in the current view
       // Only compare fields in the current view:
+
       for (const field in values) {
         // Formik & Pouch should give us comparable JSON objects.
         // As long as it differs at the top level, we say it's touched
@@ -282,13 +293,34 @@ class RecordDraftState {
         // So we use JSON stable stringify to compare
         //
         // undefined in gives undefined out. Which is perfectly fine
+        if (DEBUG_APP) {
+          console.debug('looking at', field);
+          console.debug(
+            'data',
+            field,
+            this.data.fields?.[field],
+            values?.[field]
+          );
+          console.debug(
+            'anno',
+            field,
+            this.data.annotations?.[field],
+            annotations?.[field]
+          );
+        }
         if (
           stable_stringify(this.data.fields?.[field]) !==
             stable_stringify(values?.[field]) ||
           stable_stringify(this.data.annotations?.[field]) !==
             stable_stringify(annotations?.[field])
         ) {
+          if (DEBUG_APP) {
+            console.debug('field touched', field);
+          }
           this.touched_fields.add(field);
+        }
+        if (DEBUG_APP) {
+          console.debug('finished looking at', field);
         }
       }
 

--- a/src/sync/draft-storage.ts
+++ b/src/sync/draft-storage.ts
@@ -202,11 +202,14 @@ export async function deleteStagedData(
       ? revision_cache
       : (await draft_db.get(draft_id))._rev;
 
-  await (draft_db as PouchDB.Database<{}>).put({
-    _id: draft_id,
-    _rev: revision,
-    _deleted: true,
-  });
+  await (draft_db as PouchDB.Database<{}>).put(
+    {
+      _id: draft_id,
+      _rev: revision,
+      _deleted: true,
+    },
+    {force: true}
+  );
 }
 
 /**


### PR DESCRIPTION
It appears the way the annotations were passed around was via the same
identical object, rather than being passed a copy. Always do a deep copy
for the annotations, to ensure that changes are not implicitly
propagated to the draft.