### PR TITLE
Fix docker compose for deployment

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -18,8 +18,7 @@ services:
       - COUCHDB_PASSWORD
   conductor:
     platform: linux/amd64
-    image: ghcr.io/faims/faims3-conductor:main
-    command: "npm start" 
+    image: ghcr.io/faims/faims3-api:main
     ports:
       - "0.0.0.0:${CONDUCTOR_EXTERNAL_PORT}:${CONDUCTOR_INTERNAL_PORT}"
     volumes:


### PR DESCRIPTION
Signed-off-by: Steve Cassidy <steve.cassidy@mq.edu.au>

# Fix docker compose for conductor

## JIRA Ticket

None

## Description

Docker compose file was referencing the old docker image and had an extra run command that prevented it working.

## Proposed Changes

Reference the new conductor docker image and remove the run command.

## How to Test

In the APi folder run:

```sh
docker compose build
docker compose up -d
```

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
