### PR TITLE
feat: make photo fields more prominent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ FROM node:20 AS app
 WORKDIR /usr/src
 COPY --from=builder /usr/src .
 EXPOSE 3000
-CMD ["npm", "run", "start-app"]
+CMD ["npm", "run", "force-start-app"]

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "scripts": {
         "prestart": "npm run runconfig",
         "start": "vite",
+        "force-start": "vite --force",
         "prebuild": "npm run runconfig",
         "build": "tsc && vite build",
         "pretest": "npm run compile",

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -22,13 +22,14 @@ import React from 'react';
 import {FieldProps} from 'formik';
 import Button, {ButtonProps} from '@mui/material/Button';
 import {Camera, CameraResultType, Photo} from '@capacitor/camera';
+import CameraAltIcon from '@mui/icons-material/CameraAlt';
 
 // import ImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
 import IconButton from '@mui/material/IconButton';
 import ImageIcon from '@mui/icons-material/Image';
-import {Typography} from '@mui/material';
+import {Box, InputAdornment, Typography, useMediaQuery} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {createTheme, styled} from '@mui/material/styles';
 import {List, ListItem} from '@mui/material';
@@ -287,21 +288,25 @@ export class TakePhoto extends React.Component<
     // But it doesn't look like we support masonry right now.
     //
     // It also looks like we don't have multiple photos being returned...
+
+    // We have two properties available here - both are optional
+    const buttonLabel = this.props.label ?? 'Take Photo';
+    const helperText =
+      this.props.helpertext ?? this.props.helperText ?? undefined;
+
     return (
       <div>
-        {this.props.helpertext || this.props.helperText}
+        <h3>{buttonLabel}</h3>
+        {helperText && <p>{helperText}</p>}
         <Button
-          variant="outlined"
-          color={'primary'}
-          style={{marginRight: '10px'}}
-          fullWidth={true}
-          onClick={async () => {
-            await this.takePhoto();
-          }}
+          variant="contained"
+          color="primary"
+          fullWidth={false}
+          onClick={this.takePhoto}
         >
-          {this.props.label !== undefined && this.props.label !== ''
-            ? this.props.label
-            : 'Take Photo'}
+          Take photo
+          <span style={{width: 10}} />
+          <CameraAltIcon />
         </Button>
         <FAIMSImageList
           images={this.state.images}

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -35,11 +35,15 @@ import {createTheme, styled} from '@mui/material/styles';
 import {logError} from '../../logging';
 import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
 
-interface MediaQueryWrapperProps {
+/**
+ * This functional component provides a isMobile flag which can be used in class
+ * components to dynamically style the component.
+ */
+function MediaQueryWrapper({
+  children,
+}: {
   children: (isMobile: boolean) => React.ReactNode;
-}
-
-function MediaQueryWrapper({children}: MediaQueryWrapperProps) {
+}) {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   return children(isMobile);
 }

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -18,23 +18,31 @@
  *   TODO : to add function check if photo be downloaded
  */
 
-import React from 'react';
-import {FieldProps} from 'formik';
-import Button, {ButtonProps} from '@mui/material/Button';
 import {Camera, CameraResultType, Photo} from '@capacitor/camera';
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
+import Button, {ButtonProps} from '@mui/material/Button';
+import {FieldProps} from 'formik';
+import React from 'react';
 
 // import ImageList from '@mui/material/ImageList';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ImageIcon from '@mui/icons-material/Image';
+import {List, ListItem, Typography, useMediaQuery} from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
-import IconButton from '@mui/material/IconButton';
-import ImageIcon from '@mui/icons-material/Image';
-import {Box, InputAdornment, Typography, useMediaQuery} from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
 import {createTheme, styled} from '@mui/material/styles';
-import {List, ListItem} from '@mui/material';
 import {logError} from '../../logging';
 import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
+
+interface MediaQueryWrapperProps {
+  children: (isMobile: boolean) => React.ReactNode;
+}
+
+function MediaQueryWrapper({children}: MediaQueryWrapperProps) {
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  return children(isMobile);
+}
 
 function base64image_to_blob(image: Photo): Blob {
   if (image.base64String === undefined) {
@@ -290,51 +298,55 @@ export class TakePhoto extends React.Component<
     // It also looks like we don't have multiple photos being returned...
 
     // We have two properties available here - both are optional
-    const buttonLabel = this.props.label ?? 'Take Photo';
+    const title = this.props.label;
     const helperText =
       this.props.helpertext ?? this.props.helperText ?? undefined;
 
     return (
-      <div>
-        <h3>{buttonLabel}</h3>
-        {helperText && <p>{helperText}</p>}
-        <Button
-          variant="contained"
-          color="primary"
-          fullWidth={false}
-          onClick={this.takePhoto}
-        >
-          Take photo
-          <span style={{width: 10}} />
-          <CameraAltIcon />
-        </Button>
-        <FAIMSImageList
-          images={this.state.images}
-          setopen={(path: string) =>
-            this.setState({open: true, photopath: path})
-          }
-          setimage={(newfiles: Array<any>) => {
-            this.props.form.setFieldValue(
-              this.props.field.name,
-              newfiles,
-              true
-            );
-          }}
-          disabled={this.props.disabled ?? false}
-          fieldName={this.props.field.name}
-        />
-        <Typography variant="caption" color="textSecondary">
-          {error_text}{' '}
-        </Typography>
-        <FaimsAttachmentManagerDialog
-          project_id={this.props.form.values['_project_id']}
-          open={this.state.open}
-          setopen={() => this.setState({open: false})}
-          filedId={this.props.id}
-          path={this.state.photopath}
-          isSyncing={this.props.issyncing}
-        />
-      </div>
+      <MediaQueryWrapper>
+        {isMobile => (
+          <div>
+            {title && <h3>{title}</h3>}
+            {helperText && <p>{helperText}</p>}
+            <Button
+              variant="contained"
+              color="primary"
+              fullWidth={isMobile ? true : false}
+              onClick={this.takePhoto}
+            >
+              Take photo
+              <span style={{width: 10}} />
+              <CameraAltIcon />
+            </Button>
+            <FAIMSImageList
+              images={this.state.images}
+              setopen={(path: string) =>
+                this.setState({open: true, photopath: path})
+              }
+              setimage={(newfiles: Array<any>) => {
+                this.props.form.setFieldValue(
+                  this.props.field.name,
+                  newfiles,
+                  true
+                );
+              }}
+              disabled={this.props.disabled ?? false}
+              fieldName={this.props.field.name}
+            />
+            <Typography variant="caption" color="textSecondary">
+              {error_text}{' '}
+            </Typography>
+            <FaimsAttachmentManagerDialog
+              project_id={this.props.form.values['_project_id']}
+              open={this.state.open}
+              setopen={() => this.setState({open: false})}
+              filedId={this.props.id}
+              path={this.state.photopath}
+              isSyncing={this.props.issyncing}
+            />
+          </div>
+        )}
+      </MediaQueryWrapper>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start": "npm start --workspace=api --workspace=app",
     "start-api": "npm start --workspace=api",
     "start-app": "npm start --workspace=app",
+    "force-start-app": "npm force-start --workspace=app",
     "watch-api": "npm run local --workspace=api",
     "start-designer": "npm run start --workspace=designer",
     "initdb": "npm run initdb --workspace=api",


### PR DESCRIPTION
# feat: make photo fields more prominent

Moves the 'label' text from the button itself to a <\h3\> component. Moves the helper text into a \<p\> element which helps with size and spacing. The button is adorned with a camera icon, and uses a contained style which makes it more visible. 

@stevecassidy worth considering if this change will negatively impact any existing notebooks which rely on the button text being the label - I didn't really personally think this was very helpful as the button always does the same thing, in any notebook, it 'takes a photo'. 

![image](https://github.com/user-attachments/assets/ade156c6-1094-4d38-993a-da7102e3da0a)


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
