### PR TITLE
Improve Auto-incrementers

### DIFF
--- a/app/src/gui/components/autoincrement/edit-form.test.tsx
+++ b/app/src/gui/components/autoincrement/edit-form.test.tsx
@@ -19,7 +19,7 @@
  */
 
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
-import BasicAutoIncrementer from './edit-form';
+import {AutoIncrementEditForm} from './edit-form';
 import {expect, describe, it} from 'vitest';
 
 const props = {
@@ -27,11 +27,13 @@ const props = {
   form_id: '',
   field_id: '',
   label: '',
+  open: true,
+  handleClose: () => {},
 };
 
 describe('Check edit-form component', () => {
   it('Check add btn', async () => {
-    render(<BasicAutoIncrementer {...props} />);
+    render(<AutoIncrementEditForm {...props} />);
     const addRangeBtn = screen.getByTestId('addNewRangeBtn');
 
     await waitFor(() => {
@@ -45,7 +47,7 @@ describe('Check edit-form component', () => {
     });
   });
   it('Check remove btn', async () => {
-    render(<BasicAutoIncrementer {...props} />);
+    render(<AutoIncrementEditForm {...props} />);
     const addRangeBtn = screen.getByTestId('addNewRangeBtn');
 
     await waitFor(() => {
@@ -67,7 +69,7 @@ describe('Check edit-form component', () => {
     });
   });
   it('Check adding range start and stop fields', async () => {
-    render(<BasicAutoIncrementer {...props} />);
+    render(<AutoIncrementEditForm {...props} />);
     const addRangeBtn = screen.getByTestId('addNewRangeBtn');
 
     await waitFor(() => {

--- a/app/src/gui/components/autoincrement/edit-form.tsx
+++ b/app/src/gui/components/autoincrement/edit-form.tsx
@@ -48,7 +48,6 @@ import {
   createNewAutoincrementRange,
 } from '../../../local-data/autoincrement';
 import CloseIcon from '@mui/icons-material/Close';
-import {all} from 'ol/events/condition';
 
 interface Props {
   project_id: ProjectID;
@@ -57,11 +56,6 @@ interface Props {
   label: string;
   open: boolean;
   handleClose: () => void;
-}
-
-interface State {
-  ranges: LocalAutoIncrementRange[] | null;
-  ranges_initialised: boolean;
 }
 
 const FORM_SCHEMA = yup.object().shape({

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -154,7 +154,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
 
   const {data: template_id} = useQuery({
     queryKey: ['project-template-id', project.project_id],
-    queryFn: async () : Promise<string | null> => {
+    queryFn: async (): Promise<string | null> => {
       // don't return undefined from queryFn
       const id = await getMetadataValue(project.project_id, 'template_id');
       if (id !== undefined) return id as string;

--- a/app/src/gui/components/notebook/settings/auto_incrementers.tsx
+++ b/app/src/gui/components/notebook/settings/auto_incrementers.tsx
@@ -1,9 +1,9 @@
-import React, {useEffect} from 'react';
-import {Box, Grid, Typography, Paper, Alert} from '@mui/material';
+import React, {useEffect, useState} from 'react';
+import {Box, Grid, Typography, Paper, Alert, Button} from '@mui/material';
 import {ProjectInformation, ProjectUIModel} from '@faims3/data-model';
 import {getAutoincrementReferencesForProject} from '../../../../local-data/autoincrement';
 import {AutoIncrementReference} from '@faims3/data-model';
-import AutoIncrementEditForm from '../../autoincrement/edit-form';
+import {AutoIncrementEditForm} from '../../autoincrement/edit-form';
 import {logError} from '../../../../logging';
 
 interface AutoIncrementerSettingsListProps {
@@ -11,21 +11,11 @@ interface AutoIncrementerSettingsListProps {
   uiSpec: ProjectUIModel;
 }
 
-function get_form(section_id: string, uiSpec: ProjectUIModel) {
-  let form = '';
-  uiSpec.visible_types.map(viewset =>
-    uiSpec.viewsets[viewset].views.includes(section_id)
-      ? (form = uiSpec.viewsets[viewset].label ?? viewset)
-      : viewset
-  );
-  return form;
-}
 export default function AutoIncrementerSettingsList(
   props: AutoIncrementerSettingsListProps
 ) {
-  const [references, setReferences] = React.useState(
-    [] as AutoIncrementReference[]
-  );
+  const [open, setOpen] = useState(false);
+  const [references, setReferences] = useState([] as AutoIncrementReference[]);
   useEffect(() => {
     getAutoincrementReferencesForProject(props.project_info.project_id)
       .then(refs => {
@@ -35,62 +25,57 @@ export default function AutoIncrementerSettingsList(
   }, [props.project_info.project_id]);
 
   return (
-    <Grid container spacing={{xs: 1, sm: 2, md: 3}}>
+    <>
       {references.length === 0 ? (
-        <Grid item xs={12} sm={6} md={6}>
-          <Box component={Paper} variant={'outlined'} elevation={0}>
-            <Typography variant={'h6'} sx={{m: 2}}>
-              Edit Allocations
-            </Typography>
-            <Alert severity={'info'}>
-              This project has no Auto-Incrementers
-            </Alert>
-          </Box>
-        </Grid>
+        <></>
       ) : (
-        ''
+        <Box component={Paper} variant={'outlined'} p={2} elevation={0}>
+          <Typography variant={'h6'} gutterBottom>
+            Edit auto-incrementers
+          </Typography>
+          <Typography gutterBottom>
+            View and modify the range settings for auto-incrementers. These are
+            used to generate unique identifiers for records within a defined
+            range.
+          </Typography>
+
+          {references.map(ai => {
+            const label = ai.label ?? '';
+            return (
+              <Grid
+                item
+                xs={12}
+                sm={6}
+                md={6}
+                lg={4}
+                key={
+                  'autoincrementer_range_' + ai.form_id + ai.field_id + ai.label
+                }
+              >
+                <Box mt={1}>
+                  <AutoIncrementEditForm
+                    project_id={props.project_info.project_id}
+                    form_id={ai.form_id}
+                    field_id={ai.field_id}
+                    label={label}
+                    open={open}
+                    handleClose={() => setOpen(false)}
+                  />
+                  <Button
+                    variant="outlined"
+                    color={'primary'}
+                    onClick={() => {
+                      setOpen(true);
+                    }}
+                  >
+                    {label}
+                  </Button>
+                </Box>
+              </Grid>
+            );
+          })}
+        </Box>
       )}
-      {references.map(ai => {
-        // display form section label for user to fill Auto correctly
-        const section =
-          props.uiSpec['views'][ai.form_id] !== undefined
-            ? (props.uiSpec['views'][ai.form_id]['label'] ?? ai.form_id)
-            : ai.form_id;
-        const label =
-          get_form(ai.form_id, props.uiSpec) +
-          ' <' +
-          section +
-          '> ' +
-          (ai.label ?? '');
-        return (
-          <Grid
-            item
-            xs={12}
-            sm={6}
-            md={6}
-            lg={4}
-            key={'autoincrementer_range_' + ai.form_id + ai.field_id + ai.label}
-          >
-            <Box component={Paper} variant={'outlined'} p={2} elevation={0}>
-              <Typography variant={'h6'} gutterBottom>
-                Edit Allocations for {label}
-              </Typography>
-              <Typography variant={'caption'} sx={{mb: 2}} gutterBottom>
-                The allocated range will be &ge; the start value and &lt; the
-                stop value. e.g., a range allocation of start:1, stop:5 will
-                generate hrids in the range (1,2,3,4). There must always be a
-                least one range to ensure that new IDs can be generated.
-              </Typography>
-              <AutoIncrementEditForm
-                project_id={props.project_info.project_id}
-                form_id={ai.form_id}
-                field_id={ai.field_id}
-                label={label}
-              />
-            </Box>
-          </Grid>
-        );
-      })}
-    </Grid>
+    </>
   );
 }

--- a/app/src/gui/components/notebook/settings/auto_incrementers.tsx
+++ b/app/src/gui/components/notebook/settings/auto_incrementers.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Box, Grid, Typography, Paper, Alert, Button} from '@mui/material';
+import {Box, Grid, Typography, Paper, Button} from '@mui/material';
 import {ProjectInformation, ProjectUIModel} from '@faims3/data-model';
 import {getAutoincrementReferencesForProject} from '../../../../local-data/autoincrement';
 import {AutoIncrementReference} from '@faims3/data-model';

--- a/app/src/gui/fields/BasicAutoIncrementer.tsx
+++ b/app/src/gui/fields/BasicAutoIncrementer.tsx
@@ -15,29 +15,20 @@
  *
  * Filename: BasicAutoIncrementer.tsx
  * Description:
- *   TODO
+ *   Implements an auto-incrementer field that is hidden but provides
+ *   a value that can be used in templated string fields.
  */
 
-import React from 'react';
 import Input from '@mui/material/Input';
 import {FieldProps} from 'formik';
-import {ActionType} from '../../context/actions';
-import {store} from '../../context/store';
+import {useEffect, useState} from 'react';
 import {
   getLocalAutoincrementStateForField,
   setLocalAutoincrementStateForField,
 } from '../../local-data/autoincrement';
 
-import {
-  Grid,
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-} from '@mui/material';
-import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
+import {AutoIncrementEditForm} from '../components/autoincrement/edit-form';
+
 interface Props {
   num_digits: number;
   // This could be dropped depending on how multi-stage forms are configured
@@ -45,92 +36,24 @@ interface Props {
   label?: string;
 }
 
-interface State {
-  has_run: boolean;
-  is_ranger: boolean;
-  label: string;
-}
+export const BasicAutoIncrementer = (props: FieldProps & Props) => {
+  const [showAutoIncrementEditForm, setShowAutoIncrementEditForm] =
+    useState(false);
 
-function AddRangeDialog() {
-  const [open, setOpen] = React.useState(false);
-  return (
-    <Grid container>
-      <Button
-        onClick={() => setOpen(true)}
-        color={'error'}
-        variant={'text'}
-        disableElevation={true}
-      >
-        Add Range
-      </Button>
-      <Dialog
-        open={open}
-        onClose={() => setOpen(false)}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id="alert-dialog-title">Information</DialogTitle>
-        <DialogContent style={{width: '600px', height: '100px'}}>
-          <DialogContentText id="alert-dialog-description">
-            {`Go to ${NOTEBOOK_NAME_CAPITALIZED} > Settings Tab > Edit Allocations to Add New Range`}{' '}
-            <br />
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpen(false)} autoFocus>
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Grid>
-  );
-}
-
-export class BasicAutoIncrementer extends React.Component<
-  FieldProps & Props,
-  State
-> {
-  constructor(props: FieldProps & Props) {
-    super(props);
-    const label =
-      this.props.label !== '' && this.props.label !== undefined
-        ? this.props.label
-        : this.props.form_id;
-    this.state = {
-      has_run: false,
-      is_ranger: true,
-      label: label ?? this.props.form_id,
-    };
-  }
-
-  async get_id(): Promise<number | null> {
-    const project_id = this.props.form.values['_project_id'];
-    const form_id = this.props.form_id;
-    const field_id = this.props.field.name;
+  const get_id = async (): Promise<number | null> => {
+    const project_id = props.form.values['_project_id'];
+    const form_id = props.form_id;
+    const field_id = props.field.name;
     const local_state = await getLocalAutoincrementStateForField(
       project_id,
       form_id,
       field_id
     );
-    console.debug(
-      `local_auto_inc for ${project_id} ${form_id} ${field_id} is`,
-      local_state
-    );
     if (local_state.last_used_id === null && local_state.ranges.length === 0) {
-      // We have no range allocations, block
-      // TODO: add link to range allocation
-      (this.context as any).dispatch({
-        type: ActionType.ADD_ALERT,
-        payload: {
-          message: `No ranges exist for this ${NOTEBOOK_NAME} yet. Go to the ${NOTEBOOK_NAME} Settings tab to add/edit ranges.`,
-          severity: 'error',
-        },
-      });
-      this.setState({...this.state, is_ranger: false});
-      return null;
+      setShowAutoIncrementEditForm(true);
     }
+
     if (local_state.last_used_id === null) {
-      console.debug('local_auto_inc starting with clean slate');
       // We've got a clean slate with ranges allocated, start allocating ids
       const new_id = local_state.ranges[0].start;
       local_state.ranges[0].using = true;
@@ -138,12 +61,12 @@ export class BasicAutoIncrementer extends React.Component<
       await setLocalAutoincrementStateForField(local_state);
       return new_id;
     }
+
     // We're now using the allocated ranges, find where we've up to:
     // If we're using a range, find it
     for (const range of local_state.ranges) {
       if (range.using) {
         if (local_state.last_used_id + 1 < range.stop) {
-          console.debug('local_auto_inc using existing range', range);
           const next_id = local_state.last_used_id + 1;
           local_state.last_used_id = next_id;
           await setLocalAutoincrementStateForField(local_state);
@@ -151,100 +74,86 @@ export class BasicAutoIncrementer extends React.Component<
         }
         range.fully_used = true;
         range.using = false;
-        console.debug('local_auto_inc finished with range', range);
       }
     }
+
     // find a new range to use
     for (const range of local_state.ranges) {
+      console.debug('checking range', range);
       if (!range.fully_used) {
         const next_id = range.start;
         range.using = true;
         local_state.last_used_id = next_id;
-        console.debug('local_auto_inc staring with range', range);
         await setLocalAutoincrementStateForField(local_state);
         return next_id;
       }
     }
-    // we've got no new ranges to use, either we block, or use the highest range
-    // as a starting point
-    // TODO: Add blocking logic
-    let max_stop = local_state.last_used_id;
-    for (const range of local_state.ranges) {
-      if (range.stop > max_stop) {
-        max_stop = range.stop;
-      }
-    }
-    if (max_stop === local_state.last_used_id) {
-      max_stop = max_stop + 1;
-    }
-    local_state.last_used_id = max_stop;
-    await setLocalAutoincrementStateForField(local_state);
-    console.debug('local_auto_inc using overrun', local_state);
-    return max_stop;
-  }
+    // we've got no new ranges to use, ask the user to allocate more
 
-  async compute_id(num_digits: number): Promise<string | undefined> {
-    const new_id = await this.get_id();
+    setShowAutoIncrementEditForm(true);
+    return null;
+  };
+
+  const compute_id = async (
+    num_digits: number
+  ): Promise<string | undefined> => {
+    const new_id = await get_id();
     if (new_id === null || new_id === undefined) {
       return undefined;
     }
     return new_id.toString().padStart(num_digits, '0');
-  }
+  };
 
-  async update_form() {
-    const current_value = this.props.form.values[this.props.field.name];
-
-    if (!this.state.has_run) {
-      this.setState({has_run: true});
-      console.debug('running autoinc');
-      if (current_value === null) {
-        const new_id = await this.compute_id(this.props.num_digits || 4);
-        if (new_id === undefined) {
-          (this.context as any).dispatch({
-            type: ActionType.ADD_ALERT,
-            payload: {
-              message: 'Failed to get autoincremented ID',
-              severity: 'error',
-            },
-          });
-        } else {
-          this.props.form.setFieldValue(this.props.field.name, new_id, true);
-          if (this.props.form.errors[this.props.field.name] !== undefined)
-            this.props.form.setFieldError(this.props.field.name, undefined);
-        }
+  const update_form = async () => {
+    const current_value = props.form.values[props.field.name];
+    // we'll set the value in a form if the value has not already been set
+    // assume it has been set if the value is not null, empty or undefined
+    if (
+      current_value === null ||
+      current_value === '' ||
+      current_value === undefined
+    ) {
+      const new_id = await compute_id(props.num_digits || 4);
+      if (new_id === undefined) {
+        setShowAutoIncrementEditForm(true);
       } else {
-        if (this.props.form.errors[this.props.field.name] !== undefined)
-          this.props.form.setFieldError(this.props.field.name, undefined);
+        props.form.setFieldValue(props.field.name, new_id, true);
+        if (props.form.errors[props.field.name] !== undefined)
+          props.form.setFieldError(props.field.name, undefined);
       }
+    } else {
+      if (props.form.errors[props.field.name] !== undefined)
+        props.form.setFieldError(props.field.name, undefined);
     }
-  }
+  };
 
-  async componentDidMount() {
-    console.debug('did mount', this.props.form.values[this.props.field.name]);
-    await this.update_form();
-  }
-  // remove the update for form, should only be update once
-  // async componentDidUpdate() {
-  //   console.debug('did update',this.props.form.values[this.props.field.name])
-  //   await this.update_form();
-  // }
+  useEffect(() => {
+    update_form();
+  }, [props.form.values[props.field.name]]);
 
-  render() {
-    return (
-      <>
-        <Input
-          name={this.props.field.name}
-          id={this.props.field.name}
-          readOnly={true}
-          type={'hidden'}
-        />
-        {this.state.is_ranger === false && <AddRangeDialog />}
-      </>
-    );
-  }
-}
-
-BasicAutoIncrementer.contextType = store;
+  return (
+    <>
+      <Input
+        name={props.field.name}
+        id={props.field.name}
+        readOnly={true}
+        type={'hidden'}
+      />
+      <AutoIncrementEditForm
+        project_id={props.form.values['_project_id']}
+        form_id={props.form_id}
+        field_id={props.field.name}
+        label={props.field.name}
+        open={showAutoIncrementEditForm}
+        handleClose={async () => {
+          console.debug('closing edit form');
+          await update_form();
+          setShowAutoIncrementEditForm(false);
+        }}
+      />
+    </>
+  );
+};
 
 // const uiSpec = {
 //   'component-namespace': 'faims-custom', // this says what web component to use to render/acquire value from

--- a/app/src/gui/fields/BasicAutoIncrementer.tsx
+++ b/app/src/gui/fields/BasicAutoIncrementer.tsx
@@ -51,6 +51,7 @@ export const BasicAutoIncrementer = (props: FieldProps & Props) => {
     );
     if (local_state.last_used_id === null && local_state.ranges.length === 0) {
       setShowAutoIncrementEditForm(true);
+      return null;
     }
 
     if (local_state.last_used_id === null) {
@@ -79,7 +80,6 @@ export const BasicAutoIncrementer = (props: FieldProps & Props) => {
 
     // find a new range to use
     for (const range of local_state.ranges) {
-      console.debug('checking range', range);
       if (!range.fully_used) {
         const next_id = range.start;
         range.using = true;
@@ -118,13 +118,11 @@ export const BasicAutoIncrementer = (props: FieldProps & Props) => {
         setShowAutoIncrementEditForm(true);
       } else {
         props.form.setFieldValue(props.field.name, new_id, true);
-        if (props.form.errors[props.field.name] !== undefined)
-          props.form.setFieldError(props.field.name, undefined);
       }
-    } else {
-      if (props.form.errors[props.field.name] !== undefined)
-        props.form.setFieldError(props.field.name, undefined);
     }
+    // reset any errors, we don't want to report these to the user
+    if (props.form.errors[props.field.name] !== undefined)
+      props.form.setFieldError(props.field.name, undefined);
   };
 
   useEffect(() => {
@@ -146,7 +144,6 @@ export const BasicAutoIncrementer = (props: FieldProps & Props) => {
         label={props.field.name}
         open={showAutoIncrementEditForm}
         handleClose={async () => {
-          console.debug('closing edit form');
           await update_form();
           setShowAutoIncrementEditForm(false);
         }}

--- a/designer/src/state/migrateNotebook.test.ts
+++ b/designer/src/state/migrateNotebook.test.ts
@@ -97,6 +97,13 @@ describe('Migrate Notebook Tests', () => {
     }
   });
 
+  test('fix auto incrementer initial value', () => {
+    const migrated = migrateNotebook(sampleNotebook);
+    const fields = migrated['ui-specification'].fields;
+    const targetField = fields['Field-ID'];
+    expect(targetField.initialValue).toBe('');
+  });
+
   test('update form descriptions', () => {
     const migrated = migrateNotebook(sampleNotebook);
     const fviews = migrated['ui-specification'].fviews;

--- a/designer/src/state/migrateNotebook.ts
+++ b/designer/src/state/migrateNotebook.ts
@@ -44,6 +44,9 @@ export const migrateNotebook = (notebook: unknown) => {
   // fix validation for photo fields which had a bad default
   fixPhotoValidation(notebookCopy);
 
+  // fix bad autoincrementer initial value
+  fixAutoIncrementerInitialValue(notebookCopy);
+
   return notebookCopy;
 };
 
@@ -233,6 +236,29 @@ const fixPhotoValidation = (notebook: Notebook) => {
     if (field['component-name'] === 'TakePhoto') {
       if (field.validationSchema?.length === 2)
         field.validationSchema = goodValidation;
+    }
+
+    fields[fieldName] = field;
+  }
+
+  notebook['ui-specification'].fields = fields;
+};
+
+/**
+ * In some old notebooks, the initialValue of an auto incrementer was null
+ * which conflicts with the validate schema and triggers an error
+ * message on load in some cases.  Here we replace that with the empty string.
+ *
+ * @param notebook A notebook that might be out of date, modified
+ */
+const fixAutoIncrementerInitialValue = (notebook: Notebook) => {
+  const fields: {[key: string]: FieldType} = {};
+
+  for (const fieldName in notebook['ui-specification'].fields) {
+    const field = notebook['ui-specification'].fields[fieldName];
+
+    if (field['component-name'] === 'BasicAutoIncrementer') {
+      if (field.initialValue === null) field.initialValue = '';
     }
 
     fields[fieldName] = field;


### PR DESCRIPTION

# Fix: Improve Auto-incrementers

## JIRA Ticket

None

## Description

Auto increment fields are used to generate human readable IDs for records.  There 
was a bug that caused them to not work if the initial value of the field was 
set to "" as it was in the designer. 

These fields require that a range of numbers is set for the device before records can
be properly created.  The past behaviour was to notice when they weren't set up but
not really help the user set them.

## Proposed Changes

- Deals with the case when the initial value is ""
- Turn the range setting form into a popup dialog
- trigger the popup if a user tries to create a record without the ranges being set

## How to Test

Open a notebook with an auto increment field configured, eg. [Campus Survey](https://github.com/FAIMS/FAIMS3-Notebook-Campus-Survey-Demo).  Try to create
a record after activating the notebook, you should see a popup to allow you to set
the ranges.

Same popup is accessible via the Settings tab on the notebook.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
