### PR TITLE
feat: improved ui for sync (add dialog to confirm sync status change …

### DIFF
--- a/src/gui/components/notebook/settings/activation-switch.tsx
+++ b/src/gui/components/notebook/settings/activation-switch.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import {Alert, Box, AlertTitle, Button, FormHelperText} from '@mui/material';
+import {Alert, Box, AlertTitle, Button} from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
 import {ProjectInformation} from '../../../../datamodel/ui';
 import DialogActions from '@mui/material/DialogActions';
-import ToggleOffIcon from '@mui/icons-material/ToggleOff';
 
 import Dialog from '@mui/material/Dialog';
 
@@ -29,11 +28,10 @@ export default function NotebookActivationSwitch(
     <Box my={1}>
       <Button
         onClick={handleOpen}
-        color={'info'}
+        color={'primary'}
         size={'small'}
         variant={'outlined'}
         disableElevation={true}
-        startIcon={<ToggleOffIcon />}
       >
         Activate
       </Button>
@@ -72,7 +70,6 @@ export default function NotebookActivationSwitch(
           )}
         </DialogActions>
       </Dialog>
-      <FormHelperText>Begin syncing notebook to this device.</FormHelperText>
     </Box>
   );
 }

--- a/src/gui/components/notebook/settings/sync_switch.tsx
+++ b/src/gui/components/notebook/settings/sync_switch.tsx
@@ -154,7 +154,7 @@ export default function NotebookSyncSwitch(props: NotebookSyncSwitchProps) {
 
               {isWorking ? (
                 <LoadingButton loading variant="outlined" size={'small'}>
-                  {isSyncing ? 'Stoping' : 'Starting'} sync
+                  {isSyncing ? 'Stopping' : 'Starting'} sync
                 </LoadingButton>
               ) : (
                 <Button

--- a/src/gui/components/workspace/notebooks.tsx
+++ b/src/gui/components/workspace/notebooks.tsx
@@ -20,7 +20,7 @@
 
 import React, {useEffect, useState} from 'react';
 import {useHistory} from 'react-router-dom';
-import {Box, Paper, Typography, Alert} from '@mui/material';
+import {Box, Paper, Typography, Alert, Button, Stack} from '@mui/material';
 import FolderIcon from '@mui/icons-material/Folder';
 
 import {
@@ -39,6 +39,11 @@ import ProjectStatus from '../notebook/settings/status';
 import NotebookSyncSwitch from '../notebook/settings/sync_switch';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {useTheme} from '@mui/material/styles';
+import {grey} from '@mui/material/colors';
+import Tab from '@mui/material/Tab';
+import TabContext from '@mui/lab/TabContext';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
 
 interface sortModel {
   field: string;
@@ -52,6 +57,12 @@ type NoteBookListProps = {
 export default function NoteBooks(props: NoteBookListProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [counter, setCounter] = React.useState(5);
+  const [value, setValue] = React.useState('1');
+
+  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+    setValue(newValue);
+  };
+
   const history = useHistory();
   const theme = useTheme();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
@@ -64,7 +75,11 @@ export default function NoteBooks(props: NoteBookListProps) {
   ).expect();
 
   const handleRowClick: GridEventListener<'rowClick'> = params => {
-    history.push(ROUTES.NOTEBOOK + params.row.project_id);
+    if (params.row.is_activated) {
+      history.push(ROUTES.NOTEBOOK + params.row.project_id);
+    } else {
+      // do nothing
+    }
   };
   const columns: GridColDef[] = not_xs
     ? [
@@ -85,10 +100,14 @@ export default function NoteBooks(props: NoteBookListProps) {
               >
                 <FolderIcon
                   fontSize={'small'}
-                  color={'secondary'}
+                  color={params.row.is_activated ? 'secondary' : 'disabled'}
                   sx={{mr: '3px'}}
                 />
-                <Typography variant={'body2'} fontWeight={'bold'}>
+                <Typography
+                  variant={'body2'}
+                  fontWeight={params.row.is_activated ? 'bold' : 'normal'}
+                  color={params.row.is_activated ? 'black' : grey[800]}
+                >
                   {params.row.name}
                 </Typography>
               </span>
@@ -150,10 +169,14 @@ export default function NoteBooks(props: NoteBookListProps) {
               >
                 <FolderIcon
                   fontSize={'small'}
-                  color={'secondary'}
+                  color={params.row.is_activated ? 'secondary' : 'disabled'}
                   sx={{mr: '3px'}}
                 />
-                <Typography variant={'body2'} fontWeight={'bold'}>
+                <Typography
+                  variant={'body2'}
+                  fontWeight={params.row.is_activated ? 'bold' : 'normal'}
+                  color={params.row.is_activated ? 'black' : grey[800]}
+                >
                   {params.row.name}
                 </Typography>
               </span>
@@ -170,7 +193,7 @@ export default function NoteBooks(props: NoteBookListProps) {
           field: 'last_updated',
           headerName: 'Last Updated',
           type: 'dateTime',
-          minWidth: 80,
+          minWidth: 100,
           flex: 0.3,
           valueGetter: ({value}) => value && new Date(value),
         },
@@ -178,7 +201,7 @@ export default function NoteBooks(props: NoteBookListProps) {
           field: 'actions',
           type: 'actions',
           flex: 0.3,
-          minWidth: 60,
+          minWidth: 80,
           headerName: 'Sync',
           description: 'Toggle syncing this notebook to the server',
           renderCell: (params: GridCellParams) => (
@@ -206,27 +229,123 @@ export default function NoteBooks(props: NoteBookListProps) {
           No notebooks found. Checking again in {counter} seconds.
         </Alert>
       ) : (
-        <Box component={Paper} elevation={0}>
-          <DataGrid
-            key={'notebook_list_datagrid'}
-            rows={pouchProjectList}
-            loading={loading}
-            columns={columns}
-            onRowClick={handleRowClick}
-            autoHeight
-            sx={{cursor: 'pointer'}}
-            getRowId={r => r.project_id}
-            hideFooter={true}
-            getRowHeight={() => 'auto'}
-            initialState={{
-              sorting: {
-                sortModel: [props.sortModel],
-              },
-              pagination: {
-                pageSize: pouchProjectList.length,
-              },
-            }}
-          />
+        <Box component={Paper} elevation={0} p={2}>
+          <Typography variant={'body1'} gutterBottom>
+            You have {pouchProjectList.filter(r => r.is_activated).length}{' '}
+            notebook
+            {pouchProjectList.filter(r => r.is_activated).length > 1
+              ? 's'
+              : ''}{' '}
+            activated on this device. To start syncing a notebook, visit the{' '}
+            <Button
+              variant="text"
+              size={'small'}
+              onClick={() => {
+                setValue('2');
+              }}
+            >
+              Available
+            </Button>{' '}
+            tab and click the activate button.
+          </Typography>
+          <TabContext value={value}>
+            <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
+              <TabList
+                onChange={handleChange}
+                aria-label="lab API tabs example"
+              >
+                <Tab
+                  label={
+                    'Activated (' +
+                    pouchProjectList.filter(r => r.is_activated).length +
+                    ')'
+                  }
+                  value="1"
+                />
+                <Tab
+                  label={
+                    'Available (' +
+                    pouchProjectList.filter(r => !r.is_activated).length +
+                    ')'
+                  }
+                  value="2"
+                />
+              </TabList>
+            </Box>
+            <TabPanel value="1" sx={{px: 0}}>
+              <div style={{display: 'flex', height: '100%'}}>
+                <div style={{flexGrow: 1}}>
+                  <DataGrid
+                    key={'notebook_list_datagrid'}
+                    rows={pouchProjectList.filter(r => r.is_activated)}
+                    loading={loading}
+                    columns={columns}
+                    onRowClick={handleRowClick}
+                    autoHeight
+                    sx={{cursor: 'pointer'}}
+                    getRowId={r => r.project_id}
+                    hideFooter={true}
+                    getRowHeight={() => 'auto'}
+                    initialState={{
+                      sorting: {
+                        sortModel: [props.sortModel],
+                      },
+                      pagination: {
+                        pageSize: pouchProjectList.length,
+                      },
+                    }}
+                    components={{
+                      NoRowsOverlay: () => (
+                        <Stack
+                          height="100%"
+                          alignItems="center"
+                          justifyContent="center"
+                        >
+                          No Notebooks have been activated yet.
+                        </Stack>
+                      ),
+                    }}
+                  />
+                </div>
+              </div>
+            </TabPanel>
+            <TabPanel value="2" sx={{px: 0}}>
+              <div style={{display: 'flex', height: '100%'}}>
+                <div style={{flexGrow: 1}}>
+                  <DataGrid
+                    key={'notebook_list_datagrid'}
+                    rows={pouchProjectList.filter(r => !r.is_activated)}
+                    loading={loading}
+                    columns={columns}
+                    autoHeight
+                    sx={{cursor: 'pointer'}}
+                    getRowId={r => r.project_id}
+                    hideFooter={true}
+                    getRowHeight={() => 'auto'}
+                    initialState={{
+                      sorting: {
+                        sortModel: [props.sortModel],
+                      },
+                      pagination: {
+                        pageSize: pouchProjectList.length,
+                      },
+                    }}
+                    components={{
+                      NoRowsOverlay: () => (
+                        <Stack
+                          height="100%"
+                          alignItems="center"
+                          justifyContent="center"
+                        >
+                          You don't have any unactivated notebooks.
+                        </Stack>
+                      ),
+                    }}
+                  />
+                </div>
+              </div>
+            </TabPanel>
+          </TabContext>
         </Box>
       )}
     </Box>

--- a/src/gui/pages/workspace.tsx
+++ b/src/gui/pages/workspace.tsx
@@ -43,7 +43,7 @@ export default function Workspace() {
           <Typography variant="h6" color="textSecondary">
             My Notebooks
           </Typography>
-          <Notebooks sortModel={{field: 'updated', sort: 'desc'}} />
+          <Notebooks sortModel={{field: 'last_updated', sort: 'desc'}} />
         </Grid>
       </Grid>
     </React.Fragment>


### PR DESCRIPTION
…such that users don't accidentally trigger sync change)

feat: improved ui for notebooks list - workspace sorts by last_updated, and notebooks are split between activated and available (as the activate switch needs to be pressed just once, users will want to quickly find an active notebook).

FAIMS3-632

Signed-off-by: Liz Mannering <elizabeth.mannering@mq.edu.au>