### PR TITLE
Get app url parsed on non-Safari browsers

### DIFF
--- a/src/native_hooks.ts
+++ b/src/native_hooks.ts
@@ -89,6 +89,12 @@ function parseAndHandleAppUrl(url_s: string) {
     const token = JSON.parse(decodeURIComponent(urlenc_token));
     console.debug('Parsed url token', token);
     processUrlPassedToken(token as TokenURLObject);
+  } else if (url.pathname.startsWith('//auth/')) {
+    // Drop //auth/ from pathname
+    const urlenc_token = url.pathname.substring(7);
+    const token = JSON.parse(decodeURIComponent(urlenc_token));
+    console.debug('Parsed url token', token);
+    processUrlPassedToken(token as TokenURLObject);
   } else {
     console.warn('App url not handled', url_s, url);
   }


### PR DESCRIPTION
For some reason, Safari manages to extract the host but Firefox and Chrome do not, add handling of the non-Safari case.

Should provide a workaround for FAIMS3-631.