### PR TITLE
fix: add callback for switching to activate tab once notebook is acti…

### DIFF
--- a/src/gui/components/workspace/notebooks.tsx
+++ b/src/gui/components/workspace/notebooks.tsx
@@ -147,6 +147,7 @@ export default function NoteBooks(props: NoteBookListProps) {
               project={params.row}
               showHelperText={false}
               project_status={params.row.status}
+              handleTabChange={setValue}
             />
           ),
         },
@@ -209,6 +210,7 @@ export default function NoteBooks(props: NoteBookListProps) {
               project={params.row}
               showHelperText={false}
               project_status={params.row.status}
+              handleTabChange={setValue}
             />
           ),
         },

--- a/src/sync/sync-toggle.ts
+++ b/src/sync/sync-toggle.ts
@@ -92,6 +92,9 @@ export async function setSyncingProject(
     await active_db.put(active_doc);
   } catch (err) {
     console.error('Failed to update active_db with sync state', err);
+    throw Error(
+      `Could not change sync for this notebook (${active_id}). Contact Support.`
+    );
   }
 
   const created = createdProjects[active_id];


### PR DESCRIPTION
…vated.

fix: simplify activation interface to react from pouch. Remove react isActivated in favour of project.is_activated. fix: add error catch for syncing
fix: wrap sync code in promise to ensure all callbacks are complete before react does anything else e.g., unmount the component.

FAIMS3-659

Signed-off-by: Liz Mannering <elizabeth.mannering@mq.edu.au>