### PR TITLE
Copy to clipboard not working on Firefox

### DIFF
--- a/api/views/home.handlebars
+++ b/api/views/home.handlebars
@@ -88,14 +88,12 @@
 
   <script>
 const copyTokenToClipboard = () => {
-    navigator.permissions.query({name: "clipboard-write"}).then((result) => {
-    if (result.state === "granted" || result.state === "prompt") {
-        navigator.clipboard.writeText("{{{token}}}").then(() => {
-            alert("Bearer token copied to clipboard.")
-        }, () => {
-                alert("Could not copy token.")
-        });
-    }
+
+    navigator.clipboard.writeText("{{{token}}}").then(() => {
+        alert("Bearer token copied to clipboard.")
+    }, () => {
+            alert("Could not copy token.")
     });
 }
+
 </script>

--- a/api/views/notebook-landing.handlebars
+++ b/api/views/notebook-landing.handlebars
@@ -210,18 +210,12 @@
 </div>
 </div>
 
-
-
   <script>
 const copyToClipboard = (text) => {
-    navigator.permissions.query({name: "clipboard-write"}).then((result) => {
-    if (result.state === "granted" || result.state === "prompt") {
-        navigator.clipboard.writeText(text).then(() => {
-            alert("Copied to clipboard.")
-        }, () => {
-                alert("Could not copy text.")
-        });
-    }
+    navigator.clipboard.writeText(text).then(() => {
+        alert("URL copied to clipboard.")
+    }, () => {
+            alert("Could not copy URL to clipboard.")
     });
 }
 


### PR DESCRIPTION
# fix: copy to clipboard not working on Firefox


## Description

In Conductor, copy to clipboard was not working on Firefox. 

## Proposed Changes

Remove browser dependent check that is not required, now works cross-browser.

## How to Test

In Conductor on the main page, click "Copy Token". On a notebook page, create an 
invite for the notebook and click "Copy Registration URL".   


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
