### PR TITLE
Log what is being passed to RecordTable

### DIFF
--- a/src/gui/components/record/table.tsx
+++ b/src/gui/components/record/table.tsx
@@ -57,6 +57,7 @@ function RecordsTable(props: RecordsTableProps) {
   const theme = useTheme();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
   const defaultMaxRowsMobile = 10;
+  console.error('RecordsTable props', rows, loading);
   // const newrows:any=[];
   // rows.map((r:any,index:number)=>
   //   props.viewsets !== null &&


### PR DESCRIPTION
It's possible the props are behaving in such as way as to cause the table to rerender.