### PR TITLE
Fix display and toggle of user roles

### DIFF
--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -303,6 +303,7 @@ app.get('/notebooks/:id/users', requireClusterAdmin, async (req, res) => {
     const notebook = await getNotebookMetadata(project_id);
 
     const userList = await getUserInfoForNotebook(project_id);
+
     res.render('users', {
       roles: userList.roles,
       users: userList.users,
@@ -320,17 +321,22 @@ app.get('/users', requireClusterAdmin, async (req, res) => {
   if (req.user) {
     const id = req.user._id;
     const userList = await getUsers();
+
+    const userListFiltered = userList
+      .filter(user => user._id !== id)
+      .map(user => {
+        return {
+          username: user._id,
+          name: user.name,
+          can_create_notebooks: userCanCreateNotebooks(user),
+          is_cluster_admin: userIsClusterAdmin(user),
+        };
+      });
+
     res.render('cluster-users', {
       cluster_admin: userIsClusterAdmin(req.user),
       can_create_notebooks: userCanCreateNotebooks(req.user),
-      users: userList
-        .filter(user => user._id !== id)
-        .map(user => {
-          return {
-            username: user._id,
-            name: user.name,
-          };
-        }),
+      users: userListFiltered,
     });
   } else {
     res.status(401).end();

--- a/api/views/cluster-users.handlebars
+++ b/api/views/cluster-users.handlebars
@@ -9,6 +9,9 @@
   make new notebooks that they will then be admin users on.
 </p>
 
+<p>Note that 'Cluster Admin' implies that the user can 'Create Notebooks'.
+</p>
+
 <div id="message">&nbsp;</div>
 
 <table class="table">


### PR DESCRIPTION
# Fix display and toggle of user roles

## JIRA Ticket

[BSS-467](https://jira.csiro.com/browse/BSS-467)

## Description

In Conductor, changing the roles of a user on the /users page didn't seem to work properly. Here we
fix this.

## Proposed Changes

The fix is to the display of roles, existing code did not properly display whether a user had these roles
or not.  Toggling the roles worked but since the page wasn't displaying them, it was confusing and
unuseable. 

## How to Test

Visit the /users page on Conductor where you have more than one user, you should be able to add roles
and refresh the page to see that they persist.

Note, there is a quirk in that 'cluster-admin'  implies notebook creation so if you toggle admin for a user
and refresh the page, create notebooks will be checked.  I decided not to write code to be any fancier 
than this but added a note into the page.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
