### PR TITLE
fix: stopping key file path reading when key source is AWS_KM

### DIFF
--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -151,7 +151,7 @@ function key_file_path(): string {
   }
 }
 
-function private_key_path(): string {
+export function private_key_path(): string {
   let host = process.env.PROFILE_NAME;
   if (host === '' || host === undefined) {
     host = 'conductor';
@@ -168,7 +168,7 @@ function private_key_path(): string {
   }
 }
 
-function public_key_path(): string {
+export function public_key_path(): string {
   let host = process.env.PROFILE_NAME;
   if (host === '' || host === undefined) {
     host = 'conductor';
@@ -282,8 +282,6 @@ export const RUNNING_UNDER_TEST = is_testing();
 export const CONDUCTOR_PUBLIC_URL = conductor_url();
 export const CONDUCTOR_INTERNAL_PORT = conductor_internal_port();
 export const CONDUCTOR_KEY_ID = signing_key_id();
-export const CONDUCTOR_PRIVATE_KEY_PATH = private_key_path();
-export const CONDUCTOR_PUBLIC_KEY_PATH = public_key_path();
 export const CONDUCTOR_INSTANCE_NAME = instance_name();
 export const CONDUCTOR_SHORT_CODE_PREFIX = short_code_prefix();
 export const CONDUCTOR_DESCRIPTION = instance_description();

--- a/api/src/services/keyService.ts
+++ b/api/src/services/keyService.ts
@@ -3,9 +3,9 @@ import {importPKCS8, importSPKI, KeyLike} from 'jose';
 import {
   CONDUCTOR_INSTANCE_NAME,
   CONDUCTOR_KEY_ID,
-  CONDUCTOR_PUBLIC_KEY_PATH,
-  CONDUCTOR_PRIVATE_KEY_PATH,
   AWS_SECRET_KEY_ARN,
+  private_key_path,
+  public_key_path,
 } from '../buildconfig';
 import {SecretsManager} from 'aws-sdk';
 import NodeCache from 'node-cache';
@@ -288,8 +288,9 @@ export function createKeyService(
   switch (keySource) {
     case KeySource.FILE:
       return new FileKeyService(config, {
-        publicKeyFile: CONDUCTOR_PUBLIC_KEY_PATH,
-        privateKeyFile: CONDUCTOR_PRIVATE_KEY_PATH,
+        // This will error if the configuration is not setup properly
+        publicKeyFile: public_key_path(),
+        privateKeyFile: private_key_path(),
       });
     case KeySource.AWS_SM:
       if (!AWS_SECRET_KEY_ARN) {

--- a/api/src/services/keyService.ts
+++ b/api/src/services/keyService.ts
@@ -276,7 +276,7 @@ class AWSSecretsManagerKeyService extends BaseKeyService {
  * @returns An instance of IKeyService.
  * @throws Error if an unsupported key source is specified.
  */
-export function createKeyService(
+function createKeyService(
   keySource: KeySource = KeySource.FILE
 ): IKeyService {
   const config: KeyConfig = {

--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -259,6 +259,14 @@ export class FaimsFrontEnd extends Construct {
       hostedZone: props.designerHz,
       domainNames: props.designerDomainNames,
       removalPolicy: RemovalPolicy.DESTROY,
+      // Add custom header response overriding CSP to allow unsafe script
+      // execution due to parsing
+      securityHeadersBehavior: {
+        contentSecurityPolicy: {
+          contentSecurityPolicy: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';`,
+          override: true,
+        },
+      },
       errorResponses: [
         {
           httpStatus: 404,


### PR DESCRIPTION
# fix: stopping key file path reading when key source is AWS_KM and CSP changes

Previously the function was being called which threw an error if the file path was not specified. Given the file path does not always need to be specified this only calls the underlying function in the key source generation. This happens anyway during build config setup due to the creation of the key source service. This prevents an error in the latest nbic deployment.

Also updating some CSP settings for AWS deployment for designer fixing a bug with notebook upload.