### PR TITLE
Fixing 'Publish and New' for child records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "clsx": "1.2.1",
         "cordova": "11.1.0",
         "cordova-plugin-inappbrowser": "^5.0.0",
-        "faims3-datamodel": "github:FAIMS/faims3-data-model#v1.1.3",
+        "faims3-datamodel": "github:FAIMS/faims3-data-model#v1.1.4",
         "fast-json-stable-stringify": "2.1.0",
         "formik": "2.4.5",
         "formik-mui": "4.0.0",
@@ -7822,8 +7822,8 @@
       "license": "MIT"
     },
     "node_modules/faims3-datamodel": {
-      "version": "1.1.3",
-      "resolved": "git+ssh://git@github.com/FAIMS/faims3-data-model.git#8728d0116b1b49d7cb5e8c1715344590a3591d71",
+      "version": "1.1.4",
+      "resolved": "git+ssh://git@github.com/FAIMS/faims3-data-model.git#d16e68f4a82549384cbe8449d990fa8b7463bb64",
       "license": "Apache",
       "dependencies": {
         "@demvsystems/yup-ast": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "clsx": "1.2.1",
     "cordova": "11.1.0",
     "cordova-plugin-inappbrowser": "^5.0.0",
-    "faims3-datamodel": "github:FAIMS/faims3-data-model#v1.1.3",
+    "faims3-datamodel": "github:FAIMS/faims3-data-model#v1.1.4",
     "fast-json-stable-stringify": "2.1.0",
     "formik": "2.4.5",
     "formik-mui": "4.0.0",

--- a/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -228,7 +228,6 @@ async function getRecordInformation(child_record: RecordReference) {
       revision_id,
       false
     );
-    console.debug('get latest record', latest_record);
   } catch (error) {
     throw Error('Error to get record information' + child_record.project_id);
   }
@@ -424,7 +423,6 @@ function get_route_for_field(
       (current_revision_id || '').toString()
     );
   } catch (error) {
-    console.log('Parent Route not passed correctly', current_revision_id);
     return project_id + record_id + current_revision_id;
   }
 }
@@ -550,10 +548,6 @@ async function get_field_RelatedFields(
           latest_record?.deleted ?? false,
           is_deleted
         );
-        // get the displayed information for the child or link item, this is used by field
-        if (is_display && latest_record !== null) {
-          console.debug('display values', displayFields);
-        }
         newfields.push(child);
       }
     } catch (error) {
@@ -836,12 +830,6 @@ export async function getDetailRelatedInformation(
 function get_last_updated(updated_by: string, updated: Date | undefined) {
   if (updated === undefined) return updated_by;
   const update_time = getLocalDate(updated).replace('T', ' ');
-  console.debug(
-    'update time',
-    getLocalDate(updated),
-    getLocalDate(new Date()),
-    update_time
-  );
   return updated_by + ' at ' + update_time;
 }
 export async function Update_New_Link(
@@ -1061,7 +1049,6 @@ async function check_if_parent_link(
 ) {
   let is_exist = false;
   const {latest_record, revision_id} = await getRecordInformation(record);
-  console.log(revision_id);
   if (latest_record !== null) {
     if (Array.isArray(latest_record.data[field_id])) {
       //if field value is array, child_record has this record,then link exist
@@ -1118,15 +1105,6 @@ export async function update_child_records_conflict(
 ) {
   for (const field of Object.keys(relation_fields)) {
     const field_info = relation_fields[field];
-    console.debug(
-      'conflict update child record',
-      conflictA.fields[field].data,
-      conflictB.fields[field].data,
-      mergeresult.fields[field].data,
-      field_info.relation_type.replace('faims-core::', ''),
-      project_id,
-      field
-    );
     await update_field_child_record_conflict(
       conflictA.fields[field].data,
       conflictB.fields[field].data,
@@ -1197,7 +1175,6 @@ async function conflict_update_child_record(
       record_label: record_id,
     };
     const {latest_record, revision_id} = await getRecordInformation(record);
-    console.log(revision_id);
     if (latest_record !== null) {
       const is_linked = check_if_child_link(
         latest_record?.relationship,
@@ -1363,7 +1340,6 @@ export async function remove_deleted_parent(
       const now = new Date();
       new_doc['updated'] = now;
       new_doc['relationship'] = new_relation;
-      console.debug('updated record relationship', new_relation);
       try {
         result['is_updated'] = true;
         result['newRelationship'] = remove_deleted_parent_link(

--- a/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -31,31 +31,36 @@ import * as ROUTES from '../../../../constants/routes';
 import {RecordLinkProps, ParentLinkProps} from './types';
 import getLocalDate from '../../../fields/LocalDate';
 import {logError} from '../../../../logging';
-//get parent link when child record been open
-export async function getParentLink_from_relationship(
-  hrid: string,
-  relationship: any,
-  record_id: string,
+
+/**
+ * Generate an object containing information to be stored in
+ *   `location.state` to persist between page views.
+ * @param parentLink - details of the linked (parent) record
+ * @param project_id - current project id
+ * @returns {location_state, latest_record, revision_id}
+ */
+export async function generateLocationState(
+  parentLink: LinkedRelation,
   project_id: string
 ) {
   const parent_record = {
     project_id: project_id,
-    record_id: relationship.parent.record_id,
-    record_label: relationship.parent.record_id,
+    record_id: parentLink.record_id,
+    record_label: parentLink.record_id,
   };
   const {latest_record, revision_id} = await getRecordInformation(
     parent_record
   );
   return {
     location_state: {
-      field_id: relationship.parent.field_id,
+      field_id: parentLink.field_id,
       parent: latest_record?.relationship?.parent,
       parent_link: ROUTES.getRecordRoute(
         project_id ?? '',
-        (relationship.parent.record_id || '').toString(),
+        (parentLink.record_id || '').toString(),
         (revision_id || '').toString()
       ),
-      parent_record_id: relationship.parent.record_id,
+      parent_record_id: parentLink.record_id,
       type: 'Child',
       // relation_type_vocabPair: relationship.parent.relation_type_vocabPair,
     },
@@ -63,46 +68,55 @@ export async function getParentLink_from_relationship(
     revision_id: revision_id,
   };
 }
-export function getParentlinkInfo(
+
+/**
+ * getParentLinkInfo - get information about whether a new record is a child of some parent record
+ * @param hrid - the HRID or revision_id of a record
+ * @param relationState - stored relation state
+ * @param record_id - the id of the record
+ * @returns {state_parent, is_direct} - `is_direct` is true if the record is a child record, false if
+ *          not.  `state_parent` contains details about the parent record or `{}` if none.
+ */
+export function getParentLinkInfo(
   hrid: string,
-  RelationState: any,
+  relationState: any,
   record_id: string
 ) {
   let is_direct = false;
   let state_parent: LocationState = {};
 
-  if (RelationState === undefined || RelationState === null)
+  if (relationState === undefined || relationState === null)
     return {state_parent, is_direct};
-  if (RelationState.field_id !== undefined) is_direct = true;
+  if (relationState.field_id !== undefined) is_direct = true;
 
   state_parent = {
-    field_id: RelationState.field_id,
+    field_id: relationState.field_id,
     record_id: record_id,
     hrid: hrid,
-    parent: RelationState.parent,
-    parent_link: RelationState.parent_link,
-    parent_record_id: RelationState.parent_record_id,
-    type: RelationState.type,
-    relation_type_vocabPair: RelationState.relation_type_vocabPair,
+    parent: relationState.parent,
+    parent_link: relationState.parent_link,
+    parent_record_id: relationState.parent_record_id,
+    type: relationState.type,
+    relation_type_vocabPair: relationState.relation_type_vocabPair,
   };
-  //check if the parent is exist
+  //check if the parent exists in the relationState record
   if (
-    RelationState.parent !== undefined &&
-    RelationState.parent.field_id !== undefined
+    relationState.parent !== undefined &&
+    relationState.parent.field_id !== undefined
   ) {
     if (
-      record_id === RelationState.parent_record_id &&
-      RelationState.parent.parent !== undefined
+      record_id === relationState.parent_record_id &&
+      relationState.parent.parent !== undefined
     ) {
       state_parent = {
-        field_id: RelationState.parent.field_id,
+        field_id: relationState.parent.field_id,
         record_id: record_id,
         hrid: hrid,
-        parent: RelationState.parent.parent,
-        parent_link: RelationState.parent.parent_link,
-        parent_record_id: RelationState.parent.parent_record_id,
-        type: RelationState.parent.type,
-        relation_type_vocabPair: RelationState.parent.relation_type_vocabPair,
+        parent: relationState.parent.parent,
+        parent_link: relationState.parent.parent_link,
+        parent_record_id: relationState.parent.parent_record_id,
+        type: relationState.parent.type,
+        relation_type_vocabPair: relationState.parent.relation_type_vocabPair,
       };
     }
   }
@@ -116,12 +130,77 @@ export function getParentlinkInfo(
   return {state_parent, is_direct};
 }
 
-const check_if_link_exist = (
+/**
+ * Generate a Relationship object to represent a relation between records
+ * @param location_state - existing location.state object
+ * @param parent - details of parent relationship
+ * @param record_id - current record id
+ * @returns a Relationship object
+ */
+export function generateRelationship(
+  location_state: any,
+  parent: Relationship,
+  record_id: string
+): Relationship {
+  let state = location_state;
+  if (state === undefined || state === null) return parent;
+  if (record_id === location_state.parent_record_id)
+    state = location_state.parent;
+  if (state === undefined || state === null) return parent;
+  if (state.type === undefined) return parent;
+  if (state.type === 'Child')
+    return {
+      ...parent,
+      parent: {
+        record_id: state.parent_record_id,
+        field_id: state.field_id,
+        relation_type_vocabPair: ['Child', 'Parent'],
+      },
+    };
+  if (state.type === 'Linked') {
+    if (parent['linked'] === undefined)
+      parent['linked'] = [
+        {
+          record_id: state.parent_record_id,
+          field_id: state.field_id,
+          relation_type_vocabPair: state.relation_type_vocabPair,
+        },
+      ];
+    else if (
+      !linkExists(parent['linked'], state.parent_record_id, state.field_id)
+    )
+      parent['linked'].push({
+        record_id: state.parent_record_id,
+        field_id: state.field_id,
+        relation_type_vocabPair: state.relation_type_vocabPair,
+      });
+    //get parent
+    if (
+      state.parent !== undefined &&
+      state.parent.type === 'Child' &&
+      state.parent.parent_record_id !== record_id //check to confirm
+    )
+      parent['parent'] = {
+        record_id: state.parent.parent_record_id,
+        field_id: state.parent.field_id,
+        relation_type_vocabPair: [],
+      };
+  }
+  return parent;
+}
+
+/**
+ * Check whether a link exists to a parent
+ * @param linkRecords - an array of link records
+ * @param parent_record_id - parent record
+ * @param field_id - relation field id
+ * @returns true if there is a link to this record
+ */
+const linkExists = (
   linkRecords: Array<LinkedRelation>,
   parent_record_id: string,
   field_id: string
 ) => {
-  //get all linked record_id
   if (linkRecords.length === 0) return false;
   let is_linked = false;
   linkRecords.map((linkRecord: LinkedRelation) =>
@@ -132,86 +211,6 @@ const check_if_link_exist = (
   );
   return is_linked;
 };
-
-//function to get parent/to be linked information to save in the child
-export function getParentInfo(
-  RelationState: any,
-  parent: Relationship,
-  record_id: string
-): Relationship {
-  let Relate_parent = RelationState;
-  if (Relate_parent === undefined || Relate_parent === null) return parent;
-  if (record_id === RelationState.parent_record_id)
-    Relate_parent = RelationState.parent;
-  if (Relate_parent === undefined || Relate_parent === null) return parent;
-  if (Relate_parent.type === undefined) return parent;
-  if (Relate_parent.type === 'Child')
-    return {
-      ...parent,
-      parent: {
-        record_id: Relate_parent.parent_record_id,
-        field_id: Relate_parent.field_id,
-        relation_type_vocabPair: ['Child', 'Parent'],
-      },
-    };
-  if (Relate_parent.type === 'Linked') {
-    if (parent['linked'] === undefined)
-      parent['linked'] = [
-        {
-          record_id: Relate_parent.parent_record_id,
-          field_id: Relate_parent.field_id,
-          relation_type_vocabPair: Relate_parent.relation_type_vocabPair,
-        },
-      ];
-    else if (
-      !check_if_link_exist(
-        parent['linked'],
-        Relate_parent.parent_record_id,
-        Relate_parent.field_id
-      )
-    )
-      parent['linked'].push({
-        record_id: Relate_parent.parent_record_id,
-        field_id: Relate_parent.field_id,
-        relation_type_vocabPair: Relate_parent.relation_type_vocabPair,
-      });
-    //get parent
-    if (
-      Relate_parent.parent !== undefined &&
-      Relate_parent.parent.type === 'Child' &&
-      Relate_parent.parent.parent_record_id !== record_id //check to confirm
-    )
-      parent['parent'] = {
-        record_id: Relate_parent.parent.parent_record_id,
-        field_id: Relate_parent.parent.field_id,
-        relation_type_vocabPair: [],
-      };
-  }
-  return parent;
-}
-//function to get child/linked information to save in parent
-export function getChildInfo(child_state: any, project_id: string) {
-  let is_related = false;
-  let field_id = '';
-  let new_record: RecordReference | null = null;
-  if (
-    child_state !== undefined &&
-    child_state !== null &&
-    child_state.record_id !== undefined
-  ) {
-    //save the sub_record id into initial value
-    field_id = child_state.field_id.replace('?', '');
-    new_record = {
-      project_id: project_id,
-      record_id: child_state.record_id,
-      record_label: child_state.hrid ?? child_state.record_id,
-      relation_type_vocabPair: child_state.relation_type_vocabPair ?? null,
-    };
-    is_related = true;
-    return {field_id, new_record, is_related};
-  }
-  return {field_id, new_record, is_related};
-}
 
 async function getRecordInformation(child_record: RecordReference) {
   let latest_record = null;
@@ -486,7 +485,6 @@ async function get_field_RelatedFields(
   displayFields: string[] = []
 ): Promise<Array<RecordLinkProps>> {
   for (const index in fields) {
-    console.debug('get related field', fields[index]['value']);
     const field = fields[index]['field'];
     const child_record = fields[index]['value'];
 
@@ -593,8 +591,6 @@ export async function addLinkedRecord(
     });
   }
 
-  console.debug('parent field information', parent_links, parent);
-
   for (const index in parent_links) {
     const parent_link = parent_links[index];
     const {latest_record, revision_id} = await getRecordInformation({
@@ -602,12 +598,6 @@ export async function addLinkedRecord(
       record_id: parent_link.record_id,
       record_label: parent_link.record_id,
     });
-    console.debug(
-      'get revisons and latest_record',
-      latest_record,
-      record_id,
-      revision_id
-    );
     if (revision_id !== undefined) {
       const child_record = {
         project_id: project_id,
@@ -967,7 +957,7 @@ export function AddLink(
   linked: LinkedRelation
 ): LinkedRelation[] {
   if (relation === undefined || relation.linked === undefined) return [linked];
-  if (check_if_link_exist(relation.linked, linked.record_id, linked.field_id))
+  if (linkExists(relation.linked, linked.record_id, linked.field_id))
     return relation.linked;
   const new_linked = relation.linked;
   new_linked.push(linked);

--- a/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -478,9 +478,7 @@ async function get_field_RelatedFields(
   form_type: string,
   hrid: string,
   relation_type: string,
-  current_revision_id: string,
-  is_display = false,
-  displayFields: string[] = []
+  current_revision_id: string
 ): Promise<Array<RecordLinkProps>> {
   for (const index in fields) {
     const field = fields[index]['field'];
@@ -1048,7 +1046,7 @@ async function check_if_parent_link(
   record_id: string
 ) {
   let is_exist = false;
-  const {latest_record, revision_id} = await getRecordInformation(record);
+  const {latest_record} = await getRecordInformation(record);
   if (latest_record !== null) {
     if (Array.isArray(latest_record.data[field_id])) {
       //if field value is array, child_record has this record,then link exist
@@ -1174,7 +1172,7 @@ async function conflict_update_child_record(
       record_id: record_id,
       record_label: record_id,
     };
-    const {latest_record, revision_id} = await getRecordInformation(record);
+    const {latest_record} = await getRecordInformation(record);
     if (latest_record !== null) {
       const is_linked = check_if_child_link(
         latest_record?.relationship,

--- a/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -176,18 +176,16 @@ export default function DataGridFieldLinksComponent(
     setIsSubmitting(true);
 
     if (props.handleUnlink !== undefined)
-      props
-        .handleUnlink(modalLink.record_id, modalLink.hrid)
-        .then((result: string) => {
-          const timer = setTimeout(() => {
-            // reset local state of component
-            setIsSubmitting(false);
-            setModalOpen(false);
-          }, 500);
-          return () => {
-            clearTimeout(timer);
-          };
-        });
+      props.handleUnlink(modalLink.record_id, modalLink.hrid).then(() => {
+        const timer = setTimeout(() => {
+          // reset local state of component
+          setIsSubmitting(false);
+          setModalOpen(false);
+        }, 500);
+        return () => {
+          clearTimeout(timer);
+        };
+      });
   }
   function recordDisplay(
     current_record_id: RecordID,

--- a/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -179,7 +179,6 @@ export default function DataGridFieldLinksComponent(
       props
         .handleUnlink(modalLink.record_id, modalLink.hrid)
         .then((result: string) => {
-          console.debug('UnClick result', result);
           const timer = setTimeout(() => {
             // reset local state of component
             setIsSubmitting(false);
@@ -208,7 +207,6 @@ export default function DataGridFieldLinksComponent(
       </Typography>
     );
   }
-  console.debug('updated record relationship', props.links);
   const columns: any = [
     {
       field: 'relation_type_vocabPair',

--- a/src/gui/components/record/relationships/record_links.tsx
+++ b/src/gui/components/record/relationships/record_links.tsx
@@ -116,7 +116,8 @@ export default function RecordLinkComponent(props: RecordLinksComponentProps) {
           headerClassName: 'faims-record-link--header',
           minWidth: 100,
           flex: 0.2,
-          valueGetter: (params: GridCellParams) => params.row.value[0],
+          valueGetter: (params: GridCellParams) =>
+            params.row.value ? params.row.value[0] : 'unknown',
         },
         {
           field: 'linked_field',
@@ -191,7 +192,8 @@ export default function RecordLinkComponent(props: RecordLinksComponentProps) {
           headerClassName: 'faims-record-link--header',
           minWidth: 150,
           flex: 0.1,
-          valueGetter: (params: gridParamsDataType) => params.value[0],
+          valueGetter: (params: gridParamsDataType) =>
+            params.row.value ? params.row.value[0] : 'unknown',
         },
         {
           field: 'linked_field',

--- a/src/gui/components/record/view.tsx
+++ b/src/gui/components/record/view.tsx
@@ -260,12 +260,12 @@ function displayErrors(
     return (
       <dl>
         {Object.keys(errors).map(field => (
-          <>
-            <dt key="{field}error">
+          <React.Fragment key="{field}error">
+            <dt>
               {getUsefulFieldNameFromUiSpec(field, thisView, ui_specification)}
             </dt>
-            <dd key="{field}errorMessage">{errors[field]}</dd>
-          </>
+            <dd>{errors[field]}</dd>
+          </React.Fragment>
         ))}
       </dl>
     );

--- a/src/gui/components/record/view.tsx
+++ b/src/gui/components/record/view.tsx
@@ -36,7 +36,7 @@ type ViewProps = {
   viewName: string;
   ui_specification: ProjectUIModel;
   formProps: FormikProps<{[key: string]: unknown}>;
-  draftState?: RecordDraftState;
+  draftState?: RecordDraftState | null;
   annotation: any;
   handleAnnotation: any;
   isSyncing?: string;
@@ -52,7 +52,7 @@ type SingleComponentProps = {
   formProps: FormikProps<{[key: string]: unknown}>;
   annotation: any;
   handleAnnotation: any;
-  draftState?: RecordDraftState;
+  draftState?: RecordDraftState | null;
   conflictfields?: string[] | null; // those two props are handling the conflict icons
   handleChangeTab?: any;
   isSyncing?: string;

--- a/src/gui/components/record/view.tsx
+++ b/src/gui/components/record/view.tsx
@@ -260,7 +260,7 @@ function displayErrors(
     return (
       <dl>
         {Object.keys(errors).map(field => (
-          <React.Fragment key="{field}error">
+          <React.Fragment key={field}>
             <dt>
               {getUsefulFieldNameFromUiSpec(field, thisView, ui_specification)}
             </dt>

--- a/src/gui/components/ui/record_link.tsx
+++ b/src/gui/components/ui/record_link.tsx
@@ -24,7 +24,7 @@ export default function RecordRouteDisplay(props: RecordLinkProps) {
       ) : (
         <ArticleIcon fontSize={'inherit'} sx={{mt: '3px', mr: '3px'}} />
       )}
-      <Typography variant={'body2'} fontWeight={'bold'}>
+      <Typography component={'span'} variant={'body2'} fontWeight={'bold'}>
         {props.children}
       </Typography>
     </span>

--- a/src/gui/fields/RelatedRecordSelector.tsx
+++ b/src/gui/fields/RelatedRecordSelector.tsx
@@ -327,10 +327,9 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
           props.current_form,
           type
         );
-        console.debug('record information', records_info);
         setRecordsInformation(records_info);
       } else {
-        console.debug('Project ID is not available');
+        console.debug('Project ID is not available - this is probably bad');
         // setIsactive(true);
       }
     })();
@@ -357,7 +356,6 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
           props.current_form,
           type
         );
-        console.debug('record information', records_info);
         setRecordsInformation(records_info);
         SetUpdated(uuidv4());
       } else {

--- a/src/gui/fields/RelatedRecordSelector.tsx
+++ b/src/gui/fields/RelatedRecordSelector.tsx
@@ -382,7 +382,7 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
   const newState: LocationState = {
     parent_record_id: props.form.values._id, //current form record id
     parent_hrid: hrid,
-    field_id: props.id,
+    field_id: props.field.name, // the field identifier
     type: type, //type of this relation
     parent_link: location.pathname.replace('/notebooks/', ''), // current form link
     parent: {},

--- a/src/gui/pages/record.tsx
+++ b/src/gui/pages/record.tsx
@@ -315,10 +315,6 @@ export default function Record() {
               },
               {title: hrid! ?? record_id!},
             ];
-            console.debug(
-              'updated record relationship parent newParent ',
-              newParent
-            );
             if (
               newParent !== null &&
               newParent.length > 0 &&
@@ -385,7 +381,6 @@ export default function Record() {
         newRelationship: RecordLinkProps[];
       }) => {
         if (result.is_updated) {
-          console.debug('updated record relationship parent ', result);
           if (
             result.new_revision_id !== undefined &&
             result.new_revision_id !== null &&
@@ -402,7 +397,6 @@ export default function Record() {
               record_id!
             ).then(newParent => {
               setParentLinks(newParent);
-              console.debug('updated record relationship parent ', newParent);
             });
           }
         } else {

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -475,14 +475,6 @@ export function listenProjectDB(
   return listenProject(
     active_id,
     (project, throw_error, meta_changed) => {
-      if (DEBUG_APP) {
-        console.info(
-          'listenProjectDB changed',
-          project,
-          throw_error,
-          meta_changed
-        );
-      }
       if (meta_changed) {
         const changes = project.meta.local.changes(change_opts);
         changes.on('change', change_listener);


### PR DESCRIPTION
For a record that is a child of some parent record, the 'Publish and New' button should create a new child of the same parent. At the moment, it doesn't. 

In the process of fixing, I've also found the problem that caused drafts to be left behind when records are saved.  Included here was a bug that left behind global timers that would try to save records at regular intervals.  There may still be some left behind drafts but should be many fewer than before. 

The publish and new behaviour turned out to be a bug.  The identity of the relation field was supposed to be passed to the next page but it wasn't being passed properly.  This broke subsequent logic to create the new child record.  In the end this was a one line fix. 