### PR TITLE
Fix status typo

### DIFF
--- a/src/gui/components/record/form.tsx
+++ b/src/gui/components/record/form.tsx
@@ -309,7 +309,7 @@ class RecordForm extends React.Component<
               payload: {
                 message:
                   'Could not load existing record: ' + this.props.record_id,
-                severity: 'warnings',
+                severity: 'warning',
               },
             });
             return;


### PR DESCRIPTION
It appears that the CSS for the toast crashed due to the use of 'warnings' rather than 'warning'. This does not fix the issue causing the data to be unable to be loaded.