### PR TITLE
Fix bugs saving drafts and storing photos

### DIFF
--- a/app/src/constants/privateRouter.tsx
+++ b/app/src/constants/privateRouter.tsx
@@ -20,7 +20,7 @@ export const PrivateRoute = (props: PrivateRouteProps): React.ReactElement => {
   // TODO use a context provider for listings instead of getting first entry
   const anyToken = useGetAnyToken();
   // The token is being retrieved
-  if (anyToken.isFetching) {
+  if (anyToken.isLoading) {
     return <LoadingApp />;
   }
 

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -406,7 +406,6 @@ class RecordForm extends React.Component<
       } catch (error) {
         // here if there was no existing record with this id above
         // so we ca't update revision_id so it is still undefined
-        if (DEBUG_APP) console.debug('new record', this.props.record_id);
       }
     }
     // work out the record type or default it
@@ -842,7 +841,7 @@ class RecordForm extends React.Component<
         // to never get here or provide a good reason if we do
         .catch(err => {
           const message = 'Could not save record';
-          console.error('Could not save record:', err);
+          logError(`Could not save record: ${JSON.stringify(err)}`);
           (this.context as any).dispatch({
             type: ActionType.ADD_ALERT,
             payload: {
@@ -1185,6 +1184,16 @@ class RecordForm extends React.Component<
                   )
                 );
 
+                // This fragment of code is critical to saving drafts, it needs
+                // to be called here on every render and as a side-effect will
+                // save the current draft.
+                this.draftState &&
+                  this.draftState.renderHook(
+                    formProps.values,
+                    this.state.annotation,
+                    this.state.relationship ?? {}
+                  );
+
                 if (layout === 'inline')
                   return (
                     <div>
@@ -1301,13 +1310,6 @@ class RecordForm extends React.Component<
                         </Box>
                       )}
                     </div>
-                  );
-
-                this.draftState &&
-                  this.draftState.renderHook(
-                    formProps.values,
-                    this.state.annotation,
-                    this.state.relationship ?? {}
                   );
 
                 const fieldNames = getFieldsMatchingCondition(


### PR DESCRIPTION
Signed-off-by: Steve Cassidy <steve.cassidy@mq.edu.au>

# Fix bugs saving drafts and storing photos

## JIRA Ticket

None

## Description

The app was not updating saved drafts as it should.  On IOS and Android, it would not save a photo after it was captured. 

## Proposed Changes

Very obscure bugs. 
- draft saving is triggered by a call in form.tsx that had been placed after a conditional for inline forms, so wasn't being called for inline forms
- photo saving was being interrupted by too frequent re-renders of the RecordForm component that lost data because it happened between GetPhoto returning and the data being stored.


## How to Test

Check Android and Apple builds, see how you are able to take photos, notice how the draft is updated if you quit out of the form without saving.

## Additional Information

OMG! OMG! OMG!

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
