### PR TITLE
fix(aws): jwt auth backwards compatibility (exp claim) and chttpd_auth security improvements

### DIFF
--- a/api/couchdb/local.ini.dist
+++ b/api/couchdb/local.ini.dist
@@ -10,7 +10,6 @@ port = 5984
 bind_address = 0.0.0.0
 authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
-
 [httpd]
 enable_cors = true
 

--- a/infrastructure/aws-cdk/.vscode/tasks.json
+++ b/infrastructure/aws-cdk/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "option": "watch",
+            "problemMatcher": [
+                "$tsc-watch"
+            ],
+            "group": "build",
+            "label": "tsc: watch - tsconfig.json"
+        }
+    ]
+}

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -312,6 +312,7 @@ Note that this validation is at a schema level, it might not catch improperly fo
   - `scheduleExpression`: The cron schedule for running backups (default: daily at 3 AM)
 - `couch`:
   - `volumeSize`: The size in GB of the EBS volume to mount to the EC2 instance
+  - `couchVersionTag`: (Optional) The DockerHub version tag to use for the couch image - defaults to 3.3.3, e.g. 'latest'
   - `instanceType`: The EC2 instance type for CouchDB (e.g., "t3.small")
   - `ebsRecoverySnapshotId`: (Optional) The ID of an EBS snapshot to recover the couch data volume from
   - `monitoring`: (Optional) Configuration for CouchDB monitoring alarms

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -14,19 +14,19 @@
  * 25-07-2024 | Peter Baker | use the same LB as the couch DB network to save $$$.
  */
 
-import {Duration, RemovalPolicy} from 'aws-cdk-lib';
-import * as r53 from 'aws-cdk-lib/aws-route53';
-import * as sm from 'aws-cdk-lib/aws-secretsmanager';
-import * as r53Targets from 'aws-cdk-lib/aws-route53-targets';
+import {Duration} from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as logs from 'aws-cdk-lib/aws-logs';
+import * as r53 from 'aws-cdk-lib/aws-route53';
+import * as r53Targets from 'aws-cdk-lib/aws-route53-targets';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
 import {Construct} from 'constructs';
+import {ConductorConfig} from '../faims-infra-stack';
 import {getPathToRoot} from '../util/mono';
 import {SharedBalancer} from './networking';
-import {ConductorConfig} from '../faims-infra-stack';
 
 /**
  * Properties for the FaimsConductor construct
@@ -58,6 +58,8 @@ export interface FaimsConductorProps {
   iosAppPublicUrl: string;
   /** The configuration object for the Conductor service */
   config: ConductorConfig;
+  /** FAIMS_COOKIE_SECRET */
+  cookieSecret: sm.Secret;
 }
 
 /**
@@ -81,20 +83,6 @@ export class FaimsConductor extends Construct {
 
     // Build the public URL and expose
     this.conductorEndpoint = `https://${props.domainName}:${this.externalPort}`;
-
-    // AUXILIARY SETUP
-    // ================
-
-    // Generate cookie auth secret at deploy time
-    const cookieSecret = new sm.Secret(this, 'conductor-cookie-secret', {
-      description: 'Contains a randomly generated string used for cookie auth',
-      removalPolicy: RemovalPolicy.DESTROY,
-      generateSecretString: {
-        includeSpace: false,
-        passwordLength: 25,
-        excludePunctuation: true,
-      },
-    });
 
     // CONTAINER SETUP
     // ================
@@ -174,7 +162,9 @@ export class FaimsConductor extends Construct {
             props.couchDbAdminSecret,
             'username'
           ),
-          FAIMS_COOKIE_SECRET: ecs.Secret.fromSecretsManager(cookieSecret),
+          FAIMS_COOKIE_SECRET: ecs.Secret.fromSecretsManager(
+            props.cookieSecret
+          ),
         },
         logging: ecs.LogDriver.awsLogs({
           streamPrefix: 'faims-conductor',

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -379,6 +379,9 @@ EOL`,
       instanceType: new ec2.InstanceType(props.instanceType),
     });
 
+    // grant permission for the instance to read the secret
+    props.cookieSecret.grantRead(this.instance);
+
     // Create and attach the EBS volume for CouchDB data
     const dataVolume = new ec2.Volume(
       this,

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
 import {BackupConstruct} from './components/backups';
 import {Construct} from 'constructs';
 import {FaimsConductor} from './components/conductor';
@@ -97,6 +98,8 @@ const CouchConfigSchema = z.object({
   monitoring: MonitoringConfigSchema.optional(),
   /** EC2 instance type for CouchDB */
   instanceType: z.string(),
+  /** The version to use of CouchDB - 3.3.3 is default */
+  couchVersionTag: z.string().default('3.3.3'),
 });
 
 const DomainsConfigSchema = z.object({
@@ -309,6 +312,19 @@ export class FaimsInfraStack extends cdk.Stack {
       certificate: primaryCert,
     });
 
+    // Cookie secret shared between couch and conductor
+
+    // Generate cookie auth secret at deploy time
+    const cookieSecret = new sm.Secret(this, 'conductor-cookie-secret', {
+      description: 'Contains a randomly generated string used for cookie auth in conductor and couch',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      generateSecretString: {
+        includeSpace: false,
+        passwordLength: 25,
+        excludePunctuation: true,
+      },
+    });
+
     // COUCHDB
     // =======
 
@@ -323,6 +339,8 @@ export class FaimsInfraStack extends cdk.Stack {
       dataVolumeSize: config.couch.volumeSize,
       dataVolumeSnapshotId: config.couch.ebsRecoverySnapshotId,
       monitoring: config.couch.monitoring,
+      couchVersionTag: config.couch.couchVersionTag,
+      cookieSecret: cookieSecret
     });
 
     // CONDUCTOR
@@ -343,6 +361,7 @@ export class FaimsInfraStack extends cdk.Stack {
       iosAppPublicUrl: config.mobileApps.iosAppPublicUrl,
       sharedBalancer: networking.sharedBalancer,
       config: config.conductor,
+      cookieSecret: cookieSecret
     });
 
     // FRONT-END


### PR DESCRIPTION
# fix(aws): jwt auth backwards compatibility (exp claim) and chttpd_auth security improvements

## Description

- adds configurable couch version tag and pins to 3.3.3 by default
- the above provides a workaround to the `jwt_auth` breaking change where 'exp' is a mandatory claim - see JIRA ticket to implement and integrate token refresh. Issue here (https://github.com/apache/couchdb/issues/5046)
- updates the user data couch configuration to inject the cookie secret from the FAIMS_COOKIE_SECRET shared AWS Secret Manager, rather than hardcoding. The dist file was copied which included a placeholder secret value which was replaced at build time with a secret.

## How to Test

AWS deployment is up to date with these changes including re-creating a new instance. 

## Additional Information

It might be worth extending the initdb API - however we would need to ensure that the chttpd_auth secret configuration is not required to enable API connection - this could be chicken and egg problem. This approach is secure for the AWS use case but does mean that dynamically updating the secret requires manual intervention.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
