### PR TITLE
feat: adding permission handling into create new survey workflow views

### DIFF
--- a/app/src/gui/components/workspace/CreateNewSurvey.tsx
+++ b/app/src/gui/components/workspace/CreateNewSurvey.tsx
@@ -1,17 +1,22 @@
 import DescriptionIcon from '@mui/icons-material/Description';
 import {
-  Grid,
-  useMediaQuery,
-  Typography,
-  useTheme,
   Box,
+  Grid,
   Stack,
+  Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import React from 'react';
+import {NOTEBOOK_NAME} from '../../../buildconfig';
+import {
+  CREATE_NOTEBOOK_ROLES,
+  userHasRoleInSpecificListing,
+} from '../../../users';
 import useGetListings from '../../../utils/custom_hooks';
+import {useGetAllUserInfo} from '../../../utils/useGetCurrentUser';
 import NewNotebookForListing from '../notebook/NewNotebookForListing';
 import CircularLoading from '../ui/circular_loading';
-import {NOTEBOOK_NAME} from '../../../buildconfig';
 
 export interface CreateNewSurveyProps {}
 const CreateNewSurvey: React.FC<CreateNewSurveyProps> = () => {
@@ -19,6 +24,22 @@ const CreateNewSurvey: React.FC<CreateNewSurveyProps> = () => {
   const listings = useGetListings();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const allUserInfo = useGetAllUserInfo();
+
+  const loading = listings.isLoading || allUserInfo.isLoading;
+  const error = listings.isError || allUserInfo.isError;
+  const errorMessage = listings.error?.message ?? allUserInfo.error?.message;
+
+  const allowedListings = allUserInfo.data
+    ? (listings.data ?? []).filter(listing => {
+        return userHasRoleInSpecificListing(
+          allUserInfo.data,
+          listing.id,
+          CREATE_NOTEBOOK_ROLES
+        );
+      })
+    : [];
 
   return (
     <>
@@ -68,14 +89,22 @@ const CreateNewSurvey: React.FC<CreateNewSurveyProps> = () => {
         spacing={theme.spacing(2)}
         padding={theme.spacing(3)}
       >
-        {listings.isLoading ? (
-          <CircularLoading label={'Loading servers...'}></CircularLoading>
+        {loading ? (
+          <CircularLoading label="Loading servers..." />
+        ) : error ? (
+          <p>
+            An error occurred: {errorMessage || 'Unknown error'}. Please contact
+            a system administrator.
+          </p>
+        ) : allowedListings.length !== 0 ? (
+          allowedListings.map(listing => (
+            <NewNotebookForListing listingObject={listing} key={listing.id} />
+          ))
         ) : (
-          listings.data?.map(listing => {
-            return (
-              <NewNotebookForListing listingObject={listing} key={listing.id} />
-            );
-          })
+          // The user should not get here
+          <p>
+            You do not have permission to create notebooks in any active server.
+          </p>
         )}
       </Stack>
     </>

--- a/app/src/gui/components/workspace/CreateNewSurvey.tsx
+++ b/app/src/gui/components/workspace/CreateNewSurvey.tsx
@@ -25,12 +25,15 @@ const CreateNewSurvey: React.FC<CreateNewSurveyProps> = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
+  // Get all user info from local auth DB
   const allUserInfo = useGetAllUserInfo();
 
+  // Loading or error states from either fetch
   const loading = listings.isLoading || allUserInfo.isLoading;
   const error = listings.isError || allUserInfo.isError;
   const errorMessage = listings.error?.message ?? allUserInfo.error?.message;
 
+  // Only show listings for which the current active user has create permissions
   const allowedListings = allUserInfo.data
     ? (listings.data ?? []).filter(listing => {
         return userHasRoleInSpecificListing(

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -18,23 +18,24 @@
  *   TODO
  */
 
-import {useContext, useState} from 'react';
-import {Box, Paper, Typography, Button} from '@mui/material';
-import FolderIcon from '@mui/icons-material/Folder';
-import {GridColDef} from '@mui/x-data-grid';
-import ProjectStatus from '../notebook/settings/status';
-import NotebookSyncSwitch from '../notebook/settings/sync_switch';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import {useTheme} from '@mui/material/styles';
-import {grey} from '@mui/material/colors';
-import Tabs from '../ui/tab-grid';
-import HeadingProjectGrid from '../ui/heading-grid';
-import {NOTEBOOK_LIST_TYPE, NOTEBOOK_NAME} from '../../../buildconfig';
 import AddCircleSharpIcon from '@mui/icons-material/AddCircleSharp';
+import FolderIcon from '@mui/icons-material/Folder';
+import {Box, Button, Paper, Typography} from '@mui/material';
+import {grey} from '@mui/material/colors';
+import {useTheme} from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import {GridColDef} from '@mui/x-data-grid';
+import {useContext, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {NOTEBOOK_LIST_TYPE, NOTEBOOK_NAME} from '../../../buildconfig';
 import * as ROUTES from '../../../constants/routes';
 import {ProjectsContext} from '../../../context/projects-context';
 import {ProjectExtended} from '../../../types/project';
-import {useNavigate} from 'react-router-dom';
+import {CREATE_NOTEBOOK_ROLES, userHasRoleInAnyListing} from '../../../users';
+import {useGetAllUserInfo} from '../../../utils/useGetCurrentUser';
+import NotebookSyncSwitch from '../notebook/settings/sync_switch';
+import HeadingProjectGrid from '../ui/heading-grid';
+import Tabs from '../ui/tab-grid';
 
 export default function NoteBooks() {
   const [tabID, setTabID] = useState('1');
@@ -175,6 +176,12 @@ export default function NoteBooks() {
 
   const activatedProjects = projects.filter(({activated}) => activated);
 
+  // fetch all user info then determine if any listing has permission to create notebooks
+  const allUserInfo = useGetAllUserInfo();
+  const showCreateNewNotebookButton = allUserInfo?.data
+    ? userHasRoleInAnyListing(allUserInfo.data, CREATE_NOTEBOOK_ROLES)
+    : false;
+
   return (
     <Box>
       <Box component={Paper} elevation={0} p={2}>
@@ -187,15 +194,17 @@ export default function NoteBooks() {
           </Button>{' '}
           tab and click the activate button.
         </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => history(ROUTES.CREATE_NEW_SURVEY)}
-          sx={{mb: 3, mt: 3, backgroundColor: theme.palette.primary.main}}
-          startIcon={<AddCircleSharpIcon />}
-        >
-          Create New Survey
-        </Button>
+        {showCreateNewNotebookButton && (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => history(ROUTES.CREATE_NEW_SURVEY)}
+            sx={{mb: 3, mt: 3, backgroundColor: theme.palette.primary.main}}
+            startIcon={<AddCircleSharpIcon />}
+          >
+            Create New {NOTEBOOK_NAME}
+          </Button>
+        )}
         {NOTEBOOK_LIST_TYPE === 'tabs' ? (
           <Tabs
             projects={projects}

--- a/app/src/utils/useGetCurrentUser.tsx
+++ b/app/src/utils/useGetCurrentUser.tsx
@@ -1,7 +1,12 @@
-import {useQuery} from '@tanstack/react-query';
 import {ProjectID} from '@faims3/data-model';
-import {getCurrentUserId} from '../users';
+import {useQuery} from '@tanstack/react-query';
+import {getAllUserInfo, getCurrentUserId} from '../users';
 
+/**
+ * For a given project ID, refers to the local auth db to get the user ID activated
+ * @param project_id The project ID to get user for
+ * @returns The user ID for the current user
+ */
 export const useGetCurrentUser = (project_id: ProjectID) => {
   return useQuery<string, Error>({
     queryKey: ['currentUser', project_id],
@@ -14,6 +19,28 @@ export const useGetCurrentUser = (project_id: ProjectID) => {
       }
     },
     staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+};
+
+/**
+ * Fetches all user info from the local auth DB
+ * @returns All user info from the auth DB
+ */
+export const useGetAllUserInfo = () => {
+  return useQuery({
+    queryKey: ['alluserinfo'],
+    queryFn: async () => {
+      try {
+        return await getAllUserInfo();
+      } catch (error) {
+        console.error('Error fetching user info:', error);
+        throw error;
+      }
+    },
+    // I don't think we want to cache this?
+    // TODO consider caching implications for user info
+    staleTime: Infinity,
     retry: 1,
   });
 };


### PR DESCRIPTION
# feat: adding permission handling into create new survey workflow views

## JIRA Ticket

[BSS-465](https://jira.csiro.au/browse/BSS-465)

## Description

Updates the create new survey workflows to respect authorisation. Keeping in mind this is not currently well defined because there is no sense of 'active listing'. This is the behaviour proposed and implemented.

- on the surveys page, if there is ANY listing in which the active user for that listing has creation permissions, show the button
- on the create new <survey> page, filter the listings to only show listings for which the user has permission

## How to Test

Create a user with permission, and one without, and check that things render as expected. Noting that you will need to manually refresh tokens using the Workspace refresh button to get the updated tokens. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
