### PR TITLE
add express-async-errors

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -36,6 +36,7 @@
     "cors": "2.8.5",
     "csv-stringify": "^6.4.4",
     "express": "4.21.0",
+    "express-async-errors": "^3.1.1",
     "express-handlebars": "7.1.2",
     "express-rate-limit": "^7.1.5",
     "express-validator": "7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "cors": "2.8.5",
         "csv-stringify": "^6.4.4",
         "express": "4.21.0",
+        "express-async-errors": "^3.1.1",
         "express-handlebars": "7.1.2",
         "express-rate-limit": "^7.1.5",
         "express-validator": "7.0.1",
@@ -24817,6 +24818,15 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-handlebars": {


### PR DESCRIPTION
# Fix: add missing express-async-error package

## Description

This package was not in package.json. Now it is.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
