### PR TITLE
Different conductor URL for production builds

### DIFF
--- a/.github/workflows/appstore-deploy.yml
+++ b/.github/workflows/appstore-deploy.yml
@@ -62,8 +62,8 @@ jobs:
           export VITE_CLUSTER_ADMIN_GROUP_NAME=cluster-admin
           export VITE_COMMIT_VERSION=${{env.version_string}}
           export VITE_SHOW_WIPE=true
-          export VITE_SHOW_MINIFAUXTON=true
-          export VITE_CONDUCTOR_URL=${{vars.NIGHTLY_CONDUCTOR_URL}}
+          export VITE_SHOW_MINIFAUXTON=false
+          export VITE_CONDUCTOR_URL=${{vars.PRODUCTION_CONDUCTOR_URL}}
           export VITE_TAG=prodIOS
           export VITE_NOTEBOOK_LIST_TYPE=${{vars.NOTEBOOK_LIST_TYPE}}
           export VITE_NOTEBOOK_NAME=${{vars.NOTEBOOK_NAME}}

--- a/.github/workflows/fieldmark-google-play-prod.yml
+++ b/.github/workflows/fieldmark-google-play-prod.yml
@@ -82,7 +82,7 @@ jobs:
           export VITE_COMMIT_VERSION=${{env.version_string}}
           export VITE_SHOW_WIPE=true
           export VITE_SHOW_MINIFAUXTON=false
-          export VITE_CONDUCTOR_URL=${{vars.NIGHTLY_CONDUCTOR_URL}}
+          export VITE_CONDUCTOR_URL=${{vars.PRODUCTION_CONDUCTOR_URL}}
           export VITE_TAG=prodAndroid
           export VITE_NOTEBOOK_LIST_TYPE=${{vars.NOTEBOOK_LIST_TYPE}}
           export VITE_NOTEBOOK_NAME=${{vars.NOTEBOOK_NAME}}


### PR DESCRIPTION
Signed-off-by: Steve Cassidy <steve.cassidy@mq.edu.au>

# Different conductor URL for production builds

## JIRA Ticket

None

## Description

Need a different configuration variable for production build server.

## Proposed Changes

Adds PRODUCTION_CONDUCTOR_URL to production builds.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
