### PR TITLE
dev: new survey API mock interfaces

### DIFF
--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -678,3 +678,66 @@ export interface InitialMergeDetails {
   initial_head: RevisionID;
   initial_head_data: RecordMergeInformation;
 }
+
+// ================== MOCKS FOR NEW SURVEY API ===============
+// TODO cleanup
+
+// Template database item
+
+// These are the fields used to instantiate the item
+type UiSpecificationType = object;
+
+export interface TemplateDbDocumentDetails {
+  name: string;
+  ui_specification: UiSpecificationType;
+}
+
+// Once it's in the DB we'll have a _id field as well
+export interface TemplateDbDocument extends TemplateDbDocumentDetails {
+  _id: string;
+}
+
+// Conductor CRUD API
+
+// Create new template
+
+// To create a new template
+// POST /templates
+
+// Expects JSON Payload
+interface PostCreateTemplateInput extends TemplateDbDocumentDetails {}
+interface PostCreateTemplateResponse extends TemplateDbDocument {}
+
+// To update an existing template
+// POST /templates/:id
+
+// Expects JSON Payload
+interface PostUpdateTemplateInput extends TemplateDbDocumentDetails {}
+interface PostUpdateTemplateResponse extends TemplateDbDocument {}
+
+// To get all templates
+// GET /templates'
+interface GetListTemplatesResponse {
+  templates: Array<TemplateDbDocument>;
+}
+
+// To get a specific template by _id
+// GET /templates/:id'
+interface GetTemplateByIdResponse extends TemplateDbDocument {}
+
+// To delete a specific template by _id
+// POST /templates/:id/delete'
+// 200 OK ack
+
+// To create a new survey from a template by ID
+/**
+ * POST to /notebooks/template/:id to create a new notebook from a template ID
+ */
+
+type NotebookMetadataType = object;
+
+interface PostCreateNotebookFromTemplate {
+  template_id: string;
+  project_name: string;
+  metadata: NotebookMetadataType;
+}

--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -685,11 +685,13 @@ export interface InitialMergeDetails {
 // Template database item
 
 // These are the fields used to instantiate the item
-type UiSpecificationType = object;
+type UiSpecificationType = {[k: string]: any};
+type NotebookMetadataType = {[k: string]: string};
 
 export interface TemplateDbDocumentDetails {
-  name: string;
+  template_name: string;
   ui_specification: UiSpecificationType;
+  metadata: NotebookMetadataType;
 }
 
 // Once it's in the DB we'll have a _id field as well
@@ -734,10 +736,7 @@ interface GetTemplateByIdResponse extends TemplateDbDocument {}
  * POST to /notebooks/template/:id to create a new notebook from a template ID
  */
 
-type NotebookMetadataType = object;
-
 interface PostCreateNotebookFromTemplate {
   template_id: string;
   project_name: string;
-  metadata: NotebookMetadataType;
 }


### PR DESCRIPTION
# dev: new survey API mock interfaces

Proposed set of interfaces / endpoints for new functions in the new survey API.

See `library/data-model/src/types.ts` for the new interfaces. 

```typescript 
// ================== MOCKS FOR NEW SURVEY API ===============
// TODO cleanup

// Template database item

// These are the fields used to instantiate the item
type UiSpecificationType = object;

export interface TemplateDbDocumentDetails {
  name: string;
  ui_specification: UiSpecificationType;
}

// Once it's in the DB we'll have a _id field as well
export interface TemplateDbDocument extends TemplateDbDocumentDetails {
  _id: string;
}

// Conductor CRUD API

// Create new template

// To create a new template
// POST /templates

// Expects JSON Payload
interface PostCreateTemplateInput extends TemplateDbDocumentDetails {}
interface PostCreateTemplateResponse extends TemplateDbDocument {}

// To update an existing template
// POST /templates/:id

// Expects JSON Payload
interface PostUpdateTemplateInput extends TemplateDbDocumentDetails {}
interface PostUpdateTemplateResponse extends TemplateDbDocument {}

// To get all templates
// GET /templates'
interface GetListTemplatesResponse {
  templates: Array<TemplateDbDocument>;
}

// To get a specific template by _id
// GET /templates/:id'
interface GetTemplateByIdResponse extends TemplateDbDocument {}

// To delete a specific template by _id
// POST /templates/:id/delete'
// 200 OK ack

// To create a new survey from a template by ID
/**
 * POST to /notebooks/template/:id to create a new notebook from a template ID
 */

type NotebookMetadataType = object;

interface PostCreateNotebookFromTemplate {
  template_id: string;
  project_name: string;
  metadata: NotebookMetadataType;
}

```
