### PR TITLE
fix: api url in metadata fetch

### DIFF
--- a/app/src/sync/metadata.ts
+++ b/app/src/sync/metadata.ts
@@ -54,7 +54,7 @@ export const fetchProjectMetadata = async (
   lst: minimalCreatedListing,
   project_id: string
 ) => {
-  const url = `${lst.listing.conductor_url}/api${INDIVIDUAL_NOTEBOOK_ROUTE}${project_id}`;
+  const url = `${lst.listing.conductor_url}/api/notebooks/${project_id}`;
   const jwt_token = await getTokenForCluster(lst.listing._id);
   const full_project_id = lst.listing._id + '||' + project_id;
   const response = await fetch(url, {


### PR DESCRIPTION
## JIRA Ticket

[BSS-309](https://jira.csiro.au/browse/BSS-309)

## Description

There was a bunch of errors being thrown on app load which was being caused by the notebook metadata fetch pinging the incorrect url. 

## Proposed Changes

- updated api URL to be fixed.

## How to Test

- ensure you are logged in and have at least one activated notebook (survey).
- monitor console for errors.

## Additional Information

This was caused by the previous notebook rename PR.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
