### PR TITLE
Fix draft deletion

### DIFF
--- a/app/src/drafts.ts
+++ b/app/src/drafts.ts
@@ -40,7 +40,7 @@ export function listenDrafts(
       live: true,
     })
     .on('change', info => {
-      console.log(info);
+      console.log('change in drafts database', info);
       if (info.doc!.project_id === project_id) {
         runCallback();
       }

--- a/app/src/gui/components/notebook/delete.tsx
+++ b/app/src/gui/components/notebook/delete.tsx
@@ -73,7 +73,6 @@ async function deleteFromDB(
     );
     await deleteDraftsForRecord(project_id, record_id);
   }
-  console.log('calling callback fn');
   await callback();
 }
 
@@ -106,7 +105,6 @@ export default function RecordDelete(props: RecordDeleteProps) {
         )
       )
       .then(() => {
-        console.log('first then clause');
         const message = is_draft
           ? `Draft ${draft_id} for record ${record_id} discarded`
           : `Record ${record_id} deleted`;
@@ -117,7 +115,6 @@ export default function RecordDelete(props: RecordDeleteProps) {
             severity: 'success',
           },
         });
-        console.log('closing now');
         handleClose();
         history(ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + project_id);
       })

--- a/app/src/gui/components/notebook/delete.tsx
+++ b/app/src/gui/components/notebook/delete.tsx
@@ -50,7 +50,7 @@ type RecordDeleteProps = {
   revision_id: RevisionID | null;
   draft_id: string | null;
   show_label: boolean;
-  handleRefresh: () => Promise<any>;
+  handleRefresh: () => void;
 };
 
 async function deleteFromDB(
@@ -59,8 +59,9 @@ async function deleteFromDB(
   revision_id: RevisionID | null,
   draft_id: string | null,
   userid: string,
-  callback: () => Promise<any>
+  callback: () => void
 ) {
+  console.log('deleting data from the db', draft_id);
   if (draft_id !== null) {
     await deleteStagedData(draft_id, null);
   } else {
@@ -72,6 +73,7 @@ async function deleteFromDB(
     );
     await deleteDraftsForRecord(project_id, record_id);
   }
+  console.log('calling callback fn');
   await callback();
 }
 
@@ -104,6 +106,7 @@ export default function RecordDelete(props: RecordDeleteProps) {
         )
       )
       .then(() => {
+        console.log('first then clause');
         const message = is_draft
           ? `Draft ${draft_id} for record ${record_id} discarded`
           : `Record ${record_id} deleted`;
@@ -114,6 +117,7 @@ export default function RecordDelete(props: RecordDeleteProps) {
             severity: 'success',
           },
         });
+        console.log('closing now');
         handleClose();
         history(ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + project_id);
       })

--- a/app/src/gui/components/notebook/draft_table.tsx
+++ b/app/src/gui/components/notebook/draft_table.tsx
@@ -47,7 +47,7 @@ type DraftsTableProps = {
   project_id: ProjectID;
   maxRows: number | null;
   viewsets?: ProjectUIViewsets | null;
-  handleRefresh: () => Promise<any>;
+  handleRefresh: () => void;
 };
 
 type DraftsRecordProps = {
@@ -56,7 +56,7 @@ type DraftsRecordProps = {
   rows: any;
   loading: boolean;
   viewsets?: ProjectUIViewsets | null;
-  handleRefresh: () => Promise<any>;
+  handleRefresh: () => void;
 };
 
 function DraftRecord(props: DraftsRecordProps) {

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -90,7 +90,6 @@ function a11yProps(index: number, id: string) {
  */
 type NotebookComponentProps = {
   project: ProjectExtended;
-  handleRefresh: () => Promise<any>;
 };
 
 /**
@@ -132,6 +131,8 @@ export default function NotebookComponent(props: NotebookComponentProps) {
 
   const {project} = props;
   const [loading, setLoading] = useState(true);
+  // refresh state is just something to change to force a rebuild
+  const [refresh, setRefresh] = useState(false);
   const [err, setErr] = useState('');
   const [viewsets, setViewsets] = useState<null | ProjectUIViewsets>(null);
   const [uiSpec, setUiSpec] = useState<null | ProjectUIModel>(null);
@@ -161,7 +162,13 @@ export default function NotebookComponent(props: NotebookComponentProps) {
       setErr('');
       setLoading(true);
     };
-  }, [project]);
+  }, [project, refresh]);
+
+  // trigger a refresh of the component because something changed down
+  // below (a record or draft was deleted)
+  const handleRefresh = () => {
+    setRefresh(!refresh);
+  };
 
   return (
     <Box>
@@ -255,7 +262,7 @@ export default function NotebookComponent(props: NotebookComponentProps) {
                   maxRows={25}
                   viewsets={viewsets}
                   filter_deleted={true}
-                  handleRefresh={props.handleRefresh}
+                  handleRefresh={handleRefresh}
                 />
               </TabPanel>
               <TabPanel
@@ -267,7 +274,7 @@ export default function NotebookComponent(props: NotebookComponentProps) {
                   project_id={project.project_id}
                   maxRows={25}
                   viewsets={viewsets}
-                  handleRefresh={props.handleRefresh}
+                  handleRefresh={handleRefresh}
                 />
               </TabPanel>
             </Box>

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -131,8 +131,6 @@ export default function NotebookComponent(props: NotebookComponentProps) {
 
   const {project} = props;
   const [loading, setLoading] = useState(true);
-  // refresh state is just something to change to force a rebuild
-  const [refresh, setRefresh] = useState(false);
   const [err, setErr] = useState('');
   const [viewsets, setViewsets] = useState<null | ProjectUIViewsets>(null);
   const [uiSpec, setUiSpec] = useState<null | ProjectUIModel>(null);
@@ -141,9 +139,16 @@ export default function NotebookComponent(props: NotebookComponentProps) {
   const history = useNavigate();
 
   /**
-   * Fetches the UI specification and viewsets for the project when the component mounts or the project changes.
+   * Fetches the UI specification and viewsets for the project
    */
-  useEffect(() => {
+  const pageLoader = () => {
+    // Starting state reset
+    setViewsets(null);
+    setUiSpec(null);
+    setErr('');
+    setLoading(true);
+
+    // Try to load details and records
     if (project.listing && project._id) {
       getUiSpecForProject(project.project_id)
         .then(spec => {
@@ -153,21 +158,24 @@ export default function NotebookComponent(props: NotebookComponentProps) {
           setErr('');
         })
         .catch(err => {
+          setLoading(false);
           setErr(err.message);
         });
     }
-    return () => {
-      setViewsets(null);
-      setUiSpec(null);
-      setErr('');
-      setLoading(true);
-    };
-  }, [project, refresh]);
+  };
 
-  // trigger a refresh of the component because something changed down
-  // below (a record or draft was deleted)
+  /**
+   * Fetches the UI specification and viewsets for the project when the
+   * component mounts or the project changes.
+   */
+  useEffect(() => {
+    pageLoader();
+  }, [project]);
+
+  // trigger a refresh of the content because something changed down below (a
+  // record or draft was deleted)
   const handleRefresh = () => {
-    setRefresh(!refresh);
+    pageLoader();
   };
 
   return (

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -59,7 +59,7 @@ type RecordsTableProps = {
   loading: boolean;
   viewsets?: ProjectUIViewsets | null;
   handleQueryFunction: Function;
-  handleRefresh: () => Promise<any>;
+  handleRefresh: () => void;
 };
 
 type RecordsBrowseTableProps = {
@@ -67,7 +67,7 @@ type RecordsBrowseTableProps = {
   maxRows: number | null;
   viewsets?: ProjectUIViewsets | null;
   filter_deleted: boolean;
-  handleRefresh: () => Promise<any>;
+  handleRefresh: () => void;
 };
 
 function RecordsTable(props: RecordsTableProps) {
@@ -429,9 +429,6 @@ export function RecordsBrowseTable(props: RecordsBrowseTableProps) {
 
   useEffect(() => {
     const getData = async () => {
-      if (DEBUG_APP) {
-        console.log('RecordsTable updating', props.project_id, query);
-      }
       try {
         if (query.length === 0) {
           const ma = await getMetadataForAllRecords(

--- a/app/src/gui/components/ui/tab-grid.tsx
+++ b/app/src/gui/components/ui/tab-grid.tsx
@@ -38,8 +38,6 @@ export default function TabGrid({
   const handleRowClick: GridEventListener<'rowClick'> = ({
     row: {activated, project_id},
   }) => {
-    console.log(`${ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE}${project_id}`);
-
     if (activated) history(`${ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE}${project_id}`);
   };
   return (

--- a/app/src/gui/fields/TakePoint.tsx
+++ b/app/src/gui/fields/TakePoint.tsx
@@ -114,8 +114,6 @@ export class TakePoint extends React.Component<
       );
     }
 
-    console.log('Take Point Props', this.props);
-
     return (
       <div>
         <p>

--- a/app/src/gui/fields/TakePoint.tsx
+++ b/app/src/gui/fields/TakePoint.tsx
@@ -113,6 +113,9 @@ export class TakePoint extends React.Component<
         <span {...this.props['ErrorTextProps']}>{error.toString()}</span>
       );
     }
+
+    console.log('Take Point Props', this.props);
+
     return (
       <div>
         <p>
@@ -122,11 +125,9 @@ export class TakePoint extends React.Component<
         </p>
         <Button
           variant="outlined"
+          fullWidth={true}
           color={'primary'}
           style={{marginRight: '10px'}}
-          {...this.props}
-          // Props from the metadata db will overwrite the above
-          // style attributes, but not overwrite the below onclick.
           onClick={async () => {
             await this.takePoint();
           }}

--- a/app/src/gui/fields/maps/MapWrapper.tsx
+++ b/app/src/gui/fields/maps/MapWrapper.tsx
@@ -257,7 +257,7 @@ function MapWrapper(props: MapProps) {
   // render component
   return (
     <div>
-      <Button variant="outlined" onClick={handleClickOpen}>
+      <Button variant="outlined" fullWidth={true} onClick={handleClickOpen}>
         {props.label}
       </Button>
 

--- a/app/src/gui/pages/notebook.tsx
+++ b/app/src/gui/pages/notebook.tsx
@@ -71,10 +71,7 @@ export default function Notebook() {
           </Typography>
         </Grid>
       </Grid>
-      <NotebookComponent
-        project={project}
-        handleRefresh={() => new Promise(() => {})}
-      />
+      <NotebookComponent project={project} />
     </Box>
   );
 }

--- a/app/src/sync/draft-storage.ts
+++ b/app/src/sync/draft-storage.ts
@@ -135,9 +135,6 @@ export async function setStagedData(
   relationship: Relationship
 ): Promise<PouchDB.Core.Response> {
   const existing = await draft_db.get(draft_id);
-  if (DEBUG_APP) {
-    console.debug('Saving draft values:', new_data, new_annotations);
-  }
   const encoded_info = encodeStagedData(
     new_data,
     new_annotations,

--- a/app/src/utils/status.tsx
+++ b/app/src/utils/status.tsx
@@ -51,9 +51,11 @@ export function getSyncStatusCallbacks(
 ): SyncStatusCallbacks {
   const handleStartSyncUp = () => {
     startSync(dispatch, ActionType.IS_SYNCING_UP);
+    setSyncError(dispatch, false); // no error if we're syncing
   };
   const handleStartSyncDown = () => {
     startSync(dispatch, ActionType.IS_SYNCING_DOWN);
+    setSyncError(dispatch, false); // no error if we're syncing
   };
   const handleStartSyncError = () => {
     setSyncError(dispatch, true);

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -389,10 +389,8 @@ const fields: {[key: string]: FieldType} = {
     'component-name': 'TakePoint',
     'type-returned': 'faims-pos::Location',
     'component-parameters': {
-      fullWidth: true,
       name: 'take-point-field',
       helperText: 'Click to save current location',
-      variant: 'outlined',
       label: 'Take point',
     },
     validationSchema: [['yup.object'], ['yup.nullable']],


### PR DESCRIPTION
# Fix - draft deletion doesn't work

## JIRA Ticket

[BSS-399](https://jira.csiro.com/browse/BSS-399)

## Description

Deleting draft records was not working, the dialog stayed open after clicking delete and the record stayed in the list.

## Proposed Changes

The bug was with the refresh of the record lists. Deletion was happening but a  previous PR had changed the callback
function that was supposed to trigger refresh.   The solution was actually to move the refresh down to the record
table component.

The same problem existed with deleting records. This is also now fixed.

I've also removed a few bits of debugging output and fixed some warnings that showed up during testing. 

- TakePoint fields were passing the helperText property on to the Button component causing a  warning. This was because all properties from the configuration were just passed in blindly. I changed this to pass none in so we control the look of the button in code rather than via the notebook.
- Made the Map Input button full width to match the new default for TakePoint

## How to Test

Create some records (and drafts) and then try to delete them.

Use a notebook with a TakePoint and Map field to see that the buttons render appropriately.

## Additional Information

I investigated the extra draft creation problem and found that it was due to drafts being created in useEffect inside the DraftCreate component.  The double rendering of React.StrictMode means that this is called twice and makes two drafts each time.   This won't be a problem in production but points to a poor implementation.  I've created BSS-400 to address this at some point.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
