### PR TITLE
Add an addition timeout to ensure refresh works

### DIFF
--- a/src/store.tsx
+++ b/src/store.tsx
@@ -168,10 +168,14 @@ const StateProvider = (props: any) => {
   useEffect(() => {
     initialize()
       .then(() =>
-        dispatch({
-          type: ActionType.INITIALIZED,
-          payload: undefined,
-        })
+        setTimeout(
+          () =>
+            dispatch({
+              type: ActionType.INITIALIZED,
+              payload: undefined,
+            }),
+          10000
+        )
       )
       .catch(err => {
         console.log('Could not initialize: ', err);


### PR DESCRIPTION
For reasons that still remain unclear, sometime the pouchdb code signals to react that it is ready, but it remains still in the setup phase. This adds an additional 10 second timeout once the pouchdb code signals it is ready, just to avoid this issue (which only seems to occur on refreshes). This isn't a true fix, but should be a good-enough workaround.

See FAIMS3-587 and FAIMS3-496 for details of the issue.