### PR TITLE
Remove slotprops to fix CI build

### DIFF
--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -123,9 +123,6 @@ export const FieldEditor = ({
           display: 'none',
         },
       }}
-      slotProps={{
-        transition: {unmountOnExit: true},
-      }}
     >
       <AccordionSummary
         expandIcon={<ArrowForwardIosRoundedIcon sx={{fontSize: '1rem'}} />}


### PR DESCRIPTION
# Still trying to fix CI build of Designer

## JIRA Ticket

None

## Description

Still getting a build error in CI. This time remove slotProps which it claims does not
belong on Accordian contrary to the documentation and examples. 

Change means that each field will still be mounted on being closed, should not be 
an issue. 

## How to Test

Merge into main and hope that the CI build works

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
