### PR TITLE
Fix/Call to getMetadataValue uses _id instead of project_id

### DIFF
--- a/app/src/gui/components/notebook/add_record_by_type.tsx
+++ b/app/src/gui/components/notebook/add_record_by_type.tsx
@@ -34,7 +34,7 @@ export default function AddRecordButtons({
     RecordMetadata | undefined
   >(undefined);
 
-  getMetadataValue(_id, 'showQRCodeButton').then(value => {
+  getMetadataValue(project_id, 'showQRCodeButton').then(value => {
     setShowQRButton(value === true || value === 'true');
   });
 


### PR DESCRIPTION
# feat/fix/chore: pr title

## JIRA Ticket

None

## Description

Fix a bug introduced in previous PR

## Proposed Changes

Call to getMetadataValue used the short `_id` rather than the longer `project_id` that includes the listing id. Only in one place (getting the QRCode field setting). 

## How to Test

Load up a notebook field and notice the lack of errors.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
