### PR TITLE
Fix current user state for user switcher bug

### DIFF
--- a/src/datamodel/database.ts
+++ b/src/datamodel/database.ts
@@ -117,7 +117,6 @@ export type JWTTokenMap = {
 export interface LocalAuthDoc {
   _id: string; //Corresponds to a listings ID
   _rev?: string; // optional as we may want to include the raw json in places
-  current_token: JWTToken;
   current_username: string;
   available_tokens: JWTTokenMap;
 }

--- a/src/gui/components/authentication/cluster_card.tsx
+++ b/src/gui/components/authentication/cluster_card.tsx
@@ -87,27 +87,28 @@ function UserSwitcher(props: UserSwitcherProps) {
   }
 
   const handleClick = () => {
-    switchUsername(props.listing_id, value?.username as string).then(r => {
-      console.log('switchUsername returned', r);
-      const getToken = async () => {
-        await getTokenContentsForCluster(props.listing_id).then(r => {
-          console.log('awaiting getTokenInfoForCluster() returned', r);
-          props.setToken(r);
-        });
-      };
-
-      getToken().then(() =>
+    switchUsername(props.listing_id, value?.username as string)
+      .then(async r => {
+        console.log('switchUsername returned', r);
+        const token_contents = await getTokenContentsForCluster(
+          props.listing_id
+        );
+        console.log(
+          'awaiting getTokenInfoForCluster() returned',
+          token_contents
+        );
+        props.setToken(token_contents);
         dispatch({
           type: ActionType.ADD_ALERT,
           payload: {
             message: 'Switching user ' + value?.name,
             severity: 'success',
           },
-        })
-      );
-
-      return;
-    });
+        });
+      })
+      .catch(err => {
+        console.error('Failed to switch user', value?.username, err);
+      });
   };
 
   return (
@@ -181,15 +182,7 @@ export default function ClusterCard(props: ClusterCardProps) {
     getToken();
   }, [props.listing_id]);
 
-  useEffect(() => {
-    let isactive = true;
-    if (token !== undefined) {
-      if (isactive) props.setToken(token);
-    }
-    return () => {
-      isactive = false;
-    }; // cleanup toggles value,
-  }, [token]);
+  console.error('cluster card', props, token);
 
   return (
     <MainCard


### PR DESCRIPTION
The state of the app wasn't fully switching between different users, remove duplicate information stored and make the switching flow cleaner.

Should close FAIMS3-546.