### PR TITLE
Fix form progress bar count

### DIFF
--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1164,13 +1164,6 @@ class RecordForm extends React.Component<
               }}
             >
               {formProps => {
-                this.props.setProgress?.(
-                  percentComplete(
-                    requiredFields(this.props.ui_specification.fields),
-                    formProps.values
-                  )
-                );
-
                 const layout =
                   this.props.ui_specification.viewsets[viewsetName]?.layout;
                 const views = getViewsMatchingCondition(
@@ -1179,6 +1172,17 @@ class RecordForm extends React.Component<
                   [],
                   viewsetName,
                   formProps.touched
+                );
+
+                // update the progress bar
+                this.props.setProgress?.(
+                  percentComplete(
+                    requiredFields(
+                      this.getViewsetName(),
+                      this.props.ui_specification
+                    ),
+                    formProps.values
+                  )
                 );
 
                 if (layout === 'inline')
@@ -1195,7 +1199,7 @@ class RecordForm extends React.Component<
                         );
 
                         return (
-                          <div>
+                          <div key={`form-${view}`}>
                             <h2>{ui_specification.views[view].label}</h2>
                             <Form>
                               {description !== '' && (

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -197,6 +197,7 @@ const FAIMSImageList = (props: ImageListProps) => {
         ) : (
           // ?? not allow user to delete image if the image is not download yet
           <FAIMSImageIconList
+            key={`${fieldName}-image-${index}`}
             index={index}
             setopen={setopen}
             fieldName={fieldName}

--- a/app/src/lib/form-utils.ts
+++ b/app/src/lib/form-utils.ts
@@ -2,14 +2,28 @@ import {ProjectUIModel} from '@faims3/data-model/build/src/types';
 
 /**
  * Retrieves the keys of fields that are marked as required from the given project UI model.
- *
- * @param {ProjectUIModel} fields - An object representing the project's UI model fields, where each field contains component parameters.
+ * @param {string} viewset - name of the viewset we are interested in
+ * @param {ProjectUIModel} uiSpec - The project UI Spec
  * @returns {string[]} An array of keys representing the fields that are marked as required.
  */
-export const requiredFields = (fields: ProjectUIModel): string[] =>
-  Object.entries(fields)
-    .filter(([, value]) => value['component-parameters'].required)
-    .map(([key]) => key);
+export const requiredFields = (
+  viewset: string,
+  uiSpec: ProjectUIModel
+): string[] => {
+  const required: string[] = [];
+  if (viewset in uiSpec.viewsets) {
+    const views = uiSpec.viewsets[viewset].views;
+
+    views.forEach((view: string) => {
+      const fields = uiSpec.views[view].fields;
+      fields.forEach((fieldname: string) => {
+        if (uiSpec.fields[fieldname]['component-parameters'].required)
+          required.push(fieldname);
+      });
+    });
+  }
+  return required;
+};
 
 /**
  * Determines whether a given value is considered "empty".


### PR DESCRIPTION
# Fix form progress bar count

## JIRA Ticket

None

## Description

The record completion progress bar was not working. It was counting
the percentiage of all fields in the uiSpec rather than those in 
the current form. 

Also fixed a warning about keys in the image list.

## How to Test

Progress bar should now show 100% completion when all required fields
are filled in.

## Additional Information

Note, I've left the update of the progress bar inside the render method since
there is no other place to put it that would work but it is updating the parent
state inside the render method which is bad form - get a warning if you refresh
the page when on the form but not in normal flow. 


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
