### PR TITLE
Allow autoincrement stop values to be decreased

### DIFF
--- a/src/datamodel/autoincrement.ts
+++ b/src/datamodel/autoincrement.ts
@@ -150,8 +150,11 @@ export async function set_local_autoincrement_ranges_for_field(
           throw Error('Currently used range removed');
         } else if (new_using_range.start !== range.start) {
           throw Error('Currently used range start changed');
-        } else if (new_using_range.stop < range.stop) {
-          throw Error('Currently used range stop reduced');
+        } else if (
+          state.last_used_id !== null &&
+          new_using_range.stop <= state.last_used_id
+        ) {
+          throw Error('Currently used range stop less than last used ID.');
         }
       }
     }

--- a/src/gui/components/autoincrement/edit-form.tsx
+++ b/src/gui/components/autoincrement/edit-form.tsx
@@ -33,6 +33,8 @@ import AddIcon from '@mui/icons-material/Add';
 import {TextField} from 'formik-mui';
 import * as yup from 'yup';
 
+import {ActionType} from '../../../context/actions';
+import {store} from '../../../context/store';
 import {ProjectID} from '../../../datamodel/core';
 import {LocalAutoIncrementRange} from '../../../datamodel/database';
 import {
@@ -120,13 +122,23 @@ export default class BasicAutoIncrementer extends React.Component<
 
   async update_ranges(ranges: LocalAutoIncrementRange[]) {
     const {project_id, form_id, field_id} = this.props;
-    await set_local_autoincrement_ranges_for_field(
-      project_id,
-      form_id,
-      field_id,
-      ranges
-    );
-    this.setState({ranges: ranges});
+    try {
+      await set_local_autoincrement_ranges_for_field(
+        project_id,
+        form_id,
+        field_id,
+        ranges
+      );
+      this.setState({ranges: ranges});
+    } catch (err: any) {
+      this.context.dispatch({
+        type: ActionType.ADD_ALERT,
+        payload: {
+          message: err.toString(),
+          severity: 'error',
+        },
+      });
+    }
   }
 
   render_range(
@@ -256,3 +268,4 @@ export default class BasicAutoIncrementer extends React.Component<
     );
   }
 }
+BasicAutoIncrementer.contextType = store;


### PR DESCRIPTION
Previously if a range was being used, then the stop value could not be decreased. This removes that restriction.

See FAIMS3-643.