### PR TITLE
Ensure different known ports for designer and app

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
   build: {
     outDir: 'build',
   },
+  server: {
+    port: 5000,
+  },
   resolve: {
     alias: {
       events: 'rollup-plugin-node-polyfills/polyfills/events',

--- a/designer/package.json
+++ b/designer/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "start": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/designer/vite.config.ts
+++ b/designer/vite.config.ts
@@ -1,12 +1,33 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: vite.config.ts
+ * Description:
+ *   Configuration for Vite build
+ */
 /// <reference types="vitest" />
-/// <reference types="vite/client" />
 
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react()],  
+  server: {
+    port: 5010,
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
     "start-api": "npm start --workspace=api",
     "start-app": "npm start --workspace=app",
     "watch-api": "npm run watch --workspace=api",
-    "initdb": "npm run initdb --workspace=api",
-    "load-notebooks": "npm run load-notebooks --workspace=api",
-    "webapp-build": "npm run webapp-build --workspace=app",
-    "webapp-sync": "npm run webapp-sync --workspace=app"
+    "start-designer": "npm run start --workspace=designer"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Both `app` and `designer` use vite and start up on random ports. Fix the ports at 5000 for the app and 5010 for the designer so we don't get confused.