### PR TITLE
Fix: Field validation timing

### DIFF
--- a/app/src/gui/components/record/fields.tsx
+++ b/app/src/gui/components/record/fields.tsx
@@ -61,7 +61,7 @@ export function getComponentFromFieldConfig(
       onWheel={(event: any) => event.target.blur()}
       onChange={(event: any) => {
         formProps.handleChange(event);
-        formProps.setFieldValue('updateField', fieldName);
+        formProps.setFieldValue('updateField', fieldName, true);
       }}
       disabled={disabled}
     />
@@ -79,7 +79,7 @@ export function getComponentFromFieldConfig(
       onWheel={(event: any) => event.target.blur()}
       onChange={(event: any) => {
         formProps.handleChange(event);
-        formProps.setFieldValue('updateField', fieldName);
+        formProps.setFieldValue('updateField', fieldName, true);
       }}
       issyncing={isSyncing}
       disabled={disabled}

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1146,6 +1146,11 @@ class RecordForm extends React.Component<
     this.setState({...this.state, annotation: annotation});
   }
 
+  validateForm(values: {[fieldName: string]: unknown;}) {
+    console.log('%cVALIDATE', 'background-color: red', values);
+    return {};
+  }
+
   render() {
     // we can't do this here because it changes state and forces a redraw
     // if (this.state.draft_created !== null) {
@@ -1205,6 +1210,7 @@ class RecordForm extends React.Component<
             <Formik
               // enableReinitialize
               initialValues={initialValues}
+              validate={this.validateForm}
               validationSchema={validationSchema}
               validateOnMount={true}
               validateOnChange={false}

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1146,11 +1146,6 @@ class RecordForm extends React.Component<
     this.setState({...this.state, annotation: annotation});
   }
 
-  validateForm(values: {[fieldName: string]: unknown;}) {
-    console.log('%cVALIDATE', 'background-color: red', values);
-    return {};
-  }
-
   render() {
     // we can't do this here because it changes state and forces a redraw
     // if (this.state.draft_created !== null) {
@@ -1210,7 +1205,6 @@ class RecordForm extends React.Component<
             <Formik
               // enableReinitialize
               initialValues={initialValues}
-              validate={this.validateForm}
               validationSchema={validationSchema}
               validateOnMount={true}
               validateOnChange={false}

--- a/app/src/gui/components/record/view.tsx
+++ b/app/src/gui/components/record/view.tsx
@@ -63,17 +63,7 @@ function SingleComponent(props: SingleComponentProps) {
   const fieldName = props.fieldName;
   const fields = props.fields;
   const fieldConfig = fields[fieldName];
-  const label =
-    fieldConfig['component-parameters']['InputLabelProps'] !== undefined
-      ? fieldConfig['component-parameters']['InputLabelProps']['label']
-      : fieldConfig['component-parameters']['FormLabelProps'] !== undefined
-        ? fieldConfig['component-parameters']['FormLabelProps']['children']
-        : fieldConfig['component-parameters']['FormControlLabelProps'] !==
-            undefined
-          ? fieldConfig['component-parameters']['FormControlLabelProps'][
-              'children'
-            ]
-          : fieldName;
+  const label = fieldConfig['component-parameters'].label;
   const [expanded, setExpanded] = React.useState(false);
 
   const handleExpandClick = () => {

--- a/app/src/gui/components/record/view.tsx
+++ b/app/src/gui/components/record/view.tsx
@@ -279,9 +279,7 @@ function getUsefulFieldNameFromUiSpec(
   if (field in ui_specification.fields) {
     const fieldInfo = ui_specification.fields[field];
     const fieldName =
-      fieldInfo.label ||
-      fieldInfo['component-parameters'].InputLabelProps?.label ||
-      field;
+      fieldInfo.label || fieldInfo['component-parameters'].label || field;
     // get the view that this field is part of
     let sectionName = '';
     for (const section in ui_specification.views) {

--- a/app/src/gui/fields/ActionButton.tsx
+++ b/app/src/gui/fields/ActionButton.tsx
@@ -31,7 +31,7 @@ export class ActionButton extends React.Component<
   FieldProps & Props & ButtonProps
 > {
   clickThis() {
-    this.props.form.setFieldValue(this.props.field.name, 'Change!');
+    this.props.form.setFieldValue(this.props.field.name, 'Change!', true);
   }
   render() {
     return (

--- a/app/src/gui/fields/Address.tsx
+++ b/app/src/gui/fields/Address.tsx
@@ -88,10 +88,15 @@ export const AddressField = (props: FieldProps & Props) => {
     const dn = parts.join(', ');
     setDisplayName(dn);
     setAddress(a);
-    props.form.setFieldValue(props.field.name, {
-      display_name: dn,
-      address: a,
-    });
+    props.form.setFieldValue(
+      props.field.name,
+      {
+        display_name: dn,
+        address: a,
+      },
+      true
+    );
+    props.form.validateForm();
   };
 
   const updateProperty = (

--- a/app/src/gui/fields/BasicAutoIncrementer.tsx
+++ b/app/src/gui/fields/BasicAutoIncrementer.tsx
@@ -208,7 +208,7 @@ export class BasicAutoIncrementer extends React.Component<
             },
           });
         } else {
-          this.props.form.setFieldValue(this.props.field.name, new_id);
+          this.props.form.setFieldValue(this.props.field.name, new_id, true);
           if (this.props.form.errors[this.props.field.name] !== undefined)
             this.props.form.setFieldError(this.props.field.name, undefined);
         }

--- a/app/src/gui/fields/DateTimeNow.tsx
+++ b/app/src/gui/fields/DateTimeNow.tsx
@@ -33,7 +33,7 @@ export function DateTimeNow(props: TextFieldProps & DateTimeNowProps) {
      * The internal value is ISO, display value is yyyy-MM-ddTHH:mm:ss
      */
     const date = new Date(newValue);
-    setFieldValue(name, date.toISOString());
+    setFieldValue(name, date.toISOString(), true);
   };
 
   const onChange = React.useCallback(
@@ -66,7 +66,7 @@ export function DateTimeNow(props: TextFieldProps & DateTimeNowProps) {
     if (is_auto_pick === true && value === '') {
       try {
         const date = new Date();
-        setFieldValue(name, date.toISOString());
+        setFieldValue(name, date.toISOString(), true);
       } catch (err) {
         setFieldError(name, 'Could not set display value. Contact support.');
         logError(err);

--- a/app/src/gui/fields/FileUploader.tsx
+++ b/app/src/gui/fields/FileUploader.tsx
@@ -85,7 +85,7 @@ export function FileUploader(props: FieldProps & Props) {
       );
       setfiles(newfiles);
       console.log(current_files);
-      props.form.setFieldValue(props.field.name, newfiles);
+      props.form.setFieldValue(props.field.name, newfiles, true);
     }
   };
   return (
@@ -103,7 +103,7 @@ export function FileUploader(props: FieldProps & Props) {
           onDrop={files => {
             const newfiles = current_files.concat(files);
             setfiles(newfiles);
-            props.form.setFieldValue(props.field.name, newfiles);
+            props.form.setFieldValue(props.field.name, newfiles, true);
           }}
         >
           {({getRootProps, getInputProps}) => (

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -415,7 +415,7 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
         newValue = [newValue, new_child_record];
       else newValue = [new_child_record];
     } else newValue = new_child_record;
-    props.form.setFieldValue(props.field.name, newValue);
+    props.form.setFieldValue(props.field.name, newValue, true);
     return new_record_id;
   };
 
@@ -427,7 +427,7 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
     if (multiple) newValue = [...(newValue ?? []), selectedRecord];
     else newValue = selectedRecord;
 
-    props.form.setFieldValue(props.field.name, newValue);
+    props.form.setFieldValue(props.field.name, newValue, true);
     props.form.submitForm();
     const current_record = {
       record_id: record_id,
@@ -514,7 +514,7 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
       relation_type_vocabPair: relationshipPair,
     };
     //set the form value
-    props.form.setFieldValue(props.field.name, newValue);
+    props.form.setFieldValue(props.field.name, newValue, true);
     let revision_id = props.form.values['_current_revision_id'];
     try {
       revision_id = await props.form.submitForm();
@@ -584,7 +584,7 @@ export function RelatedRecordSelector(props: FieldProps & Props) {
       );
       setRecordsInformation(newRecords);
     }
-    props.form.setFieldValue(props.field.name, newValue);
+    props.form.setFieldValue(props.field.name, newValue, true);
     if (is_preferred === true) setPreferred(child_record_id);
     else setPreferred(null);
   };

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -252,7 +252,7 @@ export class TakePhoto extends React.Component<
         this.props.field.value !== null
           ? this.props.field.value.concat(image)
           : [image];
-      this.props.form.setFieldValue(this.props.field.name, newimages);
+      this.props.form.setFieldValue(this.props.field.name, newimages, true);
     } catch (err: any) {
       logError(err);
       this.props.form.setFieldError(this.props.field.name, err.message);
@@ -274,7 +274,6 @@ export class TakePhoto extends React.Component<
     const error = this.props.form.errors[this.props.field.name];
     let error_text = <span {...this.props['NoErrorTextProps']}></span>;
     if (error) {
-      console.log('PHOTO ERRORS', this.props.field.name, error);
       error_text = (
         <span {...this.props['ErrorTextProps']}>{error as string}</span>
       );
@@ -309,7 +308,11 @@ export class TakePhoto extends React.Component<
             this.setState({open: true, photopath: path})
           }
           setimage={(newfiles: Array<any>) => {
-            this.props.form.setFieldValue(this.props.field.name, newfiles);
+            this.props.form.setFieldValue(
+              this.props.field.name,
+              newfiles,
+              true
+            );
           }}
           disabled={this.props.disabled ?? false}
           fieldName={this.props.field.name}

--- a/app/src/gui/fields/TakePoint.tsx
+++ b/app/src/gui/fields/TakePoint.tsx
@@ -83,8 +83,7 @@ export class TakePoint extends React.Component<
       const coordinates = capacitor_coordindates_to_faims_pos(
         await Geolocation.getCurrentPosition(this.getPositionOptions())
       );
-      console.debug('Take point coord', coordinates);
-      this.props.form.setFieldValue(this.props.field.name, coordinates);
+      this.props.form.setFieldValue(this.props.field.name, coordinates, true);
     } catch (err: any) {
       logError(err);
       this.props.form.setFieldError(this.props.field.name, err.message);

--- a/app/src/gui/fields/TemplatedStringField.tsx
+++ b/app/src/gui/fields/TemplatedStringField.tsx
@@ -53,10 +53,25 @@ export class TemplatedStringField extends React.Component<
     };
   }
 
+  // compute the value on startup and on any update
+  componentDidMount(): void {
+    this.updateValue();
+  }
+
   componentDidUpdate() {
+    this.updateValue();
+  }
+
+  /**
+   * Update the field value based on the values of other
+   * fields in the form and the configured template string
+   */
+  updateValue() {
     if (this.props.disabled === true) return;
     const {template, ...textFieldProps} = this.props;
 
+    // gather the field values together that will be used as
+    // placeholder names in the template
     const field_values: FieldValues = {};
     for (const field_name in textFieldProps.form.values) {
       if (field_name !== textFieldProps.field.name) {
@@ -66,10 +81,11 @@ export class TemplatedStringField extends React.Component<
         field_values[field_name] = value;
       }
     }
+    // compute the new value and update if it has changed
     const value = render_template(template, field_values);
     if (value !== this.state.value) {
       this.setState({value: value});
-      this.props.form.setFieldValue(this.props.field.name, value);
+      this.props.form.setFieldValue(this.props.field.name, value, true);
       if (value !== '')
         if (this.props.form.errors[this.props.field.name] !== undefined)
           this.props.form.setFieldError(this.props.field.name, undefined);

--- a/app/src/gui/fields/maps/MapFormField.tsx
+++ b/app/src/gui/fields/maps/MapFormField.tsx
@@ -74,7 +74,7 @@ export function MapFormField({
 
   const mapCallback = (theFeatures: GeoJSONFeatureCollection) => {
     setDrawnFeatures(theFeatures);
-    form.setFieldValue(field.name, theFeatures);
+    form.setFieldValue(field.name, theFeatures, true);
   };
 
   // get the current GPS location if don't know the map center

--- a/app/src/gui/fields/multiselect.tsx
+++ b/app/src/gui/fields/multiselect.tsx
@@ -34,6 +34,10 @@ interface Props {
 }
 
 export class MultiSelect extends React.Component<TextFieldProps & Props> {
+  handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    this.props.form.setFieldValue(this.props.field.name, e.target.value, true);
+  }
+
   render() {
     const {ElementProps, children, ...textFieldProps} = this.props;
     return (
@@ -44,6 +48,7 @@ export class MultiSelect extends React.Component<TextFieldProps & Props> {
           SelectProps={{
             multiple: true,
           }}
+          onChange={e => this.handleChange(e)}
         >
           {children}
           {ElementProps.options.map((option: any) => (

--- a/app/src/gui/fields/qrcode/QRCodeFormField.tsx
+++ b/app/src/gui/fields/qrcode/QRCodeFormField.tsx
@@ -109,7 +109,7 @@ export function QRCodeFormField({
 
   const updateField = (value: any) => {
     setState(value);
-    form.setFieldValue(field.name, value);
+    form.setFieldValue(field.name, value, true);
   };
 
   // a string version of the value

--- a/app/src/gui/fields/radio.tsx
+++ b/app/src/gui/fields/radio.tsx
@@ -56,6 +56,10 @@ interface Props {
 }
 
 export class RadioGroup extends React.Component<RadioGroupProps & Props> {
+  handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    this.props.form.setFieldValue(this.props.field.name, e.target.value, true);
+  }
+
   render() {
     const {
       ElementProps,
@@ -87,7 +91,10 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
     return (
       <FormControl error={error}>
         <FormLabel children={label} />
-        <MuiRadioGroup {...fieldToRadioGroup(radioGroupProps)}>
+        <MuiRadioGroup
+          {...fieldToRadioGroup(radioGroupProps)}
+          onChange={e => this.handleChange(e)}
+        >
           {ElementProps.options.map(option => (
             <FormControlLabel
               key={option.key ? option.key : option.value}

--- a/app/src/gui/fields/select.tsx
+++ b/app/src/gui/fields/select.tsx
@@ -24,14 +24,6 @@ import {fieldToTextField, TextFieldProps} from 'formik-mui';
 import {MenuItem} from '@mui/material';
 import {ElementOption} from '@faims3/data-model';
 
-// import TextField from '@mui/material/TextField';
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// interface option {
-//   key: string;
-//   value: string;
-//   label: string;
-// }
-
 interface ElementProps {
   options: Array<ElementOption>;
 }
@@ -42,6 +34,10 @@ interface Props {
 }
 
 export class Select extends React.Component<TextFieldProps & Props> {
+  handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    this.props.form.setFieldValue(this.props.field.name, e.target.value, true);
+  }
+
   render() {
     const {ElementProps, children, ...textFieldProps} = this.props;
     /***make select not multiple to avoid error */
@@ -57,6 +53,7 @@ export class Select extends React.Component<TextFieldProps & Props> {
           SelectProps={{
             multiple: false,
           }}
+          onChange={e => this.handleChange(e)}
         >
           {children}
           {ElementProps.options.map((option: any) => (

--- a/app/src/gui/fields/selectadvanced.tsx
+++ b/app/src/gui/fields/selectadvanced.tsx
@@ -286,11 +286,11 @@ export function AdvancedSelect(props: TextFieldProps & Props) {
     if (props.valuetype === 'child') {
       let newvalue = name;
       if (type === 'image') newvalue = label + '(' + name + ')';
-      props.form.setFieldValue(props.field.name, newvalue);
+      props.form.setFieldValue(props.field.name, newvalue, true);
 
       return;
     }
-    props.form.setFieldValue(props.field.name, newvalue);
+    props.form.setFieldValue(props.field.name, newvalue, true);
 
     return;
   };

--- a/app/src/gui/layout/appBar.tsx
+++ b/app/src/gui/layout/appBar.tsx
@@ -193,7 +193,6 @@ const useStyles = makeStyles({
 function getNestedProjects(pouchProjectList: ProjectExtended[]) {
   const projectListItems: ProjectListItemProps[] = [];
   pouchProjectList.map(project_info => {
-    console.log('PI>>>', project_info);
     projectListItems.push({
       title: project_info.name,
       icon: <DescriptionIcon />,

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -232,7 +232,7 @@ const fields: {[key: string]: FieldType} = {
       geoTiff: '',
     },
     validationSchema: [['yup.string']],
-    initialValue: '1',
+    initialValue: '',
   },
   MultiSelect: {
     'component-namespace': 'faims-custom',
@@ -288,7 +288,7 @@ const fields: {[key: string]: FieldType} = {
       helperText: 'Make sure you choose the right one!',
     },
     validationSchema: [['yup.string']],
-    initialValue: '1',
+    initialValue: '',
   },
   RandomStyle: {
     'component-namespace': 'faims-custom',
@@ -428,7 +428,7 @@ const fields: {[key: string]: FieldType} = {
       helperText: 'Scan QR Code on the sample',
     },
     validationSchema: [['yup.string']],
-    initialValue: '1',
+    initialValue: '',
   },
   AddressField: {
     'component-namespace': 'faims-custom',


### PR DESCRIPTION
# Fix Field Validation Timing

## JIRA Ticket

[BSS-352](https://jira.csiro.com/browse/BSS-352)

## Description

If a photo field is required we still show an error message after adding a photo in some cases (rapid impact prototype).   This seems to be due to when validation runs on the form - it doesn't run until a change is triggered and adding a photo doesn't trigger a change.

## Proposed Changes

It turns out that validation was not being triggered when we set field values because a third argument to `setFieldValue` was missing.  If this is true, then validation is triggered when the field is set.   All calls have been updated.  In a few cases, notably select, I had to do more work to ensure that it was called at the right time. 

Some fields are directly implemented via the Formik text field and so I've not changed them. TextField seems to work and I think the others do but in some cases you have to leave them to see the value (date field).

## How to Test

[Field-Sampler.json](https://github.com/user-attachments/files/17158913/Field-Sampler.json)
 is a sample notebook with lots of required fields.  You should see the error messages go away as you fill in values.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
