### PR TITLE
Log when draft storage isn't cleared

### DIFF
--- a/src/sync/draft-state.ts
+++ b/src/sync/draft-state.ts
@@ -639,6 +639,8 @@ class RecordDraftState {
   async clear() {
     if (this.data.state === 'edited') {
       await deleteStagedData(await this.data.draft_id, this.last_revision);
+    } else {
+      console.info('Draft not edited, so not being cleared');
     }
 
     this.data = {state: 'uninitialized'};


### PR DESCRIPTION
This should allow us to check why drafts aren't removed sometimes.

For FAIMS3-674.