### PR TITLE
get current location for overview map center, put a marker there

### DIFF
--- a/app/src/gui/components/notebook/overview_map.tsx
+++ b/app/src/gui/components/notebook/overview_map.tsx
@@ -140,9 +140,9 @@ export const OverviewMap = (props: OverviewMapProps) => {
   const mapRef = useRef<Map | undefined>();
   mapRef.current = map;
 
-  const {data: map_center} = useQuery<Array<number>>({
+  const {data: map_center} = useQuery({
     queryKey: ['current_location'],
-    queryFn: async () => {
+    queryFn: async (): Promise<[number, number]> => {
       const position = await Geolocation.getCurrentPosition();
       return [position.coords.longitude, position.coords.latitude];
     },
@@ -212,21 +212,24 @@ export const OverviewMap = (props: OverviewMapProps) => {
       }),
     });
 
-    const centerFeature = {
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: map_center,
-      },
-    };
+    // only do this if we have a real map_center, not the default 0,0
+    if (!(map_center[0] === 0 && map_center[1] === 0)) {
+      const centerFeature = {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: map_center,
+        },
+      };
 
-    source.addFeature(
-      geoJson.readFeature(centerFeature, {
-        dataProjection: 'EPSG:4326',
-        featureProjection: map.getView().getProjection(),
-      })
-    );
-    map.addLayer(layer);
+      source.addFeature(
+        geoJson.readFeature(centerFeature, {
+          dataProjection: 'EPSG:4326',
+          featureProjection: map.getView().getProjection(),
+        })
+      );
+      map.addLayer(layer);
+    }
   };
 
   /**

--- a/app/src/gui/components/notebook/overview_map.tsx
+++ b/app/src/gui/components/notebook/overview_map.tsx
@@ -41,7 +41,6 @@ import {Link} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
 import {createCenterControl} from '../map/center-control';
 import {Geolocation} from '@capacitor/geolocation';
-import {delay} from 'lodash';
 
 interface OverviewMapProps {
   uiSpec: ProjectUIModel;
@@ -147,7 +146,6 @@ export const OverviewMap = (props: OverviewMapProps) => {
       const position = await Geolocation.getCurrentPosition();
       return [position.coords.longitude, position.coords.latitude];
     },
-    initialData: [0, 0],
   });
 
   /**
@@ -202,8 +200,8 @@ export const OverviewMap = (props: OverviewMapProps) => {
       }),
     });
 
-    // only do this if we have a real map_center, not the default 0,0
-    if (!(map_center[0] === 0 && map_center[1] === 0)) {
+    // only do this if we have a real map_center
+    if (map_center) {
       const centerFeature = {
         type: 'Feature',
         geometry: {
@@ -259,8 +257,6 @@ export const OverviewMap = (props: OverviewMapProps) => {
       // don't fit if the extent is infinite because it crashes
       if (!extent.includes(Infinity)) {
         map.getView().fit(extent, {padding: [100, 100, 100, 100], maxZoom: 12});
-        const computedCenter = map.getView().getCenter();
-        console.log('computed center', computedCenter);
       }
     }
 


### PR DESCRIPTION
# Get current location for overview map center

## JIRA Ticket

None

## Description

The overview map had a fixed center point somewhere in Africa.  More useful to move it
to the current location.

## Proposed Changes

- get the current location when displaying the overview map, use it as the center point 
- add a marker (+) at the current location on the map

## How to Test

Open a notebook with geo-locations (BSS) and view the Map. See the cross at your current location.
Move the map, click the circle 'center map' button and see it center the map on your location.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
