### PR TITLE
Use Uint8Array for comparing blobs

### DIFF
--- a/src/datamodel/typesystem.ts
+++ b/src/datamodel/typesystem.ts
@@ -165,8 +165,8 @@ export async function isEqualFAIMS(a: any, b: any): Promise<boolean> {
       .then((res: [any, any]) => {
         const buf_a = res[0] as ArrayBuffer;
         const buf_b = res[1] as ArrayBuffer;
-        const arr_a = new BigUint64Array(buf_a);
-        const arr_b = new BigUint64Array(buf_b);
+        const arr_a = new Uint8Array(buf_a);
+        const arr_b = new Uint8Array(buf_b);
         console.info('Checking array buffers', arr_a, arr_b);
         return arr_a.every((element, index) => {
           return element === arr_b[index];


### PR DESCRIPTION
It appears BigUint64Array requires that the data be aligned to 8 bytes (rather than accepting less and having 0 values elsewhere). Switch to Uint8Array which should fix this.