### PR TITLE
Provide more detail on errors

### DIFF
--- a/src/gui/components/record/view.tsx
+++ b/src/gui/components/record/view.tsx
@@ -235,10 +235,10 @@ function displayErrors(
       <dl>
         {Object.keys(errors).map(field => (
           <>
-            <dt>
+            <dt key="{field}error">
               {getUsefulFieldNameFromUiSpec(field, thisView, ui_specification)}
             </dt>
-            <dd>{errors[field]}</dd>
+            <dd key="{field}errorMessage">{errors[field]}</dd>
           </>
         ))}
       </dl>

--- a/src/gui/components/record/view.tsx
+++ b/src/gui/components/record/view.tsx
@@ -29,6 +29,7 @@ import {Box, Grid, Paper, Alert, IconButton, Collapse} from '@mui/material';
 import {EditConflictDialog} from './conflict/conflictDialog';
 import NoteIcon from '@mui/icons-material/Note';
 import {grey} from '@mui/material/colors';
+import {uiSpecType} from '../project/data/ComponentSetting';
 // import makeStyles from '@mui/styles/makeStyles';
 // import {useTheme} from '@mui/material/styles';
 type ViewProps = {
@@ -203,13 +204,77 @@ export function ViewComponent(props: ViewProps) {
       {!props.formProps.isValid && error !== false && (
         <Alert severity="error">
           Form has errors, please scroll up and make changes before submitting.
+          {displayErrors(
+            props.formProps.errors,
+            props.viewName,
+            ui_specification
+          )}
         </Alert>
       )}
       {!props.formProps.isValid && error === false && (
         <Alert severity="warning">
           Form has errors, please check other tabs before submitting.
+          {displayErrors(
+            props.formProps.errors,
+            props.viewName,
+            ui_specification
+          )}
         </Alert>
       )}
     </React.Fragment>
   );
+}
+
+function displayErrors(
+  errors: any | undefined,
+  thisView: string,
+  ui_specification: uiSpecType
+) {
+  if (errors) {
+    return (
+      <dl>
+        {Object.keys(errors).map(field => (
+          <>
+            <dt>
+              {getUsefulFieldNameFromUiSpec(field, thisView, ui_specification)}
+            </dt>
+            <dd>{errors[field]}</dd>
+          </>
+        ))}
+      </dl>
+    );
+  } else {
+    return <p>No errors to display</p>;
+  }
+}
+
+/**
+ * Generate a useful field name, <section>:<field> so that a user can see where an error is
+ * @param field a form field name
+ * @param thisView current view name
+ * @param ui_specification the ui specification object
+ */
+function getUsefulFieldNameFromUiSpec(
+  field: string,
+  thisView: string,
+  ui_specification: uiSpecType
+) {
+  if (field in ui_specification.fields) {
+    const fieldInfo = ui_specification.fields[field];
+    const fieldName =
+      fieldInfo.label ||
+      fieldInfo['component-parameters'].InputLabelProps.label ||
+      field;
+    // get the view that this field is part of
+    let sectionName = '';
+    for (const section in ui_specification.views) {
+      if (ui_specification.views[section].fields.indexOf(field) >= 0) {
+        if (section === thisView) sectionName = 'This section';
+        else sectionName = ui_specification.views[section].label || section;
+      }
+    }
+    return `${sectionName} > ${fieldName}`;
+  } else {
+    return field;
+  }
 }

--- a/src/gui/components/validation.ts
+++ b/src/gui/components/validation.ts
@@ -26,7 +26,7 @@ import {
   getFieldNamesFromFields,
 } from '../../uiSpecification';
 
-function check_field_type(
+function expand_validation_schema(
   ui_specification: ProjectUIModel,
   fieldName: string,
   validationSchema: any
@@ -42,8 +42,14 @@ function check_field_type(
         ? validate
         : new_validationSchema.push(validate)
     );
-    console.debug('new validation', fieldName, new_validationSchema);
     return new_validationSchema;
+  }
+  // insert yup.required for any field marked as required if it doesn't
+  // have it already
+  const fieldInfo = ui_specification.fields[fieldName];
+  if (fieldInfo['component-parameters'].required) {
+    if (validationSchema.indexOf(['yup.required']) < 0)
+      return [...validationSchema, ['yup.required']];
   }
 
   return validationSchema;
@@ -61,7 +67,7 @@ export function getValidationSchemaForViewset(
   const fieldNames = getFieldNamesFromFields(fields);
   const validationSchema = Object();
   fieldNames.forEach(fieldName => {
-    validationSchema[fieldName] = check_field_type(
+    validationSchema[fieldName] = expand_validation_schema(
       ui_specification,
       fieldName,
       fields[fieldName]['validationSchema']

--- a/src/projectMetadata.test.ts
+++ b/src/projectMetadata.test.ts
@@ -60,7 +60,7 @@ vi.mock('./sync/index', () => ({
 describe('roundtrip reading and writing to db', () => {
   const project_id = 'test_project_id';
   test.prop([
-    fc.fullUnicodeString(), // metadata_key
+    fc.fullUnicodeString({minLength: 1}), // metadata_key
     fc.unicodeJsonValue(), //  unicodeJsonObject(), // metadata
   ])('metadata roundtrip', (metadata_key: string, metadata: any) => {
     // try {


### PR DESCRIPTION
Errors in forms are not highlighted sometimes and we have an error alert that just says that there is an error somewhere. Here we add more detail to that alert and also make sure that required fields are validated (currently only if they also have required in the validation schema).