### PR TITLE
feat: BSS-220 Implement monitoring, dashboard, alarming and logging for EC2 Couch instance

### DIFF
--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -21,7 +21,7 @@ The `EC2CouchDB` construct deploys CouchDB:
 
 - **EC2 Instance**: Runs a single EC2 instance with CouchDB.
 - **User Data**: Installs and configures CouchDB using Docker. Runs Docker command as systemd service. Mounts EBS for couch data and mounts into docker container.
-- **Cloud Watch**: Includes a set of monitoring alarms triggering SNS topics, subscribed to an email address.
+- **Cloud Watch**: Includes a set of monitoring alarms triggering SNS topics, subscribed to an email address. Cloudwatch agent is installed and configured on instance. Logs collected and reported to /ec2/couchdb log stream.
 - **Secrets Manager**: Stores CouchDB admin credentials.
 - **Custom Configuration**: Sets up CouchDB with specific settings, including CORS and authentication handlers.
 - **Load Balancer Integration**: Uses the shared ALB with a dedicated target group. Will support clustering in the future and performs TLS termination.

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -130,12 +130,12 @@ Note: The values provided above are examples. Replace them with your actual valu
 
 Here's a breakdown of each configuration value and its purpose:
 
-- hostedZone - used for deploying route 53 routes in AWS
+- hostedZone - used for deploying Route 53 routes in AWS
   - id: The ID of your Route 53 hosted zone
   - name: The domain name of your hosted zone
 - certificates
-  - primary: ARN of your primary ACM certificate (must support \*.base.domain)
-  - cloudfront: ARN of your CloudFront ACM certificate (must be in us-east-1) (must support \*.base.domain)
+  - primary: ARN of your primary ACM certificate (must support *.base.domain)
+  - cloudfront: ARN of your CloudFront ACM certificate (must be in us-east-1) (must support *.base.domain)
 - aws
   - account: Your AWS account ID
   - region: The AWS region for deployment (e.g., ap-southeast-2 for Sydney) - defaults to ap-southeast-2
@@ -149,7 +149,23 @@ Here's a breakdown of each configuration value and its purpose:
 - couch
   - volumeSize: The size in GB of the EBS volume to mount to the EC2 instance
   - ebsRecoverySnapshotId: (Optional) The ID of an EBS snapshot to recover the couch data volume from
-  - criticalAlertsEmail: (Optional) The email address to send couchDB SNS alerts too
+  - monitoring: (Optional) Configuration for CouchDB monitoring alarms
+    - cpu: (Optional) CPU utilization alarm settings
+      - threshold: Percentage threshold for CPU utilization (0-100)
+      - evaluationPeriods: Number of periods to evaluate before triggering alarm
+      - datapointsToAlarm: Number of datapoints that must be breaching to trigger alarm
+    - memory: (Optional) Memory usage alarm settings (same structure as cpu)
+    - disk: (Optional) Disk usage alarm settings (same structure as cpu)
+    - statusCheck: (Optional) EC2 status check alarm settings
+      - evaluationPeriods: Number of periods to evaluate before triggering alarm
+      - datapointsToAlarm: Number of datapoints that must be breaching to trigger alarm
+    - networkIn: (Optional) Network in alarm settings (same structure as cpu, but threshold in bytes)
+    - networkOut: (Optional) Network out alarm settings (same structure as cpu, but threshold in bytes)
+    - http5xx: (Optional) HTTP 5xx errors alarm settings (same structure as cpu, but threshold is count of errors)
+    - alarmTopic: (Optional) SNS topic settings for alarms
+      - emailAddress: Email address to send alarm notifications
+
+NOTE: All monitoring settings are optional. If not provided, default values will be used. The alarmTopic emailAddress, if provided, will receive notifications for all configured alarms.
 
 ### Using Your Configuration
 

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -24,6 +24,44 @@
     "couch": {
         "volumeSize": 100,
         "ebsRecoverySnapshotId": "1234",
-        "criticalAlertsEmail": "fake@gmail.com"
+        "monitoring": {
+            "cpu": {
+                "threshold": 80,
+                "evaluationPeriods": 3,
+                "datapointsToAlarm": 2
+            },
+            "memory": {
+                "threshold": 85,
+                "evaluationPeriods": 3,
+                "datapointsToAlarm": 2
+            },
+            "disk": {
+                "threshold": 80,
+                "evaluationPeriods": 3,
+                "datapointsToAlarm": 2
+            },
+            "statusCheck": {
+                "evaluationPeriods": 2,
+                "datapointsToAlarm": 2
+            },
+            "networkIn": {
+                "threshold": 10000000,
+                "evaluationPeriods": 3,
+                "datapointsToAlarm": 2
+            },
+            "networkOut": {
+                "threshold": 10000000,
+                "evaluationPeriods": 3,
+                "datapointsToAlarm": 2
+            },
+            "http5xx": {
+                "threshold": 10,
+                "evaluationPeriods": 5,
+                "datapointsToAlarm": 3
+            },
+            "alarmTopic": {
+                "emailAddress": "fake@gmail.com"
+            }
+        }
     }
 }

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -23,6 +23,7 @@
     },
     "couch": {
         "volumeSize": 100,
-        "ebsRecoverySnapshotId": "1234"
+        "ebsRecoverySnapshotId": "1234",
+        "criticalAlertsEmail": "fake@gmail.com"
     }
 }

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -471,6 +471,7 @@ EOL`,
         metricName: "disk_used_percent",
         dimensionsMap: {
           InstanceId: this.instance.instanceId,
+          // NOTE: It might be worth considering couch DB data volume being reported / alarmed separately
           path: "/",
         },
         statistic: "Average",

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -204,7 +204,7 @@ methods = GET, PUT, POST, HEAD, DELETE
             ],
             "metrics_collection_interval":60,
             "resources":[
-               "*"
+               "/"
             ]
          },
          "diskio":{
@@ -528,7 +528,6 @@ EOL`,
         metricName: "disk_used_percent",
         dimensionsMap: {
           InstanceId: this.instance.instanceId,
-          path: "/",
         },
         statistic: "Average",
         period: Duration.minutes(5),
@@ -696,7 +695,7 @@ EOL`,
           new Metric({
             namespace: "CWAgent",
             metricName: "disk_used_percent",
-            dimensionsMap: { InstanceId: instanceId, path: "/" },
+            dimensionsMap: { InstanceId: instanceId },
             statistic: "Average",
             period: Duration.minutes(5),
           }),

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -82,7 +82,7 @@ export class EC2CouchDB extends Construct {
   private readonly alarmSNSTopic: sns.Topic;
   /** The monitoring config */
   private readonly monitoringConfig?: MonitoringConfig;
-  /** Path to AWS cloud watch agent config */
+  /** Path to AWS cloud watch agent config - be sure to prefix with file:*/
   private readonly awsCloudWatchAgentConfigPath =
     "/opt/aws/amazon-cloudwatch-agent/bin/config.json";
 
@@ -164,7 +164,7 @@ methods = GET, PUT, POST, HEAD, DELETE
 
       // Configure CloudWatch agent to collect disk usage and memory usage -
       // publish 60 second interval
-      `cat > ${this.awsCloudWatchAgentConfigPath} <<EOL`,
+      `cat > ${this.awsCloudWatchAgentConfigPath} <<'EOL'`,
       `
 {
    "agent":{
@@ -235,15 +235,15 @@ methods = GET, PUT, POST, HEAD, DELETE
       "EOL",
 
       // Validate and load config
-      `/opt/aws/amazon-cloudwatch-agent/amazon-cloudwatch-agent-ctl -m ec2 -a fetch-config -c ${this.awsCloudWatchAgentConfigPath}`,
+      `/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a fetch-config -c file:${this.awsCloudWatchAgentConfigPath}`,
 
       // Start the service (this creates auto start systemd service)
-      `/opt/aws/amazon-cloudwatch-agent/amazon-cloudwatch-agent-ctl -m ec2 -a start -c ${this.awsCloudWatchAgentConfigPath}`,
+      `/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start -c file:${this.awsCloudWatchAgentConfigPath}`,
 
       // Run CouchDB with docker service
       "systemctl start docker",
       "systemctl enable docker",
-      `docker pull ${this.couchVersionTag}`,
+      `docker pull couchdb:${this.couchVersionTag}`,
 
       // Set environment variables
       `SECRET_ARN=${this.passwordSecret.secretArn}`,

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -69,6 +69,8 @@ const ConfigSchema = z.object({
     volumeSize: z.number(),
     /** The ID of EBS snapshot to recover from in the root device (optional) */
     ebsRecoverySnapshotId: z.string().optional(),
+    /** The email address to subscribe alerts SNS topic too */
+    criticalAlertsEmail: z.string().optional(),
   }),
   backup: BackupConfigSchema,
 });
@@ -180,6 +182,7 @@ export class FaimsInfraStack extends cdk.Stack {
       sharedBalancer: networking.sharedBalancer,
       dataVolumeSize: config.couch.volumeSize,
       dataVolumeSnapshotId: config.couch.ebsRecoverySnapshotId,
+      criticalAlertsEmail: config.couch.criticalAlertsEmail
     });
 
     // CONDUCTOR

--- a/infrastructure/aws-cdk/package.json
+++ b/infrastructure/aws-cdk/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && npm run build-src",
     "build-src": "cd src && npm install && npm run build",
     "package": "cd src && npm run package",
-    "init-api": "CONFIG_FILE_NAME=${CONFIG_FILE_NAME:-configs/dev.json} && curl -X POST https://conductor.$(jq -r .hostedZone.name < \"${CONFIG_FILE_NAME}\")/api/initialise",
+    "init-api": "CONFIG_FILE_NAME=${CONFIG_FILE_NAME:-dev.json} && curl -X POST https://conductor.$(jq -r .hostedZone.name < \"configs/${CONFIG_FILE_NAME}\")/api/initialise",
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk"

--- a/infrastructure/aws-cdk/package.json
+++ b/infrastructure/aws-cdk/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && npm run build-src",
     "build-src": "cd src && npm install && npm run build",
     "package": "cd src && npm run package",
+    "init-api": "CONFIG_FILE_NAME=${CONFIG_FILE_NAME:-configs/dev.json} && curl -X POST https://conductor.$(jq -r .hostedZone.name < \"${CONFIG_FILE_NAME}\")/api/initialise",
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk"


### PR DESCRIPTION
# feat: BSS-220 Implement monitoring, dashboard, alarming and logging for EC2 Couch instance

## JIRA 

[BSS-220](https://jira.csiro.au/browse/BSS-220)

## Description

- Installs cloud watch agent onto instance in user data
- Collects logs from mounted data volume at `data_path/couch.log`
- Reports system metrics using cloud watch agent, then adds
  -  Dashboard to visualise
  - Alarms for configurable thresholds for key metrics
  - Subscription to email alerts for alarming state
-  Adds init-api command to package.json to quickly curl the initialise endpoint

## Notes for reviewer

- Deployment should be up to date soon
- Might need to clear application storage due to redeployment

### Dashboard and metrics collection screenshot

![image](https://github.com/user-attachments/assets/6e6d5750-bde2-4515-a7f1-748a1079a5e0)

### Logs screenshot

<img width="587" alt="image" src="https://github.com/user-attachments/assets/7cfe99f8-e60a-4049-a8c3-b81c57c78242">
