### PR TITLE
get useNavigate from react-router-dom not react-router

### DIFF
--- a/app/src/gui/components/record/RecordData.tsx
+++ b/app/src/gui/components/record/RecordData.tsx
@@ -37,7 +37,7 @@ import ListAltIcon from '@mui/icons-material/ListAlt';
 import InheritedDataComponent from './inherited_data';
 import {ParentLinkProps, RecordLinkProps} from './relationships/types';
 import CircularProgress from '@mui/material/CircularProgress';
-import {useNavigate} from 'react-router';
+import {useNavigate} from 'react-router-dom';
 interface RecordDataTypes {
   project_id: ProjectID;
   record_id: RecordID;


### PR DESCRIPTION
Uncovered a crash condition while testing a notebook. Not sure why it wasn't evident before but one file mistakenly imported useNavigate from react-router rather than react-router-dom causing a crash. 