### PR TITLE
feat: initialise surveys

### DIFF
--- a/app/src/context/functions.tsx
+++ b/app/src/context/functions.tsx
@@ -109,3 +109,12 @@ export const getRemoteProjects = async () => {
 
   return projects;
 };
+
+/**
+ * Converts an array of projects into a Map where each project's ID is the key, and the project object is the value.
+ *
+ * @param {ProjectExtended[]} projects - An array of project objects with unique IDs.
+ * @returns {Map<string, ProjectExtended>} A Map with project IDs as keys and project objects as values.
+ */
+export const getProjectMap = (projects: ProjectExtended[]) =>
+  new Map(projects.map(project => [project._id, project]));

--- a/app/src/gui/components/authentication/auth_return.tsx
+++ b/app/src/gui/components/authentication/auth_return.tsx
@@ -21,11 +21,12 @@
  */
 
 import {Button, Stack} from '@mui/material';
-import {useEffect, useRef, useState} from 'react';
+import {useContext, useEffect, useRef, useState} from 'react';
 import {useNavigate} from 'react-router';
 import {getSyncableListingsInfo} from '../../../databaseAccess';
 import {update_directory} from '../../../sync/process-initialization';
 import {parseToken, setTokenForCluster} from '../../../users';
+import {ProjectsContext} from '../../../context/projects-context';
 
 async function getListingForConductorUrl(conductor_url: string) {
   const origin = new URL(conductor_url).origin;
@@ -42,6 +43,8 @@ async function getListingForConductorUrl(conductor_url: string) {
 export function AuthReturn() {
   const navigate = useNavigate();
   const [error, setError] = useState<string | undefined>(undefined);
+
+  const {initProjects} = useContext(ProjectsContext);
 
   // track if effect has already run - this should only happen once
   const hasRun = useRef(false);
@@ -96,6 +99,7 @@ export function AuthReturn() {
 
       // this requires the token
       update_directory();
+      initProjects();
       navigate('/');
     };
 

--- a/app/src/gui/components/authentication/auth_return.tsx
+++ b/app/src/gui/components/authentication/auth_return.tsx
@@ -97,10 +97,13 @@ export function AuthReturn() {
         );
       }
 
-      // this requires the token
-      update_directory();
-      initProjects();
-      navigate('/');
+      const login = async () => {
+        await update_directory();
+        await initProjects();
+        navigate('/');
+      };
+
+      login();
     };
 
     const params = new URLSearchParams(window.location.search);

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -26,7 +26,6 @@ import {
   getMetadataForAllRecords,
   getRecordsWithRegex,
 } from '@faims3/data-model';
-import ArticleIcon from '@mui/icons-material/Article';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {Alert, Box, Grid, Link, Paper, Typography} from '@mui/material';
 import {useTheme} from '@mui/material/styles';

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -36,10 +36,16 @@ import {useGetAllUserInfo} from '../../../utils/useGetCurrentUser';
 import NotebookSyncSwitch from '../notebook/settings/sync_switch';
 import HeadingProjectGrid from '../ui/heading-grid';
 import Tabs from '../ui/tab-grid';
+import {RefreshOutlined} from '@mui/icons-material';
 
 export default function NoteBooks() {
-  const [tabID, setTabID] = useState('1');
-  const {projects} = useContext(ProjectsContext);
+  const [refresh, setRefresh] = useState(false);
+  const {projects, syncRemoteProjects} = useContext(ProjectsContext);
+
+  const activatedProjects = projects.filter(({activated}) => activated);
+
+  const [tabID, setTabID] = useState(activatedProjects.length > 0 ? '1' : '2');
+
   const history = useNavigate();
 
   const theme = useTheme();
@@ -174,8 +180,6 @@ export default function NoteBooks() {
         },
       ];
 
-  const activatedProjects = projects.filter(({activated}) => activated);
-
   // fetch all user info then determine if any listing has permission to create notebooks
   const allUserInfo = useGetAllUserInfo();
   const showCreateNewNotebookButton = allUserInfo?.data
@@ -194,17 +198,35 @@ export default function NoteBooks() {
           </Button>{' '}
           tab and click the activate button.
         </Typography>
-        {showCreateNewNotebookButton && (
+        <div
+          style={{display: 'flex', justifyContent: 'space-between', gap: '8px'}}
+        >
+          {showCreateNewNotebookButton ? (
+            <Button
+              variant="contained"
+              onClick={() => history(ROUTES.CREATE_NEW_SURVEY)}
+              sx={{mb: 3, mt: 3, backgroundColor: theme.palette.primary.main}}
+              startIcon={<AddCircleSharpIcon />}
+            >
+              Create New {NOTEBOOK_NAME}
+            </Button>
+          ) : (
+            <div />
+          )}
           <Button
             variant="contained"
-            color="primary"
-            onClick={() => history(ROUTES.CREATE_NEW_SURVEY)}
+            disabled={refresh}
             sx={{mb: 3, mt: 3, backgroundColor: theme.palette.primary.main}}
-            startIcon={<AddCircleSharpIcon />}
+            startIcon={<RefreshOutlined />}
+            onClick={async () => {
+              setRefresh(true);
+              await syncRemoteProjects();
+              setRefresh(false);
+            }}
           >
-            Create New {NOTEBOOK_NAME}
+            Sync {NOTEBOOK_NAME}s
           </Button>
-        )}
+        </div>
         {NOTEBOOK_LIST_TYPE === 'tabs' ? (
           <Tabs
             projects={projects}

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -122,7 +122,7 @@ export default function NoteBooks() {
           type: 'string',
           flex: 0.4,
           minWidth: 160,
-          renderCell: ({row: {activated, name, description, status}}) => (
+          renderCell: ({row: {activated, name, description}}) => (
             <div>
               <div
                 style={{

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -40,7 +40,7 @@ import {RefreshOutlined} from '@mui/icons-material';
 
 export default function NoteBooks() {
   const [refresh, setRefresh] = useState(false);
-  const {projects, syncRemoteProjects} = useContext(ProjectsContext);
+  const {projects, syncProjects} = useContext(ProjectsContext);
 
   const activatedProjects = projects.filter(({activated}) => activated);
 
@@ -220,11 +220,11 @@ export default function NoteBooks() {
             startIcon={<RefreshOutlined />}
             onClick={async () => {
               setRefresh(true);
-              await syncRemoteProjects();
+              await syncProjects();
               setRefresh(false);
             }}
           >
-            Sync {NOTEBOOK_NAME}s
+            Refresh {NOTEBOOK_NAME}s
           </Button>
         </div>
         {NOTEBOOK_LIST_TYPE === 'tabs' ? (


### PR DESCRIPTION
## JIRA Ticket

[BSS-451](https://jira.csiro.au/browse/BSS-451)

## Description

Initialise surveys on page load and button to trigger remote sync manually.

## Proposed Changes

- added init/sync projects functions to context provider
- added init project to run on login
- added sync projects button
- made tab default to 2 if no activated projects

## How to Test

1. Log out of app
2. Log into app
3. Check that surveys are visible without refresh
4. (optional) Repeat 1-3 but clearing cache after logout
5. Add survey in conductor
6. Hit refresh button and ensure it becomes visible

## Additional Information

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
