### PR TITLE
build: publish to github container registry

### DIFF
--- a/.github/workflows/publish-conductor.yml
+++ b/.github/workflows/publish-conductor.yml
@@ -50,6 +50,7 @@ jobs:
             type=ref,event=branch
             type=raw,value={{date 'YYYYMMDD'}}-{{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/publish-conductor.yml
+++ b/.github/workflows/publish-conductor.yml
@@ -12,7 +12,7 @@ on:
 # image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: faims-api
+  IMAGE_NAME: FAIMS/faims3-api
 
 jobs:
   build-and-push:

--- a/.github/workflows/publish-conductor.yml
+++ b/.github/workflows/publish-conductor.yml
@@ -1,14 +1,26 @@
-name: Publish Conductor API to DockerHub
+name: Publish Conductor API Container to GHCR
 on:
   push:
     branches:
       - main
+      - publish-to-ghcr
   release:
     types: [published]
+
+# Defines two custom environment variables for the workflow. These are
+# used for the Container registry domain, and a name for the Docker
+# image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: faims-api
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,17 +30,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      # Uses the `docker/login-action` action to log in to the Container registry
+      # using the account and password that will publish the packages.
+      # Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKERHUB_REPOSITORY }}/faims3-api-test
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=sha-
             type=ref,event=branch

--- a/.github/workflows/publish-conductor.yml
+++ b/.github/workflows/publish-conductor.yml
@@ -48,7 +48,6 @@ jobs:
           tags: |
             type=sha,prefix=sha-
             type=ref,event=branch
-            type=semver,pattern={{version}}
             type=raw,value={{date 'YYYYMMDD'}}-{{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
 

--- a/.github/workflows/publish-conductor.yml
+++ b/.github/workflows/publish-conductor.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - publish-to-ghcr
   release:
     types: [published]
 
@@ -51,6 +50,7 @@ jobs:
             type=raw,value={{date 'YYYYMMDD'}}-{{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
+
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/api/BuildDockerfile
+++ b/api/BuildDockerfile
@@ -79,6 +79,9 @@ COPY --from=installer /app/library/data-model/node_modules ./library/data-model/
 
 # Build for API
 COPY --from=installer /app/api/build ./api/build
+# Copy handle bar views into appropriate build path
+# TODO set the app root directory better and build into build process more nicely
+COPY --from=installer /app/api/views ./views
 # Build for data model
 COPY --from=installer /app/library/data-model/build ./library/data-model/build
 


### PR DESCRIPTION
# build: publish to github container registry

## description

Merges updated work on the docker publish process with existing `api/.github/workflows/docker-image` workflow. Publishes to the GitHub container registry instead of DockerHub. 

Also fixes an issue where the `views` directory was inaccessible within the published API docker image. Fixes by copying into the appropriate location (though it's a little hacky). 

See actions for successful build. I have also confirmed the image is working on a deployment.