### PR TITLE
fix: adding initialisation step to validate local auth DB and inject parsedTokens where unavailable

### DIFF
--- a/app/src/sync/initialize.ts
+++ b/app/src/sync/initialize.ts
@@ -18,9 +18,12 @@
  *   TODO
  */
 import PouchDB from 'pouchdb-browser';
-
 import {DEBUG_POUCHDB} from '../buildconfig';
-
+import {clone} from 'lodash';
+import {getAllListings} from '.';
+import {parseToken} from '../users';
+import ObjectMap from '../utils/ObjectMap';
+import {local_auth_db, LocalAuthDoc} from './databases';
 import {events} from './events';
 import {update_directory} from './process-initialization';
 import {register_basic_automerge_resolver, register_sync_state} from './state';
@@ -36,4 +39,184 @@ export async function initialize() {
   register_sync_state(events);
   register_basic_automerge_resolver(events);
   await update_directory().catch(err => events.emit('directory_error', err));
+
+  // Initialise auth DB
+  await initialiseAuthDB();
+}
+
+/**
+ * Initializes and validates the local authentication database.
+ *
+ * This function performs several maintenance tasks on the local auth database:
+ * 1. Validates that all stored auth documents correspond to known listings
+ * 2. Ensures all stored tokens are well-formed and parseable
+ * 3. Maintains consistency between available tokens and current username
+ * 4. Removes invalid or orphaned auth entries
+ *
+ * The function is designed to be fault-tolerant and will:
+ * - Skip processing of individual documents if errors occur
+ * - Log errors for debugging but continue execution
+ * - Maintain database integrity even with partial failures
+ *
+ * @returns Promise<void> - Resolves when initialization is complete
+ * @throws Error - Only if the initial database global variable initialisation
+ * fails
+ */
+async function initialiseAuthDB(): Promise<void> {
+  // TODO this should be provided through context or similar mechanism
+  let db: PouchDB.Database<LocalAuthDoc>;
+
+  // Initialize database connection with error handling
+  try {
+    db = local_auth_db;
+    if (!db) {
+      throw new Error(
+        'The local auth DB is null or undefined during initialisation.'
+      );
+    }
+  } catch (error) {
+    console.error('Fatal: Could not initialize local auth DB:', error);
+    throw error; // Re-throw as this is a fatal initialization error
+  }
+
+  try {
+    // Fetch all documents and listings
+    const allDocs = (await db.allDocs({include_docs: true})).rows
+      .map(d => d.doc)
+      .filter(d => !!d);
+
+    const listingsMap = new Map((await getAllListings()).map(l => [l.id, l]));
+
+    // Process each document
+    for (const doc of allDocs) {
+      try {
+        // What is the listing ID?
+        const listingId = doc._id;
+
+        // Check that we know about the listing
+        if (!listingsMap.has(listingId)) {
+          console.log(`Removing auth doc for unknown listing: ${listingId}`);
+          await db.remove(doc, {});
+          continue;
+        }
+
+        // Make a new document
+        const updatedDoc = clone(doc);
+        let needsUpdate = false;
+
+        // Process available tokens
+        const usernamesToDelete: string[] = [];
+        for (const username of Object.keys(updatedDoc.available_tokens)) {
+          try {
+            // Validate username
+            if (!username || username.length === 0) {
+              usernamesToDelete.push(username);
+              console.error(
+                `Invalid username found in auth doc ${listingId}, removing entry`
+              );
+              continue;
+            }
+
+            // Process token
+            const token = ObjectMap.get(updatedDoc.available_tokens, username)!;
+            try {
+              const parsedToken = await parseToken(token.token);
+
+              // Update parsed token if missing
+              if (!token.parsedToken) {
+                console.log(
+                  `Auth doc had entry for listing ${listingId} and user ${username} which was missing parsedToken. Injecting...`
+                );
+                token.parsedToken = parsedToken;
+                needsUpdate = true;
+              }
+            } catch (tokenError) {
+              console.error(
+                `Error parsing token for username ${username} in listing ${listingId}:`,
+                tokenError
+              );
+              usernamesToDelete.push(username);
+            }
+          } catch (tokenProcessError) {
+            console.error(
+              `Error processing token for username ${username}:`,
+              tokenProcessError
+            );
+            usernamesToDelete.push(username);
+          }
+        }
+
+        // Remove invalid username entries
+        usernamesToDelete.forEach(username => {
+          console.log(
+            `Deleting ${username} from listing: ${listingId} authDoc.`
+          );
+          delete updatedDoc.available_tokens[username];
+          needsUpdate = true;
+        });
+
+        // Check if document is still valid after token processing
+        if (Object.keys(updatedDoc.available_tokens).length === 0) {
+          console.log(
+            `Removing auth doc ${listingId} as it has no valid tokens remaining`
+          );
+          await db.remove(doc, {});
+          continue;
+        }
+
+        // Validate current username
+        try {
+          const isMissing =
+            !updatedDoc.current_username ||
+            updatedDoc.current_username.length === 0;
+          const isValid = Object.values(updatedDoc.available_tokens).some(
+            t => t.parsedToken.username === updatedDoc.current_username
+          );
+
+          if (isMissing || !isValid) {
+            const firstToken = Object.values(updatedDoc.available_tokens)[0];
+            if (!firstToken) {
+              throw new Error('No valid tokens found for username update');
+            }
+            updatedDoc.current_username = firstToken.parsedToken.username;
+            needsUpdate = true;
+            console.log(
+              `Updated current username for listing ${listingId} to ${updatedDoc.current_username}`
+            );
+          }
+        } catch (usernameError) {
+          console.error(
+            `Error processing current username for listing ${listingId}:`,
+            usernameError
+          );
+          continue;
+        }
+
+        // Update document if needed
+        if (needsUpdate) {
+          try {
+            await db.put(updatedDoc);
+            console.log(
+              `Successfully updated auth doc for listing ${listingId}`
+            );
+          } catch (updateError) {
+            console.error(
+              `Failed to update auth doc for listing ${listingId}:`,
+              updateError
+            );
+          }
+        }
+      } catch (docError) {
+        console.error('Error processing auth doc:', docError);
+        continue;
+      }
+    }
+
+    console.log(
+      'Successfully completed initialization and validation of local auth DB'
+    );
+  } catch (error) {
+    console.error('Error during auth DB initialization:', error);
+    // Don't throw here - we want the function to complete even with errors
+  }
 }


### PR DESCRIPTION
# fix: adding initialisation step to validate local auth DB and inject parsedTokens where unavailable

## JIRA Ticket

[BSS-477](https://jira.csiro.au/browse/BSS-477)

## Description

Users with an existing auth DB had records with no parsedToken field. The updated versions of the app expect this field to exist. This resulted in `cannot read property <x> of undefined` errors which crashed the app. 

This PR adds a step to the initialisation logic which runs once on app startup (this is refresh on browser, or app open on phones). 

This initialisation code performs a validation of the contents of the local auth DB, fixing things were it can. It makes the best attempt possible to make sure the auth DB is valid, and tries to make no assumptions about it's contents. 

This covers

```typescript
 * This function performs several maintenance tasks on the local auth database:
 * 1. Validates that all stored auth documents correspond to known listings
 * 2. Ensures all stored tokens are well-formed and parseable
 * 3. Maintains consistency between available tokens and current username
 * 4. Removes invalid or orphaned auth entries
```

I have tested by manually injecting a missing parsedToken into my local auth DB through the auth return. The behaviour is as follows

- log out
- log in, auth return injects intentionally missing parsedToken field
- the app crashes because initialisation does not run (since app has already initialised)
- upon refresh (triggering initialisation), the initialisation logic injects corrected token contents

i.e. 
![image](https://github.com/user-attachments/assets/74a14c8f-3261-47a1-af83-dda6be4a0832)

- app functions correctly and user is logged in 

@stevecassidy  want to ensure you are happy with this behaviour. All new log ins will include the parsedToken, so this should cover all cases of existing auth docs with missing parsed token content.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
