### PR TITLE
feat: improved permission handling for MapFormField

### DIFF
--- a/app/src/gui/fields/maps/MapFormField.tsx
+++ b/app/src/gui/fields/maps/MapFormField.tsx
@@ -29,9 +29,10 @@ import {FieldProps} from 'formik';
 import {Alert} from '@mui/material';
 import {Capacitor} from '@capacitor/core';
 import {APP_NAME} from '../../../buildconfig';
+import {useNotification} from '../../../context/popup';
 
 // If no center is available - pass this through
-const FALLBACK_CENTER = [0, 0];
+const FALLBACK_CENTER = [151.2093, -33.8688];
 
 export interface MapFieldProps extends FieldProps {
   label?: string;
@@ -78,6 +79,9 @@ export function MapFormField({
     form.setFieldValue(field.name, theFeatures, true);
   };
 
+  // notification manager
+  const notify = useNotification();
+
   useEffect(() => {
     const getCoords = async () => {
       // Always get current position on component mount - this forces a permission
@@ -96,6 +100,9 @@ export function MapFormField({
             setNoPermission(false);
           })
           .catch(() => {
+            notify.showWarning(
+              'We were unable to access your current location. Map fields may not work as expected.'
+            );
             setNoPermission(true);
           });
       }
@@ -131,6 +138,7 @@ export function MapFormField({
           features={drawnFeatures}
           zoom={zoom}
           center={center ?? FALLBACK_CENTER}
+          fallbackCenter={center === undefined}
           callbackFn={mapCallback}
           geoTiff={props.geoTiff}
           projection={props.projection}

--- a/app/src/gui/fields/maps/MapFormField.tsx
+++ b/app/src/gui/fields/maps/MapFormField.tsx
@@ -32,6 +32,7 @@ import {APP_NAME} from '../../../buildconfig';
 import {useNotification} from '../../../context/popup';
 
 // If no center is available - pass this through
+// Sydney CBD
 const FALLBACK_CENTER = [151.2093, -33.8688];
 
 export interface MapFieldProps extends FieldProps {
@@ -51,10 +52,10 @@ export function MapFormField({
 }: MapFieldProps): JSX.Element {
   // State
 
-  // center to show on map - use provided center if any
+  // center location of map - use provided center if any
   const [center, setCenter] = useState<number[] | undefined>(props.center);
 
-  // and a ref to track if gps center has already been requested
+  // and a ref to track if gps location has already been requested
   const gpsCenterRequested = useRef<boolean>(false);
 
   // flag set if we find we don't have location permission

--- a/app/src/gui/fields/maps/MapFormField.tsx
+++ b/app/src/gui/fields/maps/MapFormField.tsx
@@ -73,7 +73,7 @@ export function MapFormField({
   const featureType = props.featureType ?? 'Point';
 
   // default label
-  const label = `Get ${props.featureType}`;
+  const label = props.label ?? `Get ${props.featureType}`;
 
   const mapCallback = (theFeatures: GeoJSONFeatureCollection) => {
     setDrawnFeatures(theFeatures);

--- a/app/src/gui/fields/maps/MapFormField.tsx
+++ b/app/src/gui/fields/maps/MapFormField.tsx
@@ -18,7 +18,7 @@
  *   Implement MapFormField for entry of data via maps in FAIMS
  */
 
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import './MapFormField.css';
 import MapWrapper from './MapWrapper';
 
@@ -29,6 +29,10 @@ import {FieldProps} from 'formik';
 import {Alert} from '@mui/material';
 import {Capacitor} from '@capacitor/core';
 import {APP_NAME} from '../../../buildconfig';
+
+// If no center is available - pass this through
+const FALLBACK_CENTER = [0, 0];
+
 export interface MapFieldProps extends FieldProps {
   label?: string;
   featureType: 'Point' | 'Polygon' | 'LineString';
@@ -44,52 +48,60 @@ export function MapFormField({
   form,
   ...props
 }: MapFieldProps): JSX.Element {
-  // get previous form state if available
-  let initialFeatures = {};
-  if (form.values[field.name]) {
-    initialFeatures = form.values[field.name];
-  }
+  // State
+
+  // center to show on map - use provided center if any
+  const [center, setCenter] = useState<number[] | undefined>(props.center);
+
+  // and a ref to track if gps center has already been requested
+  const gpsCenterRequested = useRef<boolean>(false);
 
   // flag set if we find we don't have location permission
   const [noPermission, setNoPermission] = useState(false);
 
-  const [drawnFeatures, setDrawnFeatures] =
-    useState<GeoJSONFeatureCollection>(initialFeatures);
+  // Use form value as default field features - otherwise empty {}
+  const [drawnFeatures, setDrawnFeatures] = useState<GeoJSONFeatureCollection>(
+    form.values[field.name] ?? {}
+  );
 
-  // default props.center if not defined
-  if (!props.center) {
-    props.center = [0, 0];
-  }
-  const [center, setCenter] = useState(props.center);
-
-  if (!props.zoom) {
-    props.zoom = 14;
-  }
+  // Default zoom level
+  const zoom = props.zoom ?? 14;
 
   // default to point if not specified
-  if (!props.featureType) {
-    props.featureType = 'Point';
-  }
+  const featureType = props.featureType ?? 'Point';
 
-  if (!props.label) {
-    props.label = `Get ${props.featureType}`;
-  }
+  // default label
+  const label = `Get ${props.featureType}`;
 
   const mapCallback = (theFeatures: GeoJSONFeatureCollection) => {
     setDrawnFeatures(theFeatures);
     form.setFieldValue(field.name, theFeatures, true);
   };
 
-  // get the current GPS location if don't know the map center
-  if (center[0] === 0 && center[1] === 0) {
-    Geolocation.getCurrentPosition()
-      .then(result => {
-        setCenter([result.coords.longitude, result.coords.latitude]);
-      })
-      .catch(() => {
-        setNoPermission(true);
-      });
-  }
+  useEffect(() => {
+    const getCoords = async () => {
+      // Always get current position on component mount - this forces a permission
+      // request
+      if (!gpsCenterRequested.current) {
+        // Mark that we've requested already
+        gpsCenterRequested.current = true;
+        Geolocation.getCurrentPosition()
+          .then(result => {
+            // Only store the center result if we actually need it
+            if (center === undefined) {
+              setCenter([result.coords.longitude, result.coords.latitude]);
+            }
+            // Since we use a ref to track this running, we can safely run a state
+            // update here without infinite loop
+            setNoPermission(false);
+          })
+          .catch(() => {
+            setNoPermission(true);
+          });
+      }
+    };
+    getCoords();
+  }, []);
 
   let valueText = '';
   if (drawnFeatures.features && drawnFeatures.features.length > 0) {
@@ -114,13 +126,11 @@ export function MapFormField({
     <div>
       <div>
         <MapWrapper
-          label={
-            props.label ? props.label : 'Get ' + props.featureType + ' from Map'
-          }
-          featureType={props.featureType}
+          label={label}
+          featureType={featureType}
           features={drawnFeatures}
-          zoom={props.zoom}
-          center={center}
+          zoom={zoom}
+          center={center ?? FALLBACK_CENTER}
           callbackFn={mapCallback}
           geoTiff={props.geoTiff}
           projection={props.projection}

--- a/app/src/gui/fields/maps/MapWrapper.tsx
+++ b/app/src/gui/fields/maps/MapWrapper.tsx
@@ -59,6 +59,7 @@ interface MapProps extends ButtonProps {
   featureType: 'Point' | 'Polygon' | 'LineString';
   zoom: number;
   center: Array<number>;
+  fallbackCenter: boolean;
   callbackFn: (features: object) => void;
   setNoPermission: (flag: boolean) => void;
 }
@@ -67,6 +68,7 @@ import {AppBar, Dialog, IconButton, Toolbar, Typography} from '@mui/material';
 import Feature from 'ol/Feature';
 import {Geometry} from 'ol/geom';
 import {createCenterControl} from '../../components/map/center-control';
+import {useNotification} from '../../../context/popup';
 
 const styles = {
   mapContainer: {
@@ -85,6 +87,9 @@ function MapWrapper(props: MapProps) {
     useState<VectorLayer<Feature<Geometry>>>();
   const defaultMapProjection = 'EPSG:3857';
   const geoJson = new GeoJSON();
+
+  // notifications
+  const notify = useNotification();
 
   // create state ref that can be accessed in OpenLayers onclick callback function
   //  https://stackoverflow.com/a/60643670
@@ -232,15 +237,13 @@ function MapWrapper(props: MapProps) {
   };
 
   const handleClickOpen = () => {
-    // only show the map if we have a center
-    if (props.center[0] !== 0 && props.center[1] !== 0) {
-      setMapOpen(true);
-      // reset this in case we set it before
-      props.setNoPermission(false);
-    } else {
-      props.setNoPermission(true);
+    if (props.fallbackCenter) {
+      notify.showWarning(
+        'Using default map location - unable to determine current location and no center location configured.'
+      );
     }
-    // TODO: should do something to inform the user here...
+    // We always provide a center, so it's always safe to open the map
+    setMapOpen(true);
   };
 
   const refCallback = (element: HTMLElement | null) => {


### PR DESCRIPTION
# feat: improved permission handling for MapFormField

This PR enables a center to be defined while still requesting and gracefully handling a current location call (which prompts permission check). This is to allow user testing with the following workflow. 

This might be temporary since in reality we probably don't need to ask for the user's location if we don't intend to actually use it. 

Technical changes include:
- useEffect with useRef to only run once
- use const variables instead of modifying readonly props
- only store get location result if center is not defined in props
- add alerts for warning conditions such as not being able to access location
- add alerts for using default map center location (no current location available AND no configured center location) - this defaults to Sydney

## How to Test

Try different permutations of permissions yes, no, ask, as well as providing and not providing a center in the notebook definition. Check it always respects the center provided, shows errors where appropriate, and notifications work. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
