### PR TITLE
Jump to record by scanning QR code

### DIFF
--- a/src/gui/components/notebook/add_record_by_type.tsx
+++ b/src/gui/components/notebook/add_record_by_type.tsx
@@ -65,94 +65,91 @@ export default function AddRecordButtons(props: AddRecordButtonsProps) {
   const visible_types = ui_spec.value.visible_types;
 
   const handleScanResult = (value: string) => {
-    console.log('got a scan result...', value);
     // find a record with this field value
     getAllRecordsWithRegex(project_id, value).then(records => {
       // navigate to it
-      console.log('got some records', records);
+      // what should happen if there are more than one?
       for (const key in records) {
-        console.log('jumping to', key);
         setSelectedRecord(records[key]);
       }
     });
   };
 
-  return (
-    <Box>
-      {/*If the list of views hasn't loaded yet*/}
-      {/*we can still show this button, except it will*/}
-      {/*redirect to the Record creation without known type*/}
-      {visible_types.length === 1 ? (
-        <ButtonGroup
-          fullWidth={mq_above_md ? false : true}
-          orientation={mq_above_sm ? 'horizontal' : 'vertical'}
-          sx={{maxHeight: '400px', overflowY: 'scroll'}}
-        >
-          <Button
-            variant="outlined"
-            color="primary"
-            startIcon={<AddIcon />}
-            component={RouterLink}
-            to={
-              ROUTES.NOTEBOOK +
-              project_id +
-              ROUTES.RECORD_CREATE +
-              visible_types
-            }
-          >
-            New Record
-          </Button>
+  console.log('visible types', visible_types);
+  visible_types.map(vt => {
+    console.log('VT', viewsets[vt]);
+  });
 
-          {showQRButton ? (
-            <QRCodeButton label="Scan QR" onScanResult={handleScanResult} />
-          ) : (
-            <span />
-          )}
-        </ButtonGroup>
-      ) : (
+  if (selectedRecord) {
+    /*  if we have selected a record (via QR scanning) then redirect to it here */
+    return (
+      <Redirect
+        to={ROUTES.getRecordRoute(
+          project_id || 'dummy',
+          (selectedRecord.record_id || '').toString(),
+          (selectedRecord.revision_id || '').toString()
+        )}
+      />
+    );
+  } else {
+    return (
+      <Box>
         <ButtonGroup
           fullWidth={mq_above_md ? false : true}
           orientation={mq_above_sm ? 'horizontal' : 'vertical'}
           sx={{maxHeight: '400px', overflowY: 'scroll'}}
         >
-          {visible_types.map(
-            viewset_name =>
-              viewsets[viewset_name].is_visible !== false && (
-                <Button
-                  component={RouterLink}
-                  to={
-                    ROUTES.NOTEBOOK +
-                    project.project_id +
-                    ROUTES.RECORD_CREATE +
-                    viewset_name
-                  }
-                  key={viewset_name}
-                  startIcon={<AddIcon />}
-                >
-                  {viewsets[viewset_name].label || viewset_name}
-                </Button>
-              )
+          {/*If the list of views hasn't loaded yet*/}
+          {/*we can still show this button, except it will*/}
+          {/*redirect to the Record creation without known type*/}
+          {visible_types.length === 1 ? (
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={<AddIcon />}
+              component={RouterLink}
+              key="newRecord"
+              to={
+                ROUTES.NOTEBOOK +
+                project_id +
+                ROUTES.RECORD_CREATE +
+                visible_types
+              }
+            >
+              New Record
+            </Button>
+          ) : (
+            visible_types.map(
+              (viewset_name: string) =>
+                viewsets[viewset_name].is_visible !== false && (
+                  <Button
+                    component={RouterLink}
+                    to={
+                      ROUTES.NOTEBOOK +
+                      project.project_id +
+                      ROUTES.RECORD_CREATE +
+                      viewset_name
+                    }
+                    key={viewset_name}
+                    startIcon={<AddIcon />}
+                  >
+                    {viewsets[viewset_name].label || viewset_name}
+                  </Button>
+                )
+            )
           )}
           {/* Show the QR code button if configured for this project */}
           {showQRButton ? (
-            <QRCodeButton label="Scan QR" onScanResult={handleScanResult} />
+            <QRCodeButton
+              key="scan-qr"
+              label="Scan QR"
+              onScanResult={handleScanResult}
+            />
           ) : (
             <span />
           )}
         </ButtonGroup>
-      )}
-      {/*  if we have selected a record (via QR scanning) then redirect to it here */}
-      {selectedRecord ? (
-        <Redirect
-          to={ROUTES.getRecordRoute(
-            project_id || 'dummy',
-            (selectedRecord.record_id || '').toString(),
-            (selectedRecord.revision_id || '').toString()
-          )}
-        />
-      ) : (
-        <span />
-      )}
-    </Box>
-  );
+      </Box>
+    );
+  }
 }

--- a/src/gui/components/notebook/add_record_by_type.tsx
+++ b/src/gui/components/notebook/add_record_by_type.tsx
@@ -74,12 +74,6 @@ export default function AddRecordButtons(props: AddRecordButtonsProps) {
       }
     });
   };
-
-  console.log('visible types', visible_types);
-  visible_types.map(vt => {
-    console.log('VT', viewsets[vt]);
-  });
-
   if (selectedRecord) {
     /*  if we have selected a record (via QR scanning) then redirect to it here */
     return (

--- a/src/gui/fields/qrcode/QRCodeFormField.tsx
+++ b/src/gui/fields/qrcode/QRCodeFormField.tsx
@@ -44,132 +44,26 @@ export function QRCodeFormField({
     initialValue = form.values[field.name];
   }
   const [state, setState] = useState(initialValue);
-  const [scanning, setScanning] = useState(false);
-  const [canScanMsg, setCanScanMsg] = useState('');
 
   const updateField = (value: any) => {
     setState(value);
     form.setFieldValue(field.name, value);
   };
 
-  const startScan = async () => {
-    BarcodeScanner.checkPermission({force: true})
-      .then(permissions => {
-        if (permissions.granted) {
-          // hide the main app so we can overlay the viewfinder
-          // relies on knowing the root id of the page
-          //
-          const rootcontainer = document.getElementById('root');
-          if (rootcontainer) {
-            rootcontainer.style.visibility = 'hidden';
-          }
-
-          // make background of WebView transparent
-          BarcodeScanner.hideBackground();
-
-          // and everything else too
-          document.getElementsByTagName('body')[0].style.backgroundColor =
-            'transparent';
-
-          // scroll to top to so that our viewfinder etc is visible
-          window.scrollTo(0, 0);
-
-          setScanning(true);
-
-          BarcodeScanner.startScan({}).then(result => {
-            // if the result has content
-            if (result.hasContent) {
-              console.debug('Barcode content:', result.content); // log the raw scanned content
-              updateField(result.content);
-            }
-            stopScan();
-          });
-        } else {
-          setCanScanMsg('Camera Access Permission not Granted');
-        }
-      })
-      .catch(() => {
-        setCanScanMsg('Scanning not supported in web browsers, mobile only');
-        updateField('1234');
-      });
-  };
-
-  const stopScan = () => {
-    BarcodeScanner.showBackground()
-      .then(() => {
-        const rootcontainer = document.getElementById('root');
-        if (rootcontainer) {
-          rootcontainer.style.visibility = 'visible';
-        }
-        BarcodeScanner.stopScan()
-          .then(() => {
-            setScanning(false);
-          })
-          .catch(() => console.debug('stopScan'));
-      })
-      .catch(() => console.debug('showBackground'));
-  };
-
   // a string version of the value
   // to display below the form field
   const valueText = JSON.stringify(state);
 
-  if (scanning) {
-    // insert or create an element to hold the overlay
-    let target;
-    target = document.getElementById('qrscanner');
-    if (!target) {
-      target = document.createElement('div');
-      target.setAttribute('id', 'qrscanner');
-      document.body.appendChild(target);
-    }
-
-    if (target) {
-      return ReactDOM.createPortal(
-        <div className={styles.container}>
-          <div className={styles.barcodeContainer}>
-            <div className={styles.relative}>
-              <p>Aim your camera at a barcode</p>
-              <Button color="primary" variant="contained" onClick={stopScan}>
-                Stop Scan
-              </Button>
-            </div>
-            <div className={styles.square}>
-              <div className={styles.outer}>
-                <div className={styles.inner}></div>
-              </div>
-            </div>
-          </div>
-        </div>,
-        target
-      );
-    } else {
-      // how did we get here?
-      return <div>Something went wrong</div>;
-    }
-  } else {
-    if (canScanMsg !== '') {
-      return (
-        <div>
-          <Button variant="outlined" disabled={true}>
-            Scan QR Code
-          </Button>
-          <div>{canScanMsg}</div>
-          <div>{valueText}</div>
-        </div>
-      );
-    } else {
-      return (
-        <div>
-          <p>{props.label}</p>
-          <Button variant="outlined" onClick={startScan}>
-            Scan QR Code
-          </Button>
-          <div>{valueText}</div>
-        </div>
-      );
-    }
-  }
+  return (
+    <div>
+      <p>{props.label}</p>
+      <QRCodeButton
+        label={props.label || 'Scan QR Code'}
+        onScanResult={updateField}
+      />
+      <div>{valueText}</div>
+    </div>
+  );
 }
 
 // A plain button that implements QRcode scanning with an onScanResult handler
@@ -182,12 +76,10 @@ export interface QRCodeButtonProps {
 }
 
 export function QRCodeButton(props: QRCodeButtonProps): JSX.Element {
-  const [state, setState] = useState('');
   const [scanning, setScanning] = useState(false);
   const [canScanMsg, setCanScanMsg] = useState('');
 
   const updateField = (value: any) => {
-    setState(value);
     props.onScanResult(value);
   };
 
@@ -229,7 +121,6 @@ export function QRCodeButton(props: QRCodeButtonProps): JSX.Element {
       })
       .catch(() => {
         setCanScanMsg('Scanning not supported in web browsers, mobile only');
-        updateField('1234');
       });
   };
 

--- a/src/gui/fields/qrcode/QRCodeFormField.tsx
+++ b/src/gui/fields/qrcode/QRCodeFormField.tsx
@@ -135,9 +135,9 @@ export function QRCodeButton(props: QRCodeButtonProps): JSX.Element {
           .then(() => {
             setScanning(false);
           })
-          .catch(() => console.log('stopScan'));
+          .catch(() => console.debug('stopScan'));
       })
-      .catch(() => console.log('showBackground'));
+      .catch(() => console.debug('showBackground'));
   };
 
   if (scanning) {

--- a/src/gui/fields/qrcode/QRCodeFormField.tsx
+++ b/src/gui/fields/qrcode/QRCodeFormField.tsx
@@ -172,6 +172,10 @@ export function QRCodeFormField({
   }
 }
 
+// A plain button that implements QRcode scanning with an onScanResult handler
+//
+// Duplicates some code above
+// TODO: refactor common parts to avoid code duplication
 export interface QRCodeButtonProps {
   label?: string;
   onScanResult: (value: string) => void;
@@ -245,10 +249,6 @@ export function QRCodeButton(props: QRCodeButtonProps): JSX.Element {
       .catch(() => console.log('showBackground'));
   };
 
-  // a string version of the value
-  // to display below the form field
-  const valueText = JSON.stringify(state);
-
   if (scanning) {
     // insert or create an element to hold the overlay
     let target;
@@ -290,7 +290,6 @@ export function QRCodeButton(props: QRCodeButtonProps): JSX.Element {
             {props.label}
           </Button>
           <div>{canScanMsg}</div>
-          <div>{valueText}</div>
         </div>
       );
     } else {
@@ -299,7 +298,6 @@ export function QRCodeButton(props: QRCodeButtonProps): JSX.Element {
           <Button variant="outlined" onClick={startScan}>
             {props.label}
           </Button>
-          <div>{valueText}</div>
         </div>
       );
     }


### PR DESCRIPTION
Adds a button to the project page to allow scanning a QR code. If the scan matches a valid record field value, then it will navigate to that record. 

Configured by adding 

```JSON
meta: {
    "showQRCodeButton": "true"
}
```

to the project metadata. 

(as yet  untested on mobile).