### PR TITLE
Be explicit about when validation is called

### DIFF
--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -816,6 +816,8 @@ class RecordForm extends React.Component<
               initialValues={initialValues}
               validationSchema={validationSchema}
               validateOnMount={true}
+              validateOnChange={false}
+              validateOnBlur={true}
               onSubmit={values => {
                 this.setTimeout(() => {
                   // console.log('is saving submitting called');


### PR DESCRIPTION
Validation is run on `onBlur` and `onChange` by default by formik. Dropping `onChange` reduces the lag as we're not checking each keypress.