### PR TITLE
Switch to saving data in External path

### DIFF
--- a/src/utils/downloadShare.ts
+++ b/src/utils/downloadShare.ts
@@ -43,7 +43,7 @@ export async function shareStringAsFileOnApp(
     await Filesystem.writeFile({
       path: filename,
       data: s,
-      directory: Directory.Cache,
+      directory: Directory.External,
       encoding: Encoding.UTF8,
       recursive: true,
     })


### PR DESCRIPTION
It seems there's an issue sharing data in the Cache directory, try the External one.

See FAIMS3-547.