### PR TITLE
Reusable dialog component and enhacements

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,12 +18,7 @@
  *   TODO
  */
 
-import {
-  BrowserRouter as Router,
-  Route,
-  Routes,
-  Navigate,
-} from 'react-router-dom';
+import {BrowserRouter as Router, Route, Routes} from 'react-router-dom';
 import './App.css';
 import * as ROUTES from './constants/routes';
 import {PrivateRoute} from './constants/privateRouter';

--- a/app/src/gui/components/notebook/settings/activation-switch.tsx
+++ b/app/src/gui/components/notebook/settings/activation-switch.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Button, Box, Typography } from '@mui/material';
-import LoadingButton from '@mui/lab/LoadingButton';
 import InfoIcon from '@mui/icons-material/Info';
 import { ProjectInformation } from '@faims3/data-model';
 import { NOTEBOOK_NAME } from '../../../../buildconfig';
@@ -41,17 +40,31 @@ export default function NotebookActivationSwitch({
       </Button>
       <ReusableDialog
         open={open}
-        title="Are you sure?"
+        title="Activating / Deactivating surveys"
         icon={<InfoIcon style={{ fontSize: 40, color: '#1976d2' }} />}
         onClose={handleClose}
         onPrimaryAction={handleActivationClick}
         primaryActionText="Activate"
         primaryActionLoading={isWorking}
+        primaryActionColor="primary"
+        primaryActionVariant="contained"
         cancelButtonText="Cancel"
       >
         <Box mb={2}>
+          <Typography variant="subtitle1" fontWeight="bold">
+            Activating a survey:
+          </Typography>
+          <Typography variant="body2" paragraph>
+            • When a survey is “Active” you are safe to work offline at any point because all the data is saved to your device.
+          </Typography>
+          <Typography variant="body2" paragraph>
+            • Before going out in the field you must ‘Activate’ your survey by pressing the  button “Activate" and selecting which survey(s) you want to be available while out in the field.
+          </Typography>
+          <Typography variant="subtitle1" fontWeight="bold">
+            Deactivating a survey:
+          </Typography>
           <Typography variant="body2">
-            Do you want to start syncing the {project.name} {NOTEBOOK_NAME} to your device?
+            • This can be helpful when you need to free up space on your device and when you no longer need access to surveys or survey data offline.
           </Typography>
         </Box>
       </ReusableDialog>

--- a/app/src/gui/components/notebook/settings/activation-switch.tsx
+++ b/app/src/gui/components/notebook/settings/activation-switch.tsx
@@ -1,76 +1,60 @@
-import React from 'react';
-import {Alert, Box, AlertTitle, Button} from '@mui/material';
+import React, { useState } from 'react';
+import { Button, Box, Typography } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
-import {ProjectInformation} from '@faims3/data-model';
-import DialogActions from '@mui/material/DialogActions';
-
-import Dialog from '@mui/material/Dialog';
-import {NOTEBOOK_NAME} from '../../../../buildconfig';
+import InfoIcon from '@mui/icons-material/Info';
+import { ProjectInformation } from '@faims3/data-model';
+import { NOTEBOOK_NAME } from '../../../../buildconfig';
+import ReusableDialog from '../../ui/Reusable_Dialog';
 
 type NotebookActivationSwitchProps = {
   project: ProjectInformation;
   project_status: string | undefined;
-  handleActivation: Function;
+  handleActivation: () => void;
   isWorking: boolean;
 };
 
-export default function NotebookActivationSwitch(
-  props: NotebookActivationSwitchProps
-) {
-  const [open, setOpen] = React.useState(false);
-  const handleOpen = () => {
-    setOpen(true);
+export default function NotebookActivationSwitch({
+  project,
+  handleActivation,
+  isWorking,
+}: NotebookActivationSwitchProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const handleActivationClick = () => {
+    handleActivation(); // Trigger the activation process
+    handleClose();      // Close the dialog
   };
 
-  const handleClose = () => {
-    setOpen(false);
-  };
   return (
     <Box my={1}>
       <Button
         onClick={handleOpen}
-        color={'primary'}
-        size={'small'}
-        variant={'outlined'}
-        disableElevation={true}
+        color="primary"
+        size="small"
+        variant="outlined"
+        disableElevation
       >
         Activate
       </Button>
-      <Dialog
+      <ReusableDialog
         open={open}
+        title="Are you sure?"
+        icon={<InfoIcon style={{ fontSize: 40, color: '#1976d2' }} />}
         onClose={handleClose}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
+        onPrimaryAction={handleActivationClick}
+        primaryActionText="Activate"
+        primaryActionLoading={isWorking}
+        cancelButtonText="Cancel"
       >
-        <Alert severity={'info'}>
-          <AlertTitle>Are you sure?</AlertTitle>
-          Do you want to start syncing the {props.project.name} {NOTEBOOK_NAME}{' '}
-          to your device?
-        </Alert>
-        <DialogActions style={{justifyContent: 'space-between'}}>
-          <Button onClick={handleClose} autoFocus color={'primary'}>
-            Cancel
-          </Button>
-
-          {props.isWorking ? (
-            <LoadingButton loading variant="outlined" size={'small'}>
-              Activating...
-            </LoadingButton>
-          ) : (
-            <Button
-              size={'small'}
-              variant="contained"
-              disableElevation
-              color={'primary'}
-              onClick={() => {
-                props.handleActivation();
-              }}
-            >
-              Activate
-            </Button>
-          )}
-        </DialogActions>
-      </Dialog>
+        <Box mb={2}>
+          <Typography variant="body2">
+            Do you want to start syncing the {project.name} {NOTEBOOK_NAME} to your device?
+          </Typography>
+        </Box>
+      </ReusableDialog>
     </Box>
   );
 }

--- a/app/src/gui/components/notebook/settings/activation-switch.tsx
+++ b/app/src/gui/components/notebook/settings/activation-switch.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
-import { Button, Box, Typography } from '@mui/material';
+import React, {useState} from 'react';
+import {Button, Box, Typography} from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import { ProjectInformation } from '@faims3/data-model';
-import { NOTEBOOK_NAME } from '../../../../buildconfig';
-import ReusableDialog from '../../ui/Reusable_Dialog';
+import {ProjectInformation} from '@faims3/data-model';
+import FaimsDialog from '../../ui/Faims_Dialog';
 
 type NotebookActivationSwitchProps = {
   project: ProjectInformation;
@@ -13,7 +12,6 @@ type NotebookActivationSwitchProps = {
 };
 
 export default function NotebookActivationSwitch({
-  project,
   handleActivation,
   isWorking,
 }: NotebookActivationSwitchProps) {
@@ -24,7 +22,7 @@ export default function NotebookActivationSwitch({
 
   const handleActivationClick = () => {
     handleActivation(); // Trigger the activation process
-    handleClose();      // Close the dialog
+    handleClose(); // Close the dialog
   };
 
   return (
@@ -38,10 +36,10 @@ export default function NotebookActivationSwitch({
       >
         Activate
       </Button>
-      <ReusableDialog
+      <FaimsDialog
         open={open}
         title="Activating / Deactivating surveys"
-        icon={<InfoIcon style={{ fontSize: 40, color: '#1976d2' }} />}
+        icon={<InfoIcon style={{fontSize: 40, color: '#1976d2'}} />}
         onClose={handleClose}
         onPrimaryAction={handleActivationClick}
         primaryActionText="Activate"
@@ -55,19 +53,24 @@ export default function NotebookActivationSwitch({
             Activating a survey:
           </Typography>
           <Typography variant="body2" paragraph>
-            • When a survey is “Active” you are safe to work offline at any point because all the data is saved to your device.
+            • When a survey is “Active” you are safe to work offline at any
+            point because all the data is saved to your device.
           </Typography>
           <Typography variant="body2" paragraph>
-            • Before going out in the field you must ‘Activate’ your survey by pressing the  button “Activate" and selecting which survey(s) you want to be available while out in the field.
+            • Before going out in the field you must ‘Activate’ your survey by
+            pressing the button “Activate" and selecting which survey(s) you
+            want to be available while out in the field.
           </Typography>
           <Typography variant="subtitle1" fontWeight="bold">
             Deactivating a survey:
           </Typography>
           <Typography variant="body2">
-            • This can be helpful when you need to free up space on your device and when you no longer need access to surveys or survey data offline.
+            • This can be helpful when you need to free up space on your device
+            and when you no longer need access to surveys or survey data
+            offline.
           </Typography>
         </Box>
-      </ReusableDialog>
+      </FaimsDialog>
     </Box>
   );
 }

--- a/app/src/gui/components/ui/Faims_Attachment_Manager_Dialog.test.tsx
+++ b/app/src/gui/components/ui/Faims_Attachment_Manager_Dialog.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import {render, screen} from '@testing-library/react';
-import FaimsDialog from './Dialog';
+import FaimsAttachmentManagerDialog from './Faims_Attachment_Manager_Dialog';
 import {expect, vi, describe, it} from 'vitest';
 
 const testData = {
@@ -30,7 +30,7 @@ const testData = {
 
 describe('Check dialog component', () => {
   it('Check with path', () => {
-    render(<FaimsDialog {...testData} path={'test-path'} />);
+    render(<FaimsAttachmentManagerDialog {...testData} path={'test-path'} />);
 
     expect(screen.getByTestId('dialog-img')).toBeTruthy();
   });

--- a/app/src/gui/components/ui/Faims_Attachment_Manager_Dialog.tsx
+++ b/app/src/gui/components/ui/Faims_Attachment_Manager_Dialog.tsx
@@ -40,8 +40,7 @@ type DiagProps = {
   path?: string | null;
   isSyncing?: string;
 };
-export default function FaimsDialog(props: DiagProps) {
-  //   const [open, setOpen] = React.useState(props.open??false);
+export default function FaimsAttachmentManagerDialog(props: DiagProps) {
   const {open, setopen, project_id, path, isSyncing} = props;
 
   return (

--- a/app/src/gui/components/ui/Faims_Dialog.tsx
+++ b/app/src/gui/components/ui/Faims_Dialog.tsx
@@ -13,8 +13,8 @@
  * See, the License, for the specific language governing permissions and
  * limitations under the License.
  *
- * Filename: Reusable_Dialog.tsx
- * Description: ReusableDialog is a customizable dialog component that provides
+ * Filename: FaimsDialog.tsx
+ * Description: FaimsDialog is a customizable dialog component that provides
  * a consistent layout for dialogs/popus across the application.
  */
 import React from 'react';
@@ -31,7 +31,7 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
-type ReusableDialogProps = {
+type FaimsDialogProps = {
   open: boolean;
   title: string;
   icon?: React.ReactNode;
@@ -61,7 +61,7 @@ type ReusableDialogProps = {
  * @param {string} [cancelButtonText='Cancel'] - The text displayed on the cancel button.
  */
 
-export default function ReusableDialog({
+export default function FaimsDialog({
   open,
   title,
   icon,
@@ -73,7 +73,7 @@ export default function ReusableDialog({
   primaryActionColor = 'primary',
   primaryActionVariant = 'contained',
   cancelButtonText = 'Cancel',
-}: ReusableDialogProps) {
+}: FaimsDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle style={{textAlign: 'center', paddingBottom: 0}}>

--- a/app/src/gui/components/ui/Reusable_Dialog.tsx
+++ b/app/src/gui/components/ui/Reusable_Dialog.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: Reusable_Dialog.tsx
+ * Description: ReusableDialog is a customizable dialog component that provides
+ * a consistent layout for dialogs/popus across the application.
+ */
+import React from 'react';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+  Button,
+  Divider,
+  Box,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+type ReusableDialogProps = {
+  open: boolean;
+  title: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  onClose: () => void;
+  onPrimaryAction: () => void;
+  primaryActionText: string;
+  primaryActionLoading?: boolean;
+  primaryActionColor?: 'primary' | 'secondary' | 'error';
+  primaryActionVariant?: 'contained' | 'outlined';
+  cancelButtonText?: string;
+};
+
+/**
+
+ *
+ * @param {boolean} open - Controls whether the dialog is open or closed.
+ * @param {string} title - The title displayed at the top of the dialog.
+ * @param {React.ReactNode} [icon] - Optional icon displayed above the title.
+ * @param {React.ReactNode} children - The content of the dialog.
+ * @param {Function} onClose - Callback function to handle the closing of the dialog.
+ * @param {Function} onPrimaryAction - Callback function for the primary action button.
+ * @param {string} primaryActionText - The text displayed on the primary action button.
+ * @param {boolean} [primaryActionLoading=false] - Controls the loading state of the primary action button.
+ * @param {'primary' | 'secondary' | 'error'} [primaryActionColor='primary'] - Color of the primary action button.
+ * @param {'contained' | 'outlined'} [primaryActionVariant='contained'] - Variant of the primary action button.
+ * @param {string} [cancelButtonText='Cancel'] - The text displayed on the cancel button.
+ */
+
+export default function ReusableDialog({
+  open,
+  title,
+  icon,
+  children,
+  onClose,
+  onPrimaryAction,
+  primaryActionText,
+  primaryActionLoading = false,
+  primaryActionColor = 'primary',
+  primaryActionVariant = 'contained',
+  cancelButtonText = 'Cancel',
+}: ReusableDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle style={{ textAlign: 'center', paddingBottom: 0 }}>
+        <Box display="flex" justifyContent="center">
+          {icon && (
+            <Box mb={2}>
+              {icon}
+            </Box>
+          )}
+        </Box>
+        <Typography variant="h6" style={{ fontWeight: 'bold' }}>
+          {title}
+        </Typography>
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          style={{ position: 'absolute', top: 8, right: 8 }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <Divider />
+      <DialogContent>
+        {children}
+      </DialogContent>
+      <DialogActions style={{ justifyContent: 'space-between', padding: '8px' }}>
+        <Button onClick={onClose} color="primary">
+          {cancelButtonText}
+        </Button>
+        <Button
+          variant={primaryActionVariant}
+          color={primaryActionColor}
+          onClick={onPrimaryAction}
+          disabled={primaryActionLoading}
+        >
+          {primaryActionText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/src/gui/components/ui/Reusable_Dialog.tsx
+++ b/app/src/gui/components/ui/Reusable_Dialog.tsx
@@ -76,30 +76,33 @@ export default function ReusableDialog({
 }: ReusableDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle style={{ textAlign: 'center', paddingBottom: 0 }}>
-        <Box display="flex" justifyContent="center">
-          {icon && (
-            <Box mb={2}>
-              {icon}
-            </Box>
-          )}
+      <DialogTitle style={{textAlign: 'center', paddingBottom: 0}}>
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexDirection="column"
+          mb={2}
+        >
+          {icon && <Box mb={1}>{icon}</Box>}
+          <Typography
+            variant="h4"
+            style={{fontWeight: 'bold', textAlign: 'center'}}
+          >
+            {title}
+          </Typography>
         </Box>
-        <Typography variant="h6" style={{ fontWeight: 'bold' }}>
-          {title}
-        </Typography>
         <IconButton
           aria-label="close"
           onClick={onClose}
-          style={{ position: 'absolute', top: 8, right: 8 }}
+          style={{position: 'absolute', top: 8, right: 8}}
         >
           <CloseIcon />
         </IconButton>
       </DialogTitle>
       <Divider />
-      <DialogContent>
-        {children}
-      </DialogContent>
-      <DialogActions style={{ justifyContent: 'space-between', padding: '8px' }}>
+      <DialogContent>{children}</DialogContent>
+      <DialogActions style={{justifyContent: 'space-between', padding: '8px'}}>
         <Button onClick={onClose} color="primary">
           {cancelButtonText}
         </Button>

--- a/app/src/gui/fields/FileUploader.tsx
+++ b/app/src/gui/fields/FileUploader.tsx
@@ -34,13 +34,10 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import {IconButton} from '@mui/material';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import ImageIcon from '@mui/icons-material/Image';
-import FaimsDialog from '../components/ui/Dialog';
-// import {FAIMSAttachmentReference} from '@faims3/data-model';
+import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 interface Props {
   label?: string;
-  accepted_filetypes?: string | string[];
   disabled?: boolean;
   multiple?: boolean;
   maximum_number_of_files?: number;
@@ -52,7 +49,6 @@ interface Props {
 }
 
 export function FileUploader(props: FieldProps & Props) {
-  const accepted_filetypes = props.accepted_filetypes ?? 'image/*';
   const disabled = props.disabled ?? false;
   const multiple = props.multiple ?? true;
   const maximum_number_of_files = props.maximum_number_of_files ?? 0;
@@ -99,7 +95,6 @@ export function FileUploader(props: FieldProps & Props) {
       </Typography>
       {props.disabled !== true && (
         <Dropzone
-          // accept={accepted_filetypes}
           disabled={disabled}
           multiple={multiple}
           maxFiles={maximum_number_of_files}
@@ -188,7 +183,7 @@ export function FileUploader(props: FieldProps & Props) {
       <Typography variant="caption" color="textSecondary">
         {props.helperText}
       </Typography>
-      <FaimsDialog
+      <FaimsAttachmentManagerDialog
         project_id={props.form.values['_project_id']}
         open={open}
         setopen={() => setopen(false)}

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -28,12 +28,12 @@ import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
 import IconButton from '@mui/material/IconButton';
 import ImageIcon from '@mui/icons-material/Image';
-import FaimsDialog from '../components/ui/Dialog';
 import {Typography} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {createTheme, styled} from '@mui/material/styles';
 import {List, ListItem} from '@mui/material';
 import {logError} from '../../logging';
+import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
 
 function base64image_to_blob(image: Photo): Blob {
   if (image.base64String === undefined) {
@@ -317,7 +317,7 @@ export class TakePhoto extends React.Component<
         <Typography variant="caption" color="textSecondary">
           {error_text}{' '}
         </Typography>
-        <FaimsDialog
+        <FaimsAttachmentManagerDialog
           project_id={this.props.form.values['_project_id']}
           open={this.state.open}
           setopen={() => this.setState({open: false})}


### PR DESCRIPTION

## JIRA Ticket

Parent Jira Issue:  https://jira.csiro.au/browse/BSS-112
Subtask - https://jira.csiro.au/browse/BSS-256

## Description

- Created a ReusableDialog component to standardize the layout and styling of dialog boxes across the application.
- The component is highly customizable, allowing for the easy addition of an icon, title, primary action button, and cancel button, which would make it easier to draft BSS Design related dialogs as exists in figma designs
-  The dialog is responsive, ensuring usability across different screen sizes.

## Proposed Changes

- New Reusable-Dialog Component Created
- Refactored the NotebookActivationSwitch component to utilize the new ReusableDialog.
- The NotebookActivationSwitch is in alignement with BSS Activate Survey Design dialog.

## How to Test
- Navigate to notebooks list.
- Click Activate on any of Unactivated notebooks.
- You should be able to see the enhanced Activate Notebook DIalog
Important Note :  The content of the dialog is subject to change based on current functionality and team reviews.



## Checklist

- [Y] I have confirmed all commits have been signed.
- [Y] I have added JSDoc style comments to any new functions or classes.
- [Y] Relevant documentation such as READMEs, guides, and class comments are updated.
