### PR TITLE
feat: improved wording for active and not-active 

### DIFF
--- a/app/src/gui/components/notebook/settings/activation-switch.tsx
+++ b/app/src/gui/components/notebook/settings/activation-switch.tsx
@@ -4,7 +4,16 @@ import InfoIcon from '@mui/icons-material/Info';
 import {ProjectExtended} from '../../../../types/project';
 import {ProjectsContext} from '../../../../context/projects-context';
 import FaimsDialog from '../../ui/Faims_Dialog';
-import {NOTEBOOK_NAME_CAPITALIZED} from '../../../../buildconfig';
+import {
+  NOTEBOOK_NAME,
+  NOTEBOOK_NAME_CAPITALIZED,
+} from '../../../../buildconfig';
+import {
+  ACTIVATE_ACTIVE_VERB_LABEL,
+  ACTIVATE_VERB_LABEL,
+  ACTIVATED_LABEL,
+  DE_ACTIVATE_VERB,
+} from '../../workspace/notebooks';
 
 type NotebookActivationSwitchProps = {
   project: ProjectExtended;
@@ -38,15 +47,15 @@ export default function NotebookActivationSwitch({
         variant="outlined"
         disableElevation
       >
-        Activate
+        {ACTIVATE_VERB_LABEL}
       </Button>
       <FaimsDialog
         open={open}
-        title={`Activating ${NOTEBOOK_NAME_CAPITALIZED}s`}
+        title={`${ACTIVATE_ACTIVE_VERB_LABEL} ${NOTEBOOK_NAME_CAPITALIZED}s`}
         icon={<InfoIcon style={{fontSize: 40, color: '#1976d2'}} />}
         onClose={handleClose}
         onPrimaryAction={handleActivationClick}
-        primaryActionText="Activate"
+        primaryActionText={ACTIVATE_VERB_LABEL}
         primaryActionLoading={isWorking}
         primaryActionColor="primary"
         primaryActionVariant="contained"
@@ -54,22 +63,23 @@ export default function NotebookActivationSwitch({
       >
         <Box mb={2}>
           <Typography variant="body2" paragraph>
-            When a {NOTEBOOK_NAME_CAPITALIZED} is “Active” you are safe to work
-            offline at any point because all the data you collect will be saved
-            to your device. To activate your {NOTEBOOK_NAME_CAPITALIZED}, click
-            the "Activate" button below.
+            When a {NOTEBOOK_NAME_CAPITALIZED} is “{ACTIVATED_LABEL}” you are
+            safe to work offline at any point because all the data you collect
+            will be saved to your device. To {ACTIVATE_VERB_LABEL.toLowerCase()}{' '}
+            your {NOTEBOOK_NAME_CAPITALIZED}, click the "{ACTIVATE_VERB_LABEL}"
+            button below.
           </Typography>
           <Typography variant="body2" paragraph>
-            <b>Warning</b>: activating a {NOTEBOOK_NAME_CAPITALIZED} will start
-            the downloading of existing records onto your device. We recommend
-            you complete this procedure while you have a stable internet
-            connection.
+            <b>Warning</b>: {ACTIVATE_ACTIVE_VERB_LABEL.toLowerCase()} a{' '}
+            {NOTEBOOK_NAME_CAPITALIZED} will start the downloading of existing
+            records onto your device. We recommend you complete this procedure
+            while you have a stable internet connection.
             <br />
             <br />
-            Currently, you cannot de-activate a survey, this is something we
-            will be adding soon. If you need to make space on your device you
-            can clear the application storage or remove and reinstall the
-            application.
+            Currently, you cannot {DE_ACTIVATE_VERB.toLowerCase()} a{' '}
+            {NOTEBOOK_NAME}, this is something we will be adding soon. If you
+            need to make space on your device you can clear the application
+            storage or remove and reinstall the application.
           </Typography>
           {/*
           <Typography variant="subtitle1" fontWeight="bold">

--- a/app/src/gui/components/ui/heading-grid.tsx
+++ b/app/src/gui/components/ui/heading-grid.tsx
@@ -10,6 +10,7 @@ import {useNavigate} from 'react-router';
 import * as ROUTES from '../../../constants/routes';
 import {useEffect, useState} from 'react';
 import {theme} from '../../themes';
+import {ACTIVATED_LABEL, NOT_ACTIVATED_LABEL} from '../workspace/notebooks';
 
 /**
  * Renders a grid with two sections: Active and Not Active.
@@ -53,7 +54,7 @@ export default function HeadingProjectGrid({
   return (
     <div style={{display: 'flex', flexDirection: 'column'}}>
       <div style={{padding: '6px', fontSize: '18px', fontWeight: 'bold'}}>
-        Active
+        {ACTIVATED_LABEL}
       </div>
 
       <DataGrid
@@ -96,7 +97,7 @@ export default function HeadingProjectGrid({
       />
       <div style={{height: '16px'}} />
       <div style={{padding: '6px', fontSize: '18px', fontWeight: 'bold'}}>
-        Not active
+        {NOT_ACTIVATED_LABEL}
       </div>
       <DataGrid
         key={'notebook_list_datagrid_not_activated'}

--- a/app/src/gui/components/ui/tab-grid.tsx
+++ b/app/src/gui/components/ui/tab-grid.tsx
@@ -12,6 +12,7 @@ import {useNavigate} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
 import {useEffect, useState} from 'react';
 import {theme} from '../../themes';
+import { ACTIVATED_LABEL, NOT_ACTIVATED_LABEL } from '../workspace/notebooks';
 
 /**
  * Renders a tabbed grid component.
@@ -72,8 +73,8 @@ export default function TabProjectGrid({
               key={tab}
               label={
                 tab === '1'
-                  ? `Activated (${activatedProjects.length})`
-                  : `Available (${availableProjects.length})`
+                  ? `${ACTIVATED_LABEL} (${activatedProjects.length})`
+                  : `${NOT_ACTIVATED_LABEL} (${availableProjects.length})`
               }
               value={tab}
               disabled={

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -43,12 +43,24 @@ import NotebookSyncSwitch from '../notebook/settings/sync_switch';
 import HeadingProjectGrid from '../ui/heading-grid';
 import Tabs from '../ui/tab-grid';
 
-// What do we call notebooks which are not active?
+// Survey status naming conventions
+
+// E.g. "This survey is not active"
 export const NOT_ACTIVATED_LABEL = 'Not Active';
+
+// E.g. "This survey is active"
 export const ACTIVATED_LABEL = 'Active';
+
+// E.g. "This survey has been activated"
 export const ACTIVATED_VERB_PAST = 'Activated';
+
+// E.g. "Please activate this survey"
 export const ACTIVATE_VERB_LABEL = 'Activate';
+
+// E.g. "This survey is currently activating" or "Before activating, consider ..."
 export const ACTIVATE_ACTIVE_VERB_LABEL = 'Activating';
+
+// E.g. "You cannot currently de-activate a survey"
 export const DE_ACTIVATE_VERB = 'De-activate';
 
 export default function NoteBooks() {
@@ -311,11 +323,12 @@ export default function NoteBooks() {
           your device. {ACTIVATE_ACTIVE_VERB_LABEL} a {NOTEBOOK_NAME} will start
           the downloading of existing {NOTEBOOK_NAME} records onto your device.
           We recommend you complete this procedure while you have a stable
-          internet connection. Currently, you cannot {DE_ACTIVATE_VERB.toLowerCase()} a{' '}
-          {NOTEBOOK_NAME}, this is something we will be adding soon. If you need
-          to make space on your device you can clear the application storage or
-          delete the application. If a {NOTEBOOK_NAME} is "{NOT_ACTIVATED_LABEL}
-          " you are unable to start using it.
+          internet connection. Currently, you cannot{' '}
+          {DE_ACTIVATE_VERB.toLowerCase()} a {NOTEBOOK_NAME}, this is something
+          we will be adding soon. If you need to make space on your device you
+          can clear the application storage or delete the application. If a{' '}
+          {NOTEBOOK_NAME} is "{NOT_ACTIVATED_LABEL}" you are unable to start
+          using it.
         </Alert>
       </Box>
     </Box>

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -21,7 +21,7 @@
 import {RefreshOutlined} from '@mui/icons-material';
 import AddCircleSharpIcon from '@mui/icons-material/AddCircleSharp';
 import FolderIcon from '@mui/icons-material/Folder';
-import {Box, Button, Paper, Typography} from '@mui/material';
+import {Alert, AlertTitle, Box, Button, Paper, Typography} from '@mui/material';
 import {grey} from '@mui/material/colors';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -44,8 +44,12 @@ import HeadingProjectGrid from '../ui/heading-grid';
 import Tabs from '../ui/tab-grid';
 
 // What do we call notebooks which are not active?
-export const NOT_ACTIVATED_LABEL = 'Available';
+export const NOT_ACTIVATED_LABEL = 'Not Active';
+export const ACTIVATED_LABEL = 'Active';
+export const ACTIVATED_VERB_PAST = 'Activated';
 export const ACTIVATE_VERB_LABEL = 'Activate';
+export const ACTIVATE_ACTIVE_VERB_LABEL = 'Activating';
+export const DE_ACTIVATE_VERB = 'De-activate';
 
 export default function NoteBooks() {
   const [refresh, setRefresh] = useState(false);
@@ -162,7 +166,7 @@ export default function NoteBooks() {
             </div>
           ),
         },
-        // commenting this untill the functionality is fixed for this column.
+        // commenting this until the functionality is fixed for this column.
 
         // {
         //   field: 'last_updated',
@@ -195,32 +199,49 @@ export default function NoteBooks() {
     ? userHasRoleInAnyListing(allUserInfo.data, CREATE_NOTEBOOK_ROLES)
     : false;
 
-  /**
-   * Determines the label for the button based on the notebook list type.
-   * If the notebook list type is 'headings', the label will be 'Not Active'.
-   * If the notebook list type is 'tabs', the label will be 'Available'.
-   */
+  // What type of layout are we using?
+  const isTabs = NOTEBOOK_LIST_TYPE === 'tabs';
+  const sectionLabel = isTabs ? 'tab' : 'section';
 
-  const isTabs = NOTEBOOK_LIST_TYPE === 'headings';
+  const buildTabLink = (target: 'active' | 'not active') => {
+    switch (target) {
+      case 'active':
+        return (
+          <Button variant="text" size={'medium'} onClick={() => setTabID('1')}>
+            "{ACTIVATED_LABEL}" tab
+          </Button>
+        );
+      case 'not active':
+        return (
+          <Button variant="text" size={'medium'} onClick={() => setTabID('2')}>
+            {NOT_ACTIVATED_LABEL} tab
+          </Button>
+        );
+    }
+  };
 
   const notActivatedAdvice = (
     <>
       You have {activatedProjects.length} {NOTEBOOK_NAME}
-      {activatedProjects.length !== 1 ? 's' : ''} currently activated on this
-      device. To start using a {NOTEBOOK_NAME}, visit the{' '}
+      {activatedProjects.length !== 1 ? 's' : ''} currently {ACTIVATED_LABEL} on
+      this device. {NOTEBOOK_NAME_CAPITALIZED}s in the{' '}
       {isTabs ? (
-        // In the tab case, link directly to tab
-        <>
-          <Button variant="text" size={'small'} onClick={() => setTabID('2')}>
-            {NOT_ACTIVATED_LABEL}
-          </Button>{' '}
-          tab
-        </>
+        <>{buildTabLink('not active')}</>
       ) : (
-        // In the section case, just reference the section
-        <>'{NOT_ACTIVATED_LABEL}' section</>
+        <>
+          "{NOT_ACTIVATED_LABEL}" {sectionLabel}
+        </>
+      )}
+      need to be {ACTIVATED_VERB_PAST.toLowerCase()} before they can be used. To
+      start using a {NOTEBOOK_NAME_CAPITALIZED} in the{' '}
+      {isTabs ? (
+        <>{buildTabLink('not active')}</>
+      ) : (
+        <>
+          "{NOT_ACTIVATED_LABEL}" {sectionLabel}
+        </>
       )}{' '}
-      and click the '{ACTIVATE_VERB_LABEL}' button.
+      click the "{ACTIVATE_VERB_LABEL}" button.
     </>
   );
 
@@ -281,6 +302,21 @@ export default function NoteBooks() {
         ) : (
           <HeadingProjectGrid projects={projects} columns={columns} />
         )}
+        <Alert severity="info">
+          <AlertTitle>
+            What does {ACTIVATED_LABEL} and {NOT_ACTIVATED_LABEL} mean?
+          </AlertTitle>
+          When a {NOTEBOOK_NAME} is “{ACTIVATED_LABEL}” you are safe to work
+          offline at any point because all the data you collect will be saved to
+          your device. {ACTIVATE_ACTIVE_VERB_LABEL} a {NOTEBOOK_NAME} will start
+          the downloading of existing {NOTEBOOK_NAME} records onto your device.
+          We recommend you complete this procedure while you have a stable
+          internet connection. Currently, you cannot {DE_ACTIVATE_VERB.toLowerCase()} a{' '}
+          {NOTEBOOK_NAME}, this is something we will be adding soon. If you need
+          to make space on your device you can clear the application storage or
+          delete the application. If a {NOTEBOOK_NAME} is "{NOT_ACTIVATED_LABEL}
+          " you are unable to start using it.
+        </Alert>
       </Box>
     </Box>
   );

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -18,6 +18,7 @@
  *   TODO
  */
 
+import {RefreshOutlined} from '@mui/icons-material';
 import AddCircleSharpIcon from '@mui/icons-material/AddCircleSharp';
 import FolderIcon from '@mui/icons-material/Folder';
 import {Box, Button, Paper, Typography} from '@mui/material';
@@ -25,7 +26,7 @@ import {grey} from '@mui/material/colors';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {GridColDef} from '@mui/x-data-grid';
-import React, {useContext, useState} from 'react';
+import {useContext, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {
   NOTEBOOK_LIST_TYPE,
@@ -33,6 +34,7 @@ import {
   NOTEBOOK_NAME_CAPITALIZED,
 } from '../../../buildconfig';
 import * as ROUTES from '../../../constants/routes';
+import {useNotification} from '../../../context/popup';
 import {ProjectsContext} from '../../../context/projects-context';
 import {ProjectExtended} from '../../../types/project';
 import {CREATE_NOTEBOOK_ROLES, userHasRoleInAnyListing} from '../../../users';
@@ -40,8 +42,6 @@ import {useGetAllUserInfo} from '../../../utils/useGetCurrentUser';
 import NotebookSyncSwitch from '../notebook/settings/sync_switch';
 import HeadingProjectGrid from '../ui/heading-grid';
 import Tabs from '../ui/tab-grid';
-import {RefreshOutlined} from '@mui/icons-material';
-import {useNotification} from '../../../context/popup';
 
 // What do we call notebooks which are not active?
 export const NOT_ACTIVATED_LABEL = 'Available';

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -186,6 +186,14 @@ export default function NoteBooks() {
     ? userHasRoleInAnyListing(allUserInfo.data, CREATE_NOTEBOOK_ROLES)
     : false;
 
+  /**
+   * Determines the label for the button based on the notebook list type.
+   * If the notebook list type is 'headings', the label will be 'Not Active'.
+   * If the notebook list type is 'tabs', the label will be 'Available'.
+   */
+  const buttonLabel =
+    NOTEBOOK_LIST_TYPE === 'headings' ? 'Not Active' : 'Available';
+
   return (
     <Box>
       <Box component={Paper} elevation={0} p={2}>
@@ -194,7 +202,7 @@ export default function NoteBooks() {
           {activatedProjects.length !== 1 ? 's' : ''} activated on this device.
           To start using a {NOTEBOOK_NAME}, visit the{' '}
           <Button variant="text" size={'small'} onClick={() => setTabID('2')}>
-            Available
+            {buttonLabel}
           </Button>{' '}
           tab and click the activate button.
         </Typography>

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -243,7 +243,7 @@ export default function NoteBooks() {
         <>
           "{NOT_ACTIVATED_LABEL}" {sectionLabel}
         </>
-      )}
+      )}{' '}
       need to be {ACTIVATED_VERB_PAST.toLowerCase()} before they can be used. To
       start using a {NOTEBOOK_NAME_CAPITALIZED} in the{' '}
       {isTabs ? (

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -199,12 +199,12 @@ export default function NoteBooks() {
       <Box component={Paper} elevation={0} p={2}>
         <Typography variant={'body1'} gutterBottom>
           You have {activatedProjects.length} {NOTEBOOK_NAME}
-          {activatedProjects.length !== 1 ? 's' : ''} activated on this device.
-          To start using a {NOTEBOOK_NAME}, visit the{' '}
+          {activatedProjects.length !== 1 ? 's' : ''} currently activated on
+          this device. To start using a {NOTEBOOK_NAME}, visit the{' '}
           <Button variant="text" size={'small'} onClick={() => setTabID('2')}>
             {buttonLabel}
           </Button>{' '}
-          tab and click the activate button.
+          tab and click the 'Activate' button.
         </Typography>
         <div
           style={{display: 'flex', justifyContent: 'space-between', gap: '8px'}}

--- a/app/src/gui/pages/workspace.tsx
+++ b/app/src/gui/pages/workspace.tsx
@@ -23,14 +23,20 @@ import {Typography, Grid} from '@mui/material';
 import Notebooks from '../components/workspace/notebooks';
 import Breadcrumbs from '../components/ui/breadcrumbs';
 import {NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
+import {useTheme} from '@mui/material/styles';
 
 export default function Workspace() {
+  const theme = useTheme();
   return (
     <React.Fragment>
       <Breadcrumbs data={[{title: 'Workspace'}]} />
       <Grid container spacing={3}>
         <Grid item xs={12} md={12} lg={8}>
-          <Typography variant="h6" color="textSecondary">
+          <Typography
+            variant="h1"
+            color="textSecondary"
+            style={{marginBottom: theme.spacing(2)}}
+          >
             My {NOTEBOOK_NAME_CAPITALIZED}s
           </Typography>
           <Notebooks />


### PR DESCRIPTION
# feat: improved wording for active and not-active 

## Description

Update the wording as per discussion - make these values consistent and configurable to make edits faster in the future. 

## Screenshots

### Notebook list (headings)

![image](https://github.com/user-attachments/assets/c2342360-d225-4810-8722-0a43995bad79)

### Notebook list (tabs)

![image](https://github.com/user-attachments/assets/bd9b35a1-91f7-467b-9362-e125ca0e5983)

### Activate warning

![image](https://github.com/user-attachments/assets/fbf092a8-4c24-464d-9af4-e723a1f2e7a8)


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
