### PR TITLE
fix: fix express async issue, return API unit tests, add turbo config

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -59,4 +59,12 @@ jobs:
         
       - name: Build
         run: npm run build
+
+      - name: API Unit tests
+        run: |
+          cd api
+          cp .env.dist .env
+          ./keymanagement/makeInstanceKeys.sh
+          cd ..
+          npx turbo run test --filter=@faims3/api
  

--- a/api/package.json
+++ b/api/package.json
@@ -36,7 +36,6 @@
     "cors": "2.8.5",
     "csv-stringify": "^6.4.4",
     "express": "4.21.0",
-    "express-async-errors": "^3.1.1",
     "express-handlebars": "7.1.2",
     "express-rate-limit": "^7.1.5",
     "express-validator": "7.0.1",

--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -65,10 +65,10 @@ import {
 import * as Exceptions from '../exceptions';
 import {requireAuthenticationAPI} from '../middleware';
 
-// See https://github.com/davidbanham/express-async-errors - this patches
-// express to handle async errors without hanging or needing an explicit try
-// catch block
-require('express-async-errors');
+import patch from '../utils/patchExpressAsync';
+
+// This must occur before express api is used
+patch();
 
 export const api = express.Router();
 

--- a/api/src/api/templates.ts
+++ b/api/src/api/templates.ts
@@ -40,10 +40,10 @@ import {userCanDoWithTemplate} from '../couchdb/users';
 import * as Exceptions from '../exceptions';
 import {requireAuthenticationAPI} from '../middleware';
 
-// See https://github.com/davidbanham/express-async-errors - this patches
-// express to handle async errors without hanging or needing an explicit try
-// catch block
-require('express-async-errors');
+import patch from '../utils/patchExpressAsync';
+
+// This must occur before express api is used
+patch();
 
 export const api = express.Router();
 

--- a/api/src/api/users.ts
+++ b/api/src/api/users.ts
@@ -31,10 +31,10 @@ import {processRequest} from 'zod-express-middleware';
 import {z} from 'zod';
 import {PostUpdateUserInputSchema} from '@faims3/data-model';
 
-// See https://github.com/davidbanham/express-async-errors - this patches
-// express to handle async errors without hanging or needing an explicit try
-// catch block
-require('express-async-errors');
+import patch from '../utils/patchExpressAsync';
+
+// This must occur before express api is used
+patch();
 
 export const api = express.Router();
 

--- a/api/src/api/utilities.ts
+++ b/api/src/api/utilities.ts
@@ -17,13 +17,14 @@
  *   This module contains utility routes at /api
  */
 
-import {ListingInformation} from '@faims3/data-model/src/types';
+import {ListingsObject} from '@faims3/data-model';
 import express from 'express';
 import multer from 'multer';
 import {
   CONDUCTOR_DESCRIPTION,
   CONDUCTOR_INSTANCE_NAME,
   CONDUCTOR_PUBLIC_URL,
+  CONDUCTOR_SHORT_CODE_PREFIX,
   DEVELOPER_MODE,
 } from '../buildconfig';
 import {initialiseDatabases} from '../couchdb';
@@ -37,10 +38,11 @@ import {slugify} from '../utils';
 // TODO: configure this directory
 const upload = multer({dest: '/tmp/'});
 
-// See https://github.com/davidbanham/express-async-errors - this patches
-// express to handle async errors without hanging or needing an explicit try
-// catch block
-require('express-async-errors');
+import patch from '../utils/patchExpressAsync';
+
+// This must occur before express api is used
+patch();
+
 export const api = express.Router();
 
 api.get('/hello/', requireAuthenticationAPI, (_req: any, res: any) => {
@@ -62,13 +64,13 @@ api.post('/initialise/', async (req, res) => {
  * Handle info requests, basic identifying information for this server
  */
 api.get('/info', async (req, res) => {
-  const info: ListingInformation = {
+  res.json({
     id: slugify(CONDUCTOR_INSTANCE_NAME),
     name: CONDUCTOR_INSTANCE_NAME,
     conductor_url: CONDUCTOR_PUBLIC_URL,
     description: CONDUCTOR_DESCRIPTION,
-  };
-  res.json(info);
+    prefix: CONDUCTOR_SHORT_CODE_PREFIX,
+  } as ListingsObject);
 });
 
 api.get('/directory/', requireAuthenticationAPI, async (req, res) => {

--- a/api/src/core.ts
+++ b/api/src/core.ts
@@ -28,11 +28,11 @@ import express, {
   Response,
 } from 'express';
 import {ExpressHandlebars} from 'express-handlebars';
+import RateLimit from 'express-rate-limit';
 import handlebars from 'handlebars';
 import morgan from 'morgan';
 import passport from 'passport';
 import flash from 'req-flash';
-import RateLimit from 'express-rate-limit';
 
 // use swaggerUI to display the UI documentation
 // need this workaround to have the swagger-ui-dist package
@@ -57,11 +57,10 @@ import {api as templatesApi} from './api/templates';
 import {api as usersApi} from './api/users';
 import {api as utilityApi} from './api/utilities';
 import {COOKIE_SECRET} from './buildconfig';
+import patch from './utils/patchExpressAsync';
 
-// See https://github.com/davidbanham/express-async-errors - this patches
-// express to handle async errors without hanging or needing an explicit try
-// catch block
-require('express-async-errors');
+// This must occur before express app is used
+patch();
 
 export const app = express();
 app.use(morgan('combined'));

--- a/api/src/utils/patchExpressAsync.js
+++ b/api/src/utils/patchExpressAsync.js
@@ -1,0 +1,52 @@
+// See https://github.com/davidbanham/express-async-errors - this patches
+// express to handle async errors without hanging or needing an explicit try
+// catch block
+
+// Refactored to make this run as a function to avoid optimisation of require
+// making the function only run once
+const Layer = require('express/lib/router/layer');
+const Router = require('express/lib/router');
+
+const last = (arr = []) => arr[arr.length - 1];
+const noop = Function.prototype;
+
+function copyFnProps(oldFn, newFn) {
+  Object.keys(oldFn).forEach(key => {
+    newFn[key] = oldFn[key];
+  });
+  return newFn;
+}
+
+function wrap(fn) {
+  const newFn = function newFn(...args) {
+    const ret = fn.apply(this, args);
+    const next = (args.length === 5 ? args[2] : last(args)) || noop;
+    if (ret && ret.catch) ret.catch(err => next(err));
+    return ret;
+  };
+  Object.defineProperty(newFn, 'length', {
+    value: fn.length,
+    writable: false,
+  });
+  return copyFnProps(fn, newFn);
+}
+
+export default function patchRouterParam() {
+  const originalParam = Router.prototype.constructor.param;
+  // @ts-ignore
+  Router.prototype.constructor.param = function param(name, fn) {
+    fn = wrap(fn);
+    return originalParam.call(this, name, fn);
+  };
+}
+
+Object.defineProperty(Layer.prototype, 'handle', {
+  enumerable: true,
+  get() {
+    return this.__handle;
+  },
+  set(fn) {
+    fn = wrap(fn);
+    this.__handle = fn;
+  },
+});

--- a/infrastructure/aws-cdk/package.json
+++ b/infrastructure/aws-cdk/package.json
@@ -14,7 +14,6 @@
         "package": "cd src && npm run package",
         "init-api": "CONFIG_FILE_NAME=${CONFIG_FILE_NAME:-dev.json} && curl -X POST https://conductor.$(jq -r .hostedZone.name < \"configs/${CONFIG_FILE_NAME}\")/api/initialise",
         "watch": "tsc -w",
-        "test": "jest",
         "cdk": "cdk",
         "config": "bash ./config.sh",
         "validate-config": "ts-node validateConfig.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "cors": "2.8.5",
         "csv-stringify": "^6.4.4",
         "express": "4.21.0",
-        "express-async-errors": "^3.1.1",
         "express-handlebars": "7.1.2",
         "express-rate-limit": "^7.1.5",
         "express-validator": "7.0.1",
@@ -24818,15 +24817,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-async-errors": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
-      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
-      "license": "ISC",
-      "peerDependencies": {
-        "express": "^4.16.2"
       }
     },
     "node_modules/express-handlebars": {

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,18 @@
                 "build",
                 "dist"
             ]
+        },
+        "test": {
+            "dependsOn": [
+                "build"
+            ],
+            "inputs": [
+                "src/**/*.ts",
+                "test/**/*.ts",
+                "package.json"
+            ],
+            "outputs": [],
+            "cache": true
         }
     }
 }


### PR DESCRIPTION
# fix: fix express async issue, return API unit tests, add turbo config

- changes require('express-async-errors') to instead hardcode the actual patch into a file, and export a function - this resolves the issue where the require was being cached causing improper patching, regressing the async timeout on API unit tests
- fixes merge issue which removed the conductor short code prefix from the listings object in info 
- adds the API unit tests as a turbo config, the other tests run but don't currently pass due to existing issues. To run unit tests, ensure `.env` file is valid and then run `turbo run test --filter=@faims3/api`
- updates github action to run this on PR