### PR TITLE
feat: BSS-203 consolidate application load balancers

### DIFF
--- a/infrastructure/aws-cdk/.gitignore
+++ b/infrastructure/aws-cdk/.gitignore
@@ -140,3 +140,4 @@ configs/*
 
 # we shouldn't track this!
 cdk.context.json
+flat.sh

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -11,61 +11,53 @@
  * ----------   --- ---------------------------------------------------------
  */
 
-import { Construct } from "constructs";
-import {
-  AutoScalingGroup,
-  DefaultResult,
-  LifecycleTransition,
-  UpdatePolicy,
-} from "aws-cdk-lib/aws-autoscaling";
-import {
-  AmazonLinuxGeneration,
-  AmazonLinuxImage,
-  InstanceClass,
-  InstanceSize,
-  InstanceType,
-  IVpc,
-  Peer,
-  Port,
-  SecurityGroup,
-  SubnetType,
-  UserData,
-} from "aws-cdk-lib/aws-ec2";
-import {
-  ApplicationLoadBalancer,
-  ApplicationProtocol,
-} from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import { ARecord, IHostedZone } from "aws-cdk-lib/aws-route53";
-import { LoadBalancerTarget } from "aws-cdk-lib/aws-route53-targets";
-import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
-import { Secret } from "aws-cdk-lib/aws-secretsmanager";
-import { aws_iam, aws_route53, Duration, RemovalPolicy } from "aws-cdk-lib";
-import {
-  DnsRecordType,
-  PrivateDnsNamespace,
-} from "aws-cdk-lib/aws-servicediscovery";
-import { Queue } from "aws-cdk-lib/aws-sqs";
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
+import * as autoscaling from "aws-cdk-lib/aws-autoscaling";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import { Rule } from "aws-cdk-lib/aws-events";
-import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
-import { SharedALB } from "./networking";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as r53targets from "aws-cdk-lib/aws-route53-targets";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import * as servicediscovery from "aws-cdk-lib/aws-servicediscovery";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+import { SharedBalancer } from "./networking";
 
+/**
+ * Properties for the EC2CouchDB construct
+ */
 export interface EC2CouchDBProps {
-  vpc: IVpc;
+  /** The VPC to deploy the CouchDB instance in */
+  vpc: ec2.IVpc;
+  /** The domain name for the CouchDB instance */
   domainName: string;
-  // Balancer to use
-  sharedALB: SharedALB;
-  hz: IHostedZone;
-  certificate: ICertificate;
+  /** The shared Application Load Balancer to use */
+  sharedBalancer: SharedBalancer;
+  /** The Hosted Zone for DNS configuration */
+  hz: route53.IHostedZone;
+  /** The SSL/TLS certificate for HTTPS connections */
+  certificate: acm.ICertificate;
 }
 
+/**
+ * A construct that sets up a CouchDB instance on EC2 with auto-scaling and load balancing
+ */
 export class EC2CouchDB extends Construct {
+  /** The public endpoint for accessing CouchDB */
   public readonly couchEndpoint: string;
+  /** The exposed HTTPS port */
   public readonly exposedPort: number = 443;
-  public readonly passwordSecret: Secret;
+  /** The secret containing the CouchDB admin user/password */
+  public readonly passwordSecret: secretsmanager.Secret;
+  /** The internal port CouchDB listens on */
+  private readonly couchInternalPort: number = 5984;
 
-  // TODO retrieve this from mono repo by reading from file OR store/host to
-  // allow dynamic reconfiguration? NOTE does not include keys.
+  /** CouchDB configuration settings */
   private readonly couchDbConfig: string = `
 ; CouchDB Configuration Settings for FAIMS
 [couchdb]
@@ -99,56 +91,46 @@ methods = GET, PUT, POST, HEAD, DELETE
   constructor(scope: Construct, id: string, props: EC2CouchDBProps) {
     super(scope, id);
 
-    const lbSecurityGroup = new SecurityGroup(
+    // AUXILIARY SETUP
+    // ================
+
+    // Create a secret for the CouchDB admin password
+    this.passwordSecret = new secretsmanager.Secret(
       this,
-      "LoadBalancerSecurityGroup",
+      "CouchDBAdminPassword",
       {
-        vpc: props.vpc,
-        allowAllOutbound: true,
-        description: "Security group for Load Balancer",
+        generateSecretString: {
+          excludeCharacters: '/\\"%@',
+          generateStringKey: "password",
+          passwordLength: 16,
+          secretStringTemplate: JSON.stringify({ username: "admin" }),
+        },
+        removalPolicy: RemovalPolicy.DESTROY,
       }
     );
 
-    // Create a security group for the EC2 instance
-    const couchSecurityGroup = new SecurityGroup(this, "CouchDBSecurityGroup", {
-      vpc: props.vpc,
-      allowAllOutbound: true,
-      description: "Security group for CouchDB EC2 instances",
-    });
+    // CLOUDMAP SETUP
+    // ================
 
-    couchSecurityGroup.addIngressRule(
-      lbSecurityGroup,
-      Port.tcp(5984),
-      "Allow CouchDB access from load balancer"
+    // Create CloudMap service for service discovery
+    const namespace = new servicediscovery.PrivateDnsNamespace(
+      this,
+      "CouchDBNamespace",
+      {
+        vpc: props.vpc,
+        name: "couchdb.local",
+      }
     );
 
-    // Create a secret for the CouchDB admin password
-    this.passwordSecret = new Secret(this, "CouchDBAdminPassword", {
-      generateSecretString: {
-        excludeCharacters: '/\\"%@',
-        generateStringKey: "password",
-        passwordLength: 16,
-        secretStringTemplate: JSON.stringify({ username: "admin" }),
-      },
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    // Create CloudMap service
-    const namespace = new PrivateDnsNamespace(this, "CouchDBNamespace", {
-      vpc: props.vpc,
-      name: "couchdb.local",
-    });
-
     const service = namespace.createService("CouchDBService", {
-      dnsRecordType: DnsRecordType.A,
+      dnsRecordType: servicediscovery.DnsRecordType.A,
       dnsTtl: Duration.seconds(60),
     });
 
     // Create a dead-letter queue for failed deregistrations
-    const dlq = new Queue(this, "DeregistrationDLQ");
+    const dlq = new sqs.Queue(this, "DeregistrationDLQ");
 
-    // This lambda instance runs on instance termination in the auto scaling
-    // group to deregister the instance from the cloudmap service
+    // Lambda function to deregister instances from CloudMap on termination
     const deregisterLambda = new lambda.Function(
       this,
       "DeregisterInstanceLambda",
@@ -163,13 +145,16 @@ methods = GET, PUT, POST, HEAD, DELETE
       }
     );
 
+    // INSTANCE CONFIG
+    // ================
+
     // Create user data script to install and configure CouchDB
-    const userData = UserData.forLinux();
+    const userData = ec2.UserData.forLinux();
     userData.addCommands(
       // Update yum and install dependencies
       "yum update -y",
       "yum install -y docker jq awscli",
-      // Run couch DB with docker service
+      // Run CouchDB with docker service
       "systemctl start docker",
       "systemctl enable docker",
       "docker pull couchdb:latest",
@@ -177,7 +162,7 @@ methods = GET, PUT, POST, HEAD, DELETE
       // Get the region dynamically
       "REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)",
       "export AWS_DEFAULT_REGION=$REGION",
-      // Get username and password
+      // Get username and password from Secrets Manager
       "ADMIN_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $SECRET_ARN --query SecretString --output text | jq -r .password)",
       "ADMIN_USER=$(aws secretsmanager get-secret-value --secret-id $SECRET_ARN --query SecretString --output text | jq -r .username)",
       // Create CouchDB configuration file
@@ -185,59 +170,65 @@ methods = GET, PUT, POST, HEAD, DELETE
       `cat > /opt/couchdb/etc/local.d/local.ini << EOL
 ${this.couchDbConfig}
 EOL`,
-      // Append admin and password configuration to local.ini -> note this will
-      // be hashed upon couch instance start.
+      // Append admin and password configuration to local.ini
       `echo "[admins]" >> /opt/couchdb/etc/local.d/local.ini`,
       `echo "$ADMIN_USER = $ADMIN_PASSWORD" >> /opt/couchdb/etc/local.d/local.ini`,
       // Run CouchDB container with mounted configuration
       "docker run -d --name couchdb -p 5984:5984 -v /opt/couchdb/etc/local.d:/opt/couchdb/etc/local.d couchdb:latest",
       // Register the instance with CloudMap
-      // Get token for metadata api
       'TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")',
-      // get instance ID
       'INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)',
-      // get Private Ip
       'PRIVATE_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)',
-      // use service discovery AWS CLI to register instance into specified service
       "SERVICE_ID=" + service.serviceId,
       `aws servicediscovery register-instance --service-id $SERVICE_ID --instance-id $INSTANCE_ID --attributes AWS_INSTANCE_IPV4=$PRIVATE_IP,AWS_INSTANCE_PORT=5984`
     );
-    // Create an Auto Scaling Group with a single EC2 instance
-    const asg = new AutoScalingGroup(this, "CouchDBAsg", {
-      vpc: props.vpc,
-      // T3 Small for now
-      // TODO add instance size to configuration
-      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
-      
-      // TODO place into private and have NAT gateway (for setting up instances
-      // we need internet connectivity) in future
-      vpcSubnets: { subnetType: SubnetType.PUBLIC },
-      associatePublicIpAddress: true,
 
-      machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+    // ASG SETUP
+    // ================
+
+    // Create a security group for the EC2 instance
+    const couchSecurityGroup = new ec2.SecurityGroup(
+      this,
+      "CouchDBSecurityGroup",
+      {
+        vpc: props.vpc,
+        allowAllOutbound: true,
+        description: "Security group for CouchDB EC2 instances",
+      }
+    );
+
+    // Create an Auto Scaling Group with a single EC2 instance
+    const asg = new autoscaling.AutoScalingGroup(this, "CouchDBAsg", {
+      vpc: props.vpc,
+      instanceType: ec2.InstanceType.of(
+        ec2.InstanceClass.T3,
+        ec2.InstanceSize.SMALL
+      ),
+      machineImage: new ec2.AmazonLinuxImage({
+        generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
       }),
       userData,
       minCapacity: 1,
       maxCapacity: 1,
       desiredCapacity: 1,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      associatePublicIpAddress: true,
       securityGroup: couchSecurityGroup,
-      updatePolicy: UpdatePolicy.rollingUpdate(),
+      updatePolicy: autoscaling.UpdatePolicy.rollingUpdate(),
     });
 
+    // LIFECYCLE CONFIG
+    // ================
 
-    // Grant the EC2 instance permission to read the secret
-    this.passwordSecret.grantRead(asg.role);
-
-    // Add lifecycle hook to deregister
+    // Add lifecycle hook to deregister instances from CloudMap on termination
     asg.addLifecycleHook("DeregisterFromCloudMap", {
-      lifecycleTransition: LifecycleTransition.INSTANCE_TERMINATING,
+      lifecycleTransition: autoscaling.LifecycleTransition.INSTANCE_TERMINATING,
       heartbeatTimeout: Duration.seconds(300),
-      defaultResult: DefaultResult.CONTINUE,
+      defaultResult: autoscaling.DefaultResult.CONTINUE,
     });
 
-    // trigger deregister when scale out occurs
-    new Rule(this, "TerminatingInstanceRule", {
+    // Trigger deregister Lambda when instance termination occurs
+    new events.Rule(this, "TerminatingInstanceRule", {
       eventPattern: {
         source: ["aws.autoscaling"],
         detailType: ["EC2 Instance-terminate Lifecycle Action"],
@@ -245,10 +236,82 @@ EOL`,
           AutoScalingGroupName: [asg.autoScalingGroupName],
         },
       },
-      targets: [new LambdaFunction(deregisterLambda)],
+      targets: [new targets.LambdaFunction(deregisterLambda)],
     });
 
-    // service discovery perms
+    // LOAD BALANCING SETUP
+    // =========================
+
+    // Create the target group for the CouchDB instances
+    const tg = new elb.ApplicationTargetGroup(this, "CouchTG", {
+      port: this.couchInternalPort,
+      protocol: elb.ApplicationProtocol.HTTP,
+      targetType: elb.TargetType.INSTANCE,
+      healthCheck: {
+        enabled: true,
+        healthyHttpCodes: "200",
+        protocol: elb.Protocol.HTTP,
+        interval: Duration.seconds(30),
+        timeout: Duration.seconds(5),
+        port: this.couchInternalPort.toString(),
+        path: "/",
+      },
+      vpc: props.vpc,
+    });
+
+    // Add the Auto Scaling Group to the target group
+    tg.addTarget(asg);
+
+    // Add HTTP redirected HTTPS service to ALB against target group
+    props.sharedBalancer.addHttpRedirectedConditionalHttpsTarget(
+      "couch",
+      tg,
+      [elb.ListenerCondition.hostHeaders([props.domainName])],
+      110, // TODO: Understand and consider priorities
+      110
+    );
+
+    // DNS ROUTES
+    // ===========
+
+    // Create a DNS record for the CouchDB endpoint
+    new route53.ARecord(this, "CouchDBAliasRecord", {
+      zone: props.hz,
+      recordName: props.domainName,
+      target: route53.RecordTarget.fromAlias(
+        new r53targets.LoadBalancerTarget(props.sharedBalancer.alb)
+      ),
+    });
+
+    // DEBUG CONFIG
+    // ============
+
+    // TODO: Handle this through config
+    const debugInstancePermissions = false;
+
+    if (debugInstancePermissions) {
+      // For debugging CouchDB instances - allow inbound traffic for SSM Instance Connect
+      couchSecurityGroup.addIngressRule(
+        ec2.Peer.anyIpv4(),
+        ec2.Port.tcp(443),
+        "Allow SSM Instance Connect"
+      );
+
+      // Add SSM Instance Connect permissions to the instance role
+      asg.role.addManagedPolicy(
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "AmazonSSMManagedInstanceCore"
+        )
+      );
+    }
+
+    // IAM PERMISSIONS
+    // ==================
+
+    // Grant the EC2 instance permission to read the secret
+    this.passwordSecret.grantRead(asg.role);
+
+    // Service discovery permissions
     const permsForServiceDiscovery = [
       "servicediscovery:DeregisterInstance",
       "servicediscovery:DiscoverInstances",
@@ -261,95 +324,47 @@ EOL`,
       "ec2:DescribeInstances",
     ];
 
-    // Grant the EC2 instance and lambda function permission to register and deregister instances in the service
+    // Grant the EC2 instance permission to register and deregister instances in the service
     asg.addToRolePolicy(
-      new aws_iam.PolicyStatement({
+      new iam.PolicyStatement({
         actions: permsForServiceDiscovery,
-        // TODO tighten this and maybe split by service e.g. service discovery, route 53, ec2
-        resources: ["*"],
+        resources: ["*"], // TODO: Tighten this and split by service
       })
     );
 
-    // lambda needs above and also complete lifecycle action
+    // Grant the Lambda function permissions for service discovery and lifecycle completion
     deregisterLambda.addToRolePolicy(
-      new aws_iam.PolicyStatement({
-        actions: permsForServiceDiscovery.concat([
+      new iam.PolicyStatement({
+        actions: [
+          ...permsForServiceDiscovery,
           "autoscaling:CompleteLifecycleAction",
-        ]),
-        // TODO tighten this and maybe split by service e.g. service discovery, route 53, ec2
-        resources: ["*"],
+        ],
+        resources: ["*"], // TODO: Tighten this and split by service
       })
     );
 
-
-    // Grant necessary permissions
+    // Grant the Lambda function permission to complete lifecycle actions
     deregisterLambda.addToRolePolicy(
-      new aws_iam.PolicyStatement({
+      new iam.PolicyStatement({
         actions: ["autoscaling:CompleteLifecycleAction"],
         resources: [asg.autoScalingGroupArn],
       })
     );
 
-    // Create an Application Load Balancer
-    const lb = new ApplicationLoadBalancer(this, "CouchDBLoadBalancer", {
-      vpc: props.vpc,
-      internetFacing: true,
-      securityGroup: lbSecurityGroup,
-    });
+    // NETWORK SECURITY
+    // ================
 
-    // Add a listener to the load balancer
-    const listener = lb.addListener("Listener", {
-      port: this.exposedPort,
-      protocol: ApplicationProtocol.HTTPS,
-      certificates: [props.certificate],
-    });
-
-    // HTTPS inbound 443 to LB
-    lbSecurityGroup.addIngressRule(
-      Peer.anyIpv4(),
-      Port.tcp(443),
-      "Allow inbound traffic to database from public on HTTPS port 443"
+    // Allow inbound traffic from the ALB to the CouchDB instances
+    couchSecurityGroup.connections.allowFrom(
+      props.sharedBalancer.alb,
+      ec2.Port.tcp(this.couchInternalPort),
+      "Allow traffic from ALB to CouchDB instances"
     );
 
-    // Add the Auto Scaling Group as a target to the listener
-    listener.addTargets("CouchDBTarget", {
-      port: 5984,
-      protocol: ApplicationProtocol.HTTP,
-      targets: [asg],
-      healthCheck: {
-        path: "/",
-        unhealthyThresholdCount: 3,
-        healthyThresholdCount: 2,
-        interval: Duration.seconds(30),
-      },
-    });
+    // OUTPUTS
+    // ================
 
-    // Create a DNS record
-    new ARecord(this, "CouchDBAliasRecord", {
-      zone: props.hz,
-      recordName: props.domainName,
-      target: aws_route53.RecordTarget.fromAlias(new LoadBalancerTarget(lb)),
-    });
-
-    // TODO handle this through config
-    const debugInstancePermissions = false;
-
-    if (debugInstancePermissions) {
-      // For debugging couch instances - allow inbound traffic for SSM Instance Connect
-      couchSecurityGroup.addIngressRule(
-        Peer.anyIpv4(),
-        Port.tcp(443),
-        "Allow SSM Instance Connect"
-      );
-
-      // Add SSM Instance Connect permissions to the instance role
-      asg.role.addManagedPolicy(
-        aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "AmazonSSMManagedInstanceCore"
-        )
-      );
-    }
-
+    // Set the public endpoint for CouchDB
     this.couchEndpoint = `https://${props.domainName}:${this.exposedPort}`;
   }
 }

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -48,10 +48,13 @@ import { Queue } from "aws-cdk-lib/aws-sqs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Rule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { SharedALB } from "./networking";
 
 export interface EC2CouchDBProps {
   vpc: IVpc;
   domainName: string;
+  // Balancer to use
+  sharedALB: SharedALB;
   hz: IHostedZone;
   certificate: ICertificate;
 }

--- a/infrastructure/aws-cdk/lib/components/networking.ts
+++ b/infrastructure/aws-cdk/lib/components/networking.ts
@@ -1,10 +1,171 @@
+import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { IVpc, Vpc } from "aws-cdk-lib/aws-ec2";
+import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Construct } from "constructs";
 
-export interface FaimsNetworkingProps {}
+/**
+ * Properties for the SharedBalancers construct
+ */
+export interface SharedBalancersProps {
+  /** The VPC in which to create the ALB */
+  vpc: ec2.IVpc;
+  /** Whether the ALB should be internet-facing */
+  isPublic: boolean;
+  /** The type of subnets to place the ALB in */
+  subnetType: ec2.SubnetType;
+  /** List of SSL/TLS certificates for the HTTPS listener */
+  certificates: elb.ListenerCertificate[];
+}
 
+/**
+ * A construct that manages a shared Application Load Balancer
+ * along with its HTTP and HTTPS listeners and routing configurations.
+ */
+export class SharedBalancer extends Construct {
+  /** The default HTTPS port */
+  private readonly httpsPort: number = 443;
+  /** The default HTTP port */
+  private readonly httpPort: number = 80;
+
+  /** The Application Load Balancer instance */
+  public readonly alb: elb.ApplicationLoadBalancer;
+
+  /** The HTTPS listener for the Application Load Balancer */
+  public readonly httpsListener: elb.ApplicationListener;
+  /** The HTTP listener for the Application Load Balancer */
+  public readonly httpListener: elb.ApplicationListener;
+
+  /**
+   * Creates a new SharedBalancers instance.
+   * @param scope The scope in which to define this construct
+   * @param id The scoped construct ID
+   * @param props Configuration properties for the SharedBalancers
+   */
+  constructor(scope: Construct, id: string, props: SharedBalancersProps) {
+    super(scope, id);
+
+    // Set up the Application Load Balancer
+    this.alb = new elb.ApplicationLoadBalancer(this, "alb", {
+      vpc: props.vpc,
+      internetFacing: props.isPublic,
+      vpcSubnets: { subnetType: props.subnetType },
+    });
+
+    // Set up the HTTPS listener
+    this.httpsListener = new elb.ApplicationListener(this, "https-listener", {
+      loadBalancer: this.alb,
+      certificates: props.certificates,
+      defaultAction: elb.ListenerAction.fixedResponse(404, {
+        contentType: "text/plain",
+        messageBody:
+          "Service does not exist. Contact administrator if you believe this is an error.",
+      }),
+      port: this.httpsPort,
+    });
+
+    // Set up the HTTP listener
+    this.httpListener = new elb.ApplicationListener(this, "http-listener", {
+      loadBalancer: this.alb,
+      defaultAction: elb.ListenerAction.fixedResponse(404, {
+        contentType: "text/plain",
+        messageBody:
+          "Service does not exist. Contact administrator if you believe this is an error.",
+      }),
+      port: this.httpPort,
+    });
+  }
+
+  /**
+   * Adds certificates to the HTTPS listener
+   * @param id Unique identifier for this operation
+   * @param certificates List of certificates to add
+   */
+  addHttpsCertificates(
+    id: string,
+    certificates: elb.ListenerCertificate[]
+  ): void {
+    this.httpsListener.addCertificates(id, certificates);
+  }
+
+  /**
+   * Adds a conditional HTTPS target with HTTP redirect
+   * @param actionId Unique identifier for this action
+   * @param targetGroup The target group to forward requests to
+   * @param conditions List of conditions to match for this rule
+   * @param priority Priority of the listener rule
+   * @param httpRedirectPriority Priority of the HTTP to HTTPS redirect rule
+   */
+  addHttpRedirectedConditionalHttpsTarget(
+    actionId: string,
+    targetGroup: elb.ApplicationTargetGroup,
+    conditions: elb.ListenerCondition[],
+    priority: number,
+    httpRedirectPriority: number
+  ): void {
+    // Add the listener action on HTTPS listener
+    this.httpsListener.addAction(actionId, {
+      action: elb.ListenerAction.forward([targetGroup]),
+      conditions,
+      priority,
+    });
+
+    // Add HTTP redirect
+    this.httpListener.addAction(`${actionId}-https-redirect`, {
+      action: elb.ListenerAction.redirect({
+        permanent: true,
+        port: this.httpsPort.toString(),
+        protocol: elb.Protocol.HTTPS,
+      }),
+      conditions,
+      priority: httpRedirectPriority,
+    });
+  }
+
+  /**
+   * Adds a conditional HTTP route
+   * @param id Unique identifier for this route
+   * @param targetGroup The target group to forward requests to
+   * @param conditions List of conditions to match for this rule
+   * @param priority Priority of the listener rule
+   */
+  addConditionalHttpRoute(
+    id: string,
+    targetGroup: elb.ApplicationTargetGroup,
+    conditions: elb.ListenerCondition[],
+    priority: number
+  ): void {
+    this.httpListener.addAction(id, {
+      action: elb.ListenerAction.forward([targetGroup]),
+      conditions,
+      priority,
+    });
+  }
+}
+
+/**
+ * Properties for the FaimsNetworking construct.
+ */
+export interface FaimsNetworkingProps {
+  /** The SSL/TLS certificate to use for HTTPS connections */
+  certificate: ICertificate;
+}
+
+/**
+ * Represents the networking infrastructure for the FAIMS application.
+ */
 export class FaimsNetworking extends Construct {
-  vpc: IVpc;
+  /** The VPC where the networking resources are created */
+  public readonly vpc: IVpc;
+  /** The shared Application Load Balancer */
+  public readonly sharedBalancer: SharedBalancer;
+
+  /**
+   * Creates a new FaimsNetworking instance.
+   * @param scope The scope in which to define this construct
+   * @param id The scoped construct ID
+   * @param props Configuration properties for the FaimsNetworking
+   */
   constructor(scope: Construct, id: string, props: FaimsNetworkingProps) {
     super(scope, id);
 
@@ -12,9 +173,16 @@ export class FaimsNetworking extends Construct {
     this.vpc = new Vpc(this, "vpc", {
       // At least 2 needed for LB
       maxAzs: 2,
-
       // No need for nat gateways right now since no private subnet outbound traffic
       natGateways: 0,
+    });
+
+    // Create the shared ALB - public facing
+    this.sharedBalancer = new SharedBalancer(this, "shared-balancer", {
+      vpc: this.vpc,
+      certificates: [props.certificate],
+      isPublic: true,
+      subnetType: ec2.SubnetType.PUBLIC,
     });
   }
 }

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -18,9 +18,6 @@ export class FaimsInfraStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: FaimsInfraStackProps) {
     super(scope, id, props);
 
-    // setup network
-    const networking = new FaimsNetworking(this, "networking", {});
-
     // Setup the hosted zone so we can define domains
     const hz = HostedZone.fromHostedZoneAttributes(
       this,
@@ -28,8 +25,8 @@ export class FaimsInfraStack extends cdk.Stack {
       props.hzAttributes
     );
 
-    // Domain setups 
-    
+    // Domain setups
+
     // TODO parameterise
 
     const rootDomain = hz.zoneName;
@@ -62,6 +59,11 @@ export class FaimsInfraStack extends cdk.Stack {
       props.cloudfrontCertArn
     );
 
+    // setup network
+    const networking = new FaimsNetworking(this, "networking", {
+      certificate: primaryCert,
+    });
+
     // Currently the ini file is setup in docker - this means we need to have the JWT public key setup before hand.
     // Maybe we can do this with a custom resource? not sure - okay for now
     // TODO investigate better key setup process which allows for one click deploy
@@ -72,6 +74,7 @@ export class FaimsInfraStack extends cdk.Stack {
       certificate: primaryCert,
       domainName: fullCouchDomain,
       hz: hz,
+      sharedALB: networking.sharedALB
     });
 
     // Deploys the conductor API as a load balanced ECS service
@@ -91,6 +94,7 @@ export class FaimsInfraStack extends cdk.Stack {
       // TODO
       androidAppPublicUrl: "https://fake.com",
       iosAppPublicUrl: "https://fake.com",
+      sharedALB: networking.sharedALB
     });
 
     // Deploys the FAIMS 3 web front-end as a S3 Cloudfront static website

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -124,7 +124,5 @@ export class FaimsInfraStack extends cdk.Stack {
       designerUsEast1Certificate: cfnCert,
       conductorUrl: conductor.conductorEndpoint,
     });
-
-    // TODO: Add any additional resources or configurations as needed
   }
 }

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -1,118 +1,130 @@
 import * as cdk from "aws-cdk-lib";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import { Construct } from "constructs";
 import { FaimsConductor } from "./components/conductor";
 import { FaimsFrontEnd } from "./components/front-end";
 import { FaimsNetworking } from "./components/networking";
-import { HostedZone, HostedZoneAttributes } from "aws-cdk-lib/aws-route53";
-import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { EC2CouchDB } from "./components/couch-db";
 
+/**
+ * Properties for the FaimsInfraStack
+ */
 export interface FaimsInfraStackProps extends cdk.StackProps {
-  hzAttributes: HostedZoneAttributes;
+  /** Attributes of the hosted zone to use */
+  hzAttributes: route53.HostedZoneAttributes;
+  /** ARN of the primary SSL/TLS certificate */
   primaryCertArn: string;
+  /** ARN of the CloudFront SSL/TLS certificate */
   cloudfrontCertArn: string;
+  /** ARN of the public key secret */
   publicKeySecretArn: string;
+  /** ARN of the private key secret */
   privateKeySecretArn: string;
 }
+
+/**
+ * Main infrastructure stack for the FAIMS application
+ */
 export class FaimsInfraStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: FaimsInfraStackProps) {
     super(scope, id, props);
 
-    // Setup the hosted zone so we can define domains
-    const hz = HostedZone.fromHostedZoneAttributes(
+    // DNS SETUP
+    // =========
+
+    // Setup the hosted zone for domain definitions
+    const hz = route53.HostedZone.fromHostedZoneAttributes(
       this,
       "hz",
       props.hzAttributes
     );
 
-    // Domain setups
-
-    // TODO parameterise
-
+    // Domain configurations
+    // TODO: Parameterize these domain configurations
     const rootDomain = hz.zoneName;
+    const domains = {
+      couch: `couchdb.${rootDomain}`,
+      conductor: `conductor.${rootDomain}`,
+      web: `faims.${rootDomain}`,
+      designer: `designer.${rootDomain}`,
+    };
 
-    // Couch
-    const couchSubDomain = "couchdb";
-    const fullCouchDomain = `${couchSubDomain}.${rootDomain}`;
+    // CERTIFICATES
+    // ============
 
-    // Conductor
-    const conductorSubDomain = "conductor";
-    const fullConductorDomain = `${conductorSubDomain}.${rootDomain}`;
-
-    // FAIMS web app
-    const webSubDomain = "faims";
-    const fullWebDomain = `${webSubDomain}.${rootDomain}`;
-
-    // FAIMS designer
-    const designerSubDomain = "designer";
-    const fullDesignerDomain = `${designerSubDomain}.${rootDomain}`;
-
-    // Certificate for hz
-    const primaryCert = Certificate.fromCertificateArn(
+    // Primary certificate for the hosted zone
+    const primaryCert = acm.Certificate.fromCertificateArn(
       this,
       "primary-cert",
       props.primaryCertArn
     );
-    const cfnCert = Certificate.fromCertificateArn(
+
+    // CloudFront certificate
+    const cfnCert = acm.Certificate.fromCertificateArn(
       this,
       "cfn-cert",
       props.cloudfrontCertArn
     );
 
-    // setup network
+    // NETWORKING
+    // ==========
+
+    // Setup networking infrastructure
     const networking = new FaimsNetworking(this, "networking", {
       certificate: primaryCert,
     });
 
-    // Currently the ini file is setup in docker - this means we need to have the JWT public key setup before hand.
-    // Maybe we can do this with a custom resource? not sure - okay for now
-    // TODO investigate better key setup process which allows for one click deploy
+    // COUCHDB
+    // =======
 
-    // Creates a single EC2 cluster which runs CouchDB
+    // Create a single EC2 cluster which runs CouchDB
+    // TODO: Investigate better key setup process for one-click deploy
     const couchDb = new EC2CouchDB(this, "couch-db", {
       vpc: networking.vpc,
       certificate: primaryCert,
-      domainName: fullCouchDomain,
+      domainName: domains.couch,
       hz: hz,
-      sharedALB: networking.sharedALB
+      sharedBalancer: networking.sharedBalancer,
     });
 
-    // Deploys the conductor API as a load balanced ECS service
+    // CONDUCTOR
+    // =========
+
+    // Deploy the conductor API as a load balanced ECS service
     const conductor = new FaimsConductor(this, "conductor", {
       vpc: networking.vpc,
-      // 1 vcpu 2 gb ram
-      cpu: 1024,
-      memory: 2048,
+      cpu: 1024, // 1 vCPU
+      memory: 2048, // 2 GB RAM
       certificate: primaryCert,
-      domainName: fullConductorDomain,
+      domainName: domains.conductor,
       privateKeySecretArn: props.privateKeySecretArn,
       hz: hz,
       couchDbAdminSecret: couchDb.passwordSecret,
       couchDBEndpoint: couchDb.couchEndpoint,
       couchDBPort: couchDb.exposedPort,
-      webAppPublicUrl: `https://${fullWebDomain}`,
-      // TODO
-      androidAppPublicUrl: "https://fake.com",
-      iosAppPublicUrl: "https://fake.com",
-      sharedALB: networking.sharedALB
+      webAppPublicUrl: `https://${domains.web}`,
+      androidAppPublicUrl: "https://fake.com", // TODO: Update with real URL
+      iosAppPublicUrl: "https://fake.com", // TODO: Update with real URL
+      sharedBalancer: networking.sharedBalancer,
     });
 
-    // Deploys the FAIMS 3 web front-end as a S3 Cloudfront static website
-    const frontEnd = new FaimsFrontEnd(this, "frontend", {
-      // CouchDB config
-      couchDbDomainOnly: fullCouchDomain,
-      couchDbPort: couchDb.exposedPort,
+    // FRONT-END
+    // =========
 
-      // Main faims frontend
-      faimsDomainNames: [fullWebDomain],
+    // Deploy the FAIMS 3 web front-end as a S3 CloudFront static website
+    const frontEnd = new FaimsFrontEnd(this, "frontend", {
+      couchDbDomainOnly: domains.couch,
+      couchDbPort: couchDb.exposedPort,
+      faimsDomainNames: [domains.web],
       faimsHz: hz,
       faimsUsEast1Certificate: cfnCert,
-
-      // Designer faims frontend
-      designerDomainNames: [fullDesignerDomain],
+      designerDomainNames: [domains.designer],
       designerHz: hz,
       designerUsEast1Certificate: cfnCert,
       conductorUrl: conductor.conductorEndpoint,
     });
+
+    // TODO: Add any additional resources or configurations as needed
   }
 }


### PR DESCRIPTION
# feat: BSS-203 consolidate application load balancers

## JIRA 

[BSS-203](https://jira.csiro.au/browse/BSS-203)

## Description 

Consolidates the two application load balancers into one. Uses target groups with domain name conditions to handle routing to the correct target group. Adds HTTP redirect (try this in browser and you'll see auto redirect to https e.g. http://faims.bss.nbic.cloud/ ). 

## Purpose

Save costs by reducing redundancy in load balancers. HTTP is not suitable for our application so automatically redirecting is good for users to transparently use the correct protocol.

## Notes for reviewer

See our deployment (contact dev for URL if needed) - this is deployed with updated version. Check conductor and couch endpoints operate properly. Test HTTP redirect. 

## TODOs

https://jira.csiro.au/browse/BSS-219 (update priority configuration) 
https://jira.csiro.au/browse/BSS-218 (fix issue with 404 on page refresh non root route)