### PR TITLE
Fix origin handling in native hooks

### DIFF
--- a/src/native_hooks.ts
+++ b/src/native_hooks.ts
@@ -48,9 +48,11 @@ export function addNativeHooks() {
 }
 
 async function getListingForConductorUrl(conductor_url: string) {
+  const origin = new URL(conductor_url).origin;
   const listings = await getSyncableListingsInfo();
   for (const l of listings) {
-    if (l.conductor_url === conductor_url) {
+    const possible_origin = new URL(l.conductor_url).origin;
+    if (possible_origin === origin) {
       return l.id;
     }
   }


### PR DESCRIPTION
This should now allow iOS logins to work. This should also work as an alternative for android, and open the native app where possible.