### PR TITLE
fix: fixing improper display of notebooks in headings mode

### DIFF
--- a/app/src/gui/components/ui/heading-grid.tsx
+++ b/app/src/gui/components/ui/heading-grid.tsx
@@ -1,50 +1,72 @@
 import {Stack} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridEventListener,
+  GridPaginationModel,
+} from '@mui/x-data-grid';
 import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '../../../buildconfig';
 import {ProjectExtended} from '../../../types/project';
+import {useNavigate} from 'react-router';
+import * as ROUTES from '../../../constants/routes';
+import {useEffect, useState} from 'react';
 
 /**
  * Renders a grid with two sections: Active and Not Active.
  * Each section displays a DataGrid component with the provided data.
  *
- * @param pouchProjectList - The list of project information.
- * @param handleRowClick - The event listener for row click.
- * @param loading - A boolean indicating if the data is loading.
- * @param columns - The columns configuration for the DataGrid.
- * @param sortModel - The sorting configuration for the DataGrid.
+ * @param projects - The list of project information.
+ * @param columns - The columns configuration for the grid.
  * @returns The rendered HeadingGrid component.
  */
-export default function HeadingGrid({
-  pouchProjectList,
-  loading,
+export default function HeadingProjectGrid({
+  projects,
   columns,
 }: {
-  pouchProjectList: ProjectExtended[];
-  loading: boolean;
+  projects: ProjectExtended[];
   columns: any;
 }) {
+  // pull out active/inactive surveys
+  const activatedProjects = projects.filter(({activated}) => activated);
+  const availableProjects = projects.filter(({activated}) => !activated);
+
+  const history = useNavigate();
+
+  const handleRowClick: GridEventListener<'rowClick'> = ({
+    row: {activated, project_id},
+  }) => {
+    if (activated) history(`${ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE}${project_id}`);
+  };
+
+  // we need a state variable to track pagination model since we want to use a
+  // controlled component style to force pagination to behave how we want
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    page: 1,
+    pageSize: projects.length,
+  });
+
+  // Update pagination settings when the projects changes
+  useEffect(() => {
+    setPaginationModel({page: 1, pageSize: projects.length});
+  }, [projects]);
+
   return (
     <div style={{display: 'flex', flexDirection: 'column'}}>
       <div style={{padding: '6px', fontSize: '18px', fontWeight: 'bold'}}>
         Active
       </div>
+
       <DataGrid
-        key={'active_notebook_list_datagrid'}
-        rows={pouchProjectList.filter(r => r.activated)}
-        loading={loading}
+        key={`notebook_list_datagrid_activated`}
+        rows={activatedProjects}
         columns={columns}
+        onRowClick={handleRowClick}
         autoHeight
         sx={{cursor: 'pointer'}}
-        getRowId={r => r._id}
+        getRowId={({_id}) => _id}
         hideFooter={true}
         getRowHeight={() => 'auto'}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: pouchProjectList.length,
-            },
-          },
-        }}
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
         slots={{
           noRowsOverlay: () => (
             <Stack height="100%" alignItems="center" justifyContent="center">
@@ -58,22 +80,17 @@ export default function HeadingGrid({
         Not active
       </div>
       <DataGrid
-        key={'not_active_notebook_list_datagrid'}
-        rows={pouchProjectList.filter(r => !r.activated)}
-        loading={loading}
+        key={`notebook_list_datagrid_not_activated`}
+        rows={availableProjects}
         columns={columns}
         autoHeight
         sx={{cursor: 'pointer'}}
-        getRowId={r => r._id}
-        hideFooter={true}
+        onRowClick={handleRowClick}
+        getRowId={({_id}) => _id}
         getRowHeight={() => 'auto'}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: pouchProjectList.length,
-            },
-          },
-        }}
+        hideFooter
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
         slots={{
           noRowsOverlay: () => (
             <Stack height="100%" alignItems="center" justifyContent="center">

--- a/app/src/gui/components/ui/tab-grid.tsx
+++ b/app/src/gui/components/ui/tab-grid.tsx
@@ -2,24 +2,26 @@ import TabContext from '@mui/lab/TabContext';
 import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
 import {Box, Tab} from '@mui/material';
-import {DataGrid, GridEventListener} from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridEventListener,
+  GridPaginationModel,
+} from '@mui/x-data-grid';
 import {ProjectExtended} from '../../../types/project';
 import {useNavigate} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
+import {useEffect, useState} from 'react';
 
 /**
  * Renders a tabbed grid component.
  *
- * @param pouchProjectList - The list of project information.
+ * @param projects - The list of project information.
  * @param tabID - The ID of the active tab.
  * @param handleChange - The event handler for tab change.
- * @param handleRowClick - The event handler for row click.
- * @param loading - A boolean indicating whether the grid is loading.
  * @param columns - The columns configuration for the grid.
- * @param sortModel - The sorting configuration for the grid.
  * @returns The rendered tabbed grid component.
  */
-export default function TabGrid({
+export default function TabProjectGrid({
   projects,
   tabID,
   handleChange,
@@ -32,6 +34,18 @@ export default function TabGrid({
 }) {
   const activatedProjects = projects.filter(({activated}) => activated);
   const availableProjects = projects.filter(({activated}) => !activated);
+
+  // we need a state variable to track pagination model since we want to use a
+  // controlled component style to force pagination to behave how we want
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    page: 1,
+    pageSize: projects.length,
+  });
+
+  // Update pagination settings when the projects changes
+  useEffect(() => {
+    setPaginationModel({page: 1, pageSize: projects.length});
+  }, [projects]);
 
   const history = useNavigate();
 
@@ -71,6 +85,8 @@ export default function TabGrid({
               onRowClick={handleRowClick}
               getRowId={({_id}) => _id}
               hideFooter
+              paginationModel={paginationModel}
+              onPaginationModelChange={setPaginationModel}
             />
           </div>
         </TabPanel>

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -28,7 +28,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import {useTheme} from '@mui/material/styles';
 import {grey} from '@mui/material/colors';
 import Tabs from '../ui/tab-grid';
-import HeadingGrid from '../ui/heading-grid';
+import HeadingProjectGrid from '../ui/heading-grid';
 import {NOTEBOOK_LIST_TYPE, NOTEBOOK_NAME} from '../../../buildconfig';
 import AddCircleSharpIcon from '@mui/icons-material/AddCircleSharp';
 import * as ROUTES from '../../../constants/routes';
@@ -63,7 +63,7 @@ export default function NoteBooks() {
               >
                 <FolderIcon
                   fontSize={'small'}
-                  color={activated ? 'secondary' : 'disabled'}
+                  color={activated ? 'primary' : 'disabled'}
                   sx={{mr: '3px'}}
                 />
                 <Typography
@@ -200,11 +200,7 @@ export default function NoteBooks() {
             columns={columns}
           />
         ) : (
-          <HeadingGrid
-            pouchProjectList={projects}
-            loading={false}
-            columns={columns}
-          />
+          <HeadingProjectGrid projects={projects} columns={columns} />
         )}
       </Box>
     </Box>


### PR DESCRIPTION
# fix: fixing improper display of notebooks in headings mode

## Description

Fixes mui data grid display issues due to stale pagination model (which was fixing the page size at 0) + bubble theme colouring hiding the folder icon. 

## How to Test

Try different combinations of theme + notebook list layout and check that items render in the available and active sections correctly. 

## Additional Information

As a consequence of changing from 'secondary' to 'primary' as the theme colour, changes the colour of the folder icon on the default theme for active notebooks to green.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
