### PR TITLE
Allow users to delete fully used ranges

### DIFF
--- a/src/datamodel/autoincrement.ts
+++ b/src/datamodel/autoincrement.ts
@@ -142,9 +142,7 @@ export async function set_local_autoincrement_ranges_for_field(
   } else {
     // We should check that we're not causing problems for existing ranges
     for (const range of state.ranges) {
-      if (range.fully_used && !new_ranges.includes(range)) {
-        throw Error('Fully used range removed');
-      } else if (range.using) {
+      if (range.using) {
         const new_using_range = new_ranges.find(r => r.using);
         if (new_using_range === undefined) {
           throw Error('Currently used range removed');


### PR DESCRIPTION
Once a range is fully used, there's not much need to keep it around expect for keeping users in the loop. Allow users to delete them. This also resolves a issue where having a fully used range prevented the creation of a new range.

Fixes FAIMS3-644.