### PR TITLE
fix: correct client side record filtering

### DIFF
--- a/app/src/users.ts
+++ b/app/src/users.ts
@@ -415,10 +415,15 @@ export async function shouldDisplayRecord(
   if (roles === undefined) {
     return false;
   }
-  for (const role in roles) {
+  for (const projectId of Object.keys(roles)) {
     if (
-      role === split_id.project_id &&
-      roles[role].includes(CLUSTER_ADMIN_GROUP_NAME)
+      projectId === split_id.project_id &&
+      // TODO BSS-453 consider how we handle this
+
+      // This currently hard-codes admin as a special role which allows visibility of all records but
+      // a) why is this necessary on client side?
+      // b) isn't this configurable in the notebook designer?
+      roles[projectId].includes('admin')
     ) {
       return true;
     }

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -225,7 +225,8 @@ export async function getHRID(
 /**
  * Returns a list of not deleted records
  * @param project_id Project ID to get list of record for
- * @returns key: record id, value: record (NOT NULL)
+ * @param record_ids Optional set of record IDs to specifically fetch
+ * @returns Object with {key: record id, value: record (NOT NULL)}
  */
 export async function listRecordMetadata(
   project_id: ProjectID,


### PR DESCRIPTION
Closes https://jira.csiro.au/browse/BSS-453

User could not see records of other users even if admin on notebook. 

I also wrapped the record fetch in useQuery to continue alignment with new style - chose a very conservative cache approach since there's no obvious trigger to rely on to refresh the record list.

Offending code was `src/users.ts` in `app` 

![image](https://github.com/user-attachments/assets/19da576c-fd1c-4c41-abd1-6de855c0b70f)

Notably the app was looking for cluster-admin on a notebook which doesn't exist as a role. `admin` is the correct role name. 

@stevecassidy  looking for insight on how to derive this role - given the roles and actions are customisable within the notebook spec, right? 

Also, shouldn't this be enforced in the DB and the client should not need to filter?