### PR TITLE
fix: only show prefix selector if more than one listing

### DIFF
--- a/app/src/gui/pages/shortcode.tsx
+++ b/app/src/gui/pages/shortcode.tsx
@@ -196,7 +196,7 @@ export function ShortCodeRegistration(props: ShortCodeProps) {
               sx: {fontFamily: 'monospace'},
               startAdornment: (
                 <InputAdornment position="start">
-                  {selectedPrefix}-
+                  {selectedPrefix} -
                 </InputAdornment>
               ),
             }}

--- a/app/src/gui/pages/shortcode.tsx
+++ b/app/src/gui/pages/shortcode.tsx
@@ -144,6 +144,9 @@ export function ShortCodeRegistration(props: ShortCodeProps) {
     }
   };
 
+  // only show the prefix selection dropdown if
+  const showPrefixSelector = props.listings.length > 1;
+
   return (
     <MainCard>
       <Stack spacing={2} sx={{p: 2}}>
@@ -156,26 +159,31 @@ export function ShortCodeRegistration(props: ShortCodeProps) {
         </Typography>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <FormControl sx={{minWidth: 80, maxWidth: 120}}>
-            <InputLabel
-              id="prefix-label"
-              sx={{backgroundColor: 'white', px: 1}}
-            >
-              Prefix
-            </InputLabel>
-            <Select
-              labelId="prefix-label"
-              value={selectedPrefix}
-              onChange={handlePrefixChange}
-              size="small"
-            >
-              {props.listings.map(listing => (
-                <MenuItem key={listing.prefix} value={listing.prefix}>
-                  {listing.prefix}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          {
+            // Only show selector if condition is true i.e. more than one listing
+          }
+          {showPrefixSelector && (
+            <FormControl sx={{minWidth: 80, maxWidth: 120}}>
+              <InputLabel
+                id="prefix-label"
+                sx={{backgroundColor: 'white', px: 1}}
+              >
+                Prefix
+              </InputLabel>
+              <Select
+                labelId="prefix-label"
+                value={selectedPrefix}
+                onChange={handlePrefixChange}
+                size="small"
+              >
+                {props.listings.map(listing => (
+                  <MenuItem key={listing.prefix} value={listing.prefix}>
+                    {listing.prefix}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
 
           <TextField
             value={shortCode}


### PR DESCRIPTION
# fix: only show prefix selector if more than one listing

We were having issues on iOS with a single listing of the prefix selector obscuring input on small/weird scaling displays. This is a **temporary fix** to facilitate user testing which conditionally renders the dropdown only when there is actually multiple listings to choose from. This allows the input field to scale to fill the whole available width.

Reasonable scaling example

![image](https://github.com/user-attachments/assets/d5f85df6-dc72-429a-a3de-c036b10c1728)

Exaggerated large scaling example

![image](https://github.com/user-attachments/assets/74989a1d-6fb8-4cbc-a852-bf677f3b5a5f)

