### PR TITLE
Add sharing of data dump

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,8 +10,13 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-app-launcher')
+    implementation project(':capacitor-browser')
     implementation project(':capacitor-camera')
+    implementation project(':capacitor-device')
+    implementation project(':capacitor-filesystem')
     implementation project(':capacitor-geolocation')
+    implementation project(':capacitor-share')
 
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="${applicationId}">
+    package="org.fedarch.faims3">
 
     <application
         android:allowBackup="true"
@@ -13,7 +13,7 @@
         <activity
             android:exported="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
-            android:name="${applicationId}.MainActivity"
+            android:name="org.fedarch.faims3.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask">

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.fedarch.faims3">
+    package="${applicationId}">
 
     <application
         android:allowBackup="true"
@@ -13,7 +13,7 @@
         <activity
             android:exported="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
-            android:name="org.fedarch.faims3.MainActivity"
+            android:name="${applicationId}.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask">

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -4,11 +4,31 @@
 		"classpath": "com.capacitorjs.plugins.app.AppPlugin"
 	},
 	{
+		"pkg": "@capacitor/app-launcher",
+		"classpath": "com.capacitorjs.plugins.applauncher.AppLauncherPlugin"
+	},
+	{
+		"pkg": "@capacitor/browser",
+		"classpath": "com.capacitorjs.plugins.browser.BrowserPlugin"
+	},
+	{
 		"pkg": "@capacitor/camera",
 		"classpath": "com.capacitorjs.plugins.camera.CameraPlugin"
 	},
 	{
+		"pkg": "@capacitor/device",
+		"classpath": "com.capacitorjs.plugins.device.DevicePlugin"
+	},
+	{
+		"pkg": "@capacitor/filesystem",
+		"classpath": "com.capacitorjs.plugins.filesystem.FilesystemPlugin"
+	},
+	{
 		"pkg": "@capacitor/geolocation",
 		"classpath": "com.capacitorjs.plugins.geolocation.GeolocationPlugin"
+	},
+	{
+		"pkg": "@capacitor/share",
+		"classpath": "com.capacitorjs.plugins.share.SharePlugin"
 	}
 ]

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="my_images" path="." />
-    <cache-path name="my_cache_images" path="." />
+    <external-path name="my_images" path="./" />
+    <cache-path name="my_cache_images" path="cache/" />
 </paths>

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,8 +5,23 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-app-launcher'
+project(':capacitor-app-launcher').projectDir = new File('../node_modules/@capacitor/app-launcher/android')
+
+include ':capacitor-browser'
+project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
+
 include ':capacitor-camera'
 project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')
 
+include ':capacitor-device'
+project(':capacitor-device').projectDir = new File('../node_modules/@capacitor/device/android')
+
+include ':capacitor-filesystem'
+project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
+
 include ':capacitor-geolocation'
 project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')
+
+include ':capacitor-share'
+project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -76,7 +76,7 @@ platform :android do
            }
            )
     upload_to_play_store(track: FIP_CLOSED_LANE,
-                         release_status: 'draft',
+                         release_status: 'completed',
                          skip_upload_metadata: true,
                          skip_upload_images: true,
                          skip_upload_screenshots: true

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -12,8 +12,13 @@ def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
+  pod 'CapacitorAppLauncher', :path => '../../node_modules/@capacitor/app-launcher'
+  pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorCamera', :path => '../../node_modules/@capacitor/camera'
+  pod 'CapacitorDevice', :path => '../../node_modules/@capacitor/device'
+  pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'
+  pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
   pod 'CordovaPlugins', :path => '../capacitor-cordova-ios-plugins'
 end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@capacitor/filesystem": "4.1.0",
         "@capacitor/geolocation": "4.0.1",
         "@capacitor/ios": "4.1.0",
-        "@capacitor/share": "4.0.1",
+        "@capacitor/share": "^4.0.1",
         "@demvsystems/yup-ast": "1.2.2",
         "@emotion/react": "11.9.3",
         "@emotion/styled": "11.9.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@capacitor/filesystem": "4.1.0",
     "@capacitor/geolocation": "4.0.1",
     "@capacitor/ios": "4.1.0",
-    "@capacitor/share": "4.0.1",
+    "@capacitor/share": "^4.0.1",
     "@demvsystems/yup-ast": "1.2.2",
     "@emotion/react": "11.9.3",
     "@emotion/styled": "11.9.3",

--- a/src/gui/pages/about-build.tsx
+++ b/src/gui/pages/about-build.tsx
@@ -21,10 +21,14 @@
 import React from 'react';
 import {Box, Container} from '@mui/material';
 import Button from '@mui/material/Button';
+
 import * as ROUTES from '../../constants/routes';
 import {unregister as unregisterServiceWorker} from '../../serviceWorkerRegistration';
-import {downloadBlob} from '../../utils';
-import {getFullDBSystemDump} from '../../sync/data-dump';
+import {downloadBlob, shareStringAsFileOnApp} from '../../utils/downloadShare';
+import {
+  getFullDBSystemDump,
+  getFullDBSystemDumpAsBlob,
+} from '../../sync/data-dump';
 import {
   DIRECTORY_PROTOCOL,
   DIRECTORY_HOST,
@@ -119,12 +123,28 @@ export default function AboutBuild() {
         variant="outlined"
         color={'primary'}
         onClick={async () => {
-          const b = await getFullDBSystemDump();
+          const b = await getFullDBSystemDumpAsBlob();
           downloadBlob(b, 'faims3-dump.json');
         }}
         style={{marginRight: '10px'}}
       >
-        Download local database contents
+        Download local database contents (browsers only)
+      </Button>
+      <Button
+        variant="outlined"
+        color={'primary'}
+        onClick={async () => {
+          const s = await getFullDBSystemDump();
+          await shareStringAsFileOnApp(
+            s,
+            'FAIMS Database Dump',
+            'Share all the FAIMS data on your device',
+            'faims3-dump.json'
+          );
+        }}
+        style={{marginRight: '10px'}}
+      >
+        Share local database contents (apps and some browsers)
       </Button>
     </Container>
   );

--- a/src/sync/data-dump.ts
+++ b/src/sync/data-dump.ts
@@ -44,7 +44,7 @@ async function dumpDatabase(db: PouchDB.Database<any>): Promise<unknown> {
   });
 }
 
-export async function getFullDBSystemDump(): Promise<Blob> {
+export async function getFullDBSystemDump(): Promise<string> {
   const dump: DumpObject = {};
   dump['directory'] = await dumpDatabase(directory_db.local);
   dump['active'] = await dumpDatabase(active_db);
@@ -64,5 +64,10 @@ export async function getFullDBSystemDump(): Promise<Blob> {
     dump['data' + name] = await dumpDatabase(db.local);
   }
 
-  return new Blob([JSON.stringify(dump)], {type: 'application/json'});
+  return JSON.stringify(dump);
+}
+
+export async function getFullDBSystemDumpAsBlob(): Promise<Blob> {
+  const dump = await getFullDBSystemDump();
+  return new Blob([dump], {type: 'application/json'});
 }

--- a/src/utils/downloadShare.ts
+++ b/src/utils/downloadShare.ts
@@ -48,7 +48,7 @@ export async function shareStringAsFileOnApp(
   ).uri;
   await Share.share({
     title: title,
-    text: s,
+    text: dialogTitle,
     url: url,
     dialogTitle: dialogTitle,
   });

--- a/src/utils/downloadShare.ts
+++ b/src/utils/downloadShare.ts
@@ -15,8 +15,10 @@
  *
  * Filename: utils.ts
  * Description:
- *   Contains utility functions which lack a better location.
+ *   Contains utility functions related to downloading and sharing
  */
+import {Filesystem, Directory, Encoding} from '@capacitor/filesystem';
+import {Share} from '@capacitor/share';
 
 /// Downloads a blob as a file onto a user's device
 export function downloadBlob(b: Blob, filename: string) {
@@ -28,4 +30,26 @@ export function downloadBlob(b: Blob, filename: string) {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(u);
+}
+
+export async function shareStringAsFileOnApp(
+  s: string,
+  title: string,
+  dialogTitle: string,
+  filename: string
+) {
+  const url = (
+    await Filesystem.writeFile({
+      path: filename,
+      data: s,
+      directory: Directory.Cache,
+      encoding: Encoding.UTF8,
+    })
+  ).uri;
+  await Share.share({
+    title: title,
+    text: s,
+    url: url,
+    dialogTitle: dialogTitle,
+  });
 }


### PR DESCRIPTION
This seems to be a better supported way to get the data off the device than trying to use downloads (which seem to be a problem on Android, and for which Capacitor currently lacks support for).