### PR TITLE
feat: multi select conditions

### DIFF
--- a/app/src/conditionals.test.ts
+++ b/app/src/conditionals.test.ts
@@ -18,7 +18,11 @@
 
 // eslint-disable-next-line n/no-unpublished-import
 import {expect, it, describe} from 'vitest';
-import {compileExpression, getDependantFields} from './conditionals';
+import {
+  compileExpression,
+  getDependantFields,
+  isStringArray,
+} from './conditionals';
 
 describe('get dependant fields', () => {
   it('finds dependant fields in a nested expression', () => {
@@ -326,5 +330,30 @@ describe('compiling expressions', () => {
     // Regex explicitly expecting whitespace should be accurate - no stripping here
     expect(fn({tags: ['urgent', 'important']})).toBe(true);
     expect(fn({tags: ['urgent ']})).toBe(false);
+  });
+
+  it('checks that string arrays are valid', () => {
+    const shouldBeArrays = [['this', 'is'], [], ['single'], ['']];
+    const shouldNotBeArrays = [
+      false,
+      'string',
+      null,
+      undefined,
+      1,
+      ['valid', null],
+      [1],
+      ['valid', undefined],
+      [1, ''],
+    ];
+
+    for (const should of shouldBeArrays) {
+      const res = isStringArray(should);
+      expect(res).to.be.true;
+    }
+
+    for (const shouldNot of shouldNotBeArrays) {
+      const res = isStringArray(shouldNot);
+      expect(res).to.be.false;
+    }
   });
 });

--- a/app/src/conditionals.test.ts
+++ b/app/src/conditionals.test.ts
@@ -37,12 +37,13 @@ describe('get dependant fields', () => {
           conditions: [
             {operator: 'less', field: 'y', value: 10},
             {operator: 'greater', field: 'y', value: 100},
+            {operator: 'contains', field: 'z', value: 'test'},
           ],
         },
       ],
     };
     const fields = getDependantFields(expr);
-    expect(fields).toEqual(new Set(['x', 'y']));
+    expect(fields).toEqual(new Set(['x', 'y', 'z']));
   });
 });
 
@@ -225,5 +226,105 @@ describe('compiling expressions', () => {
     };
     const fn = compileExpression(expr);
     expect(fn({price: 100})).toBe(true);
+  });
+
+  it('compiles a contains expression', () => {
+    const expr = {
+      operator: 'contains',
+      field: 'tags',
+      value: 'urgent',
+    };
+    const fn = compileExpression(expr);
+    expect(fn({tags: ['urgent', 'important']})).toBe(true);
+    expect(fn({tags: ['important']})).toBe(false);
+    expect(fn({tags: []})).toBe(false);
+    expect(fn({other: ['urgent']})).toBe(false);
+  });
+
+  it('compiles a does-not-contain expression', () => {
+    const expr = {
+      operator: 'does-not-contain',
+      field: 'tags',
+      value: 'urgent',
+    };
+    const fn = compileExpression(expr);
+    expect(fn({tags: ['urgent', 'important']})).toBe(false);
+    expect(fn({tags: ['important']})).toBe(true);
+    expect(fn({tags: []})).toBe(true);
+    expect(fn({other: ['urgent']})).toBe(false);
+  });
+
+  it('compiles a contains-regex expression', () => {
+    const expr = {
+      operator: 'contains-regex',
+      field: 'tags',
+      value: '^urg.*$',
+    };
+    const fn = compileExpression(expr);
+    expect(fn({tags: ['urgent', 'important']})).toBe(true);
+    expect(fn({tags: ['urge']})).toBe(true);
+    expect(fn({tags: ['important']})).toBe(false);
+    expect(fn({other: ['urgent']})).toBe(false);
+  });
+
+  it('compiles a does-not-contain-regex expression', () => {
+    const expr = {
+      operator: 'does-not-contain-regex',
+      field: 'tags',
+      value: '^urg.*$',
+    };
+    const fn = compileExpression(expr);
+    expect(fn({tags: ['urgent', 'important']})).toBe(false);
+    expect(fn({tags: ['important']})).toBe(true);
+    expect(fn({tags: []})).toBe(true);
+    expect(fn({other: ['urgent']})).toBe(false);
+  });
+
+  it('handles whitespace in contains expression', () => {
+    const expr = {
+      operator: 'contains',
+      field: 'tags',
+      value: 'urgent',
+    };
+    const fn = compileExpression(expr);
+    // Can strip white space from search param AND
+    expect(fn({tags: ['urgent', 'important']})).toBe(true);
+    // Can strip whitespace from the list
+    expect(fn({tags: ['urgent ']})).toBe(true);
+  });
+
+  it('handles whitespace in does-not-contain expression', () => {
+    const expr = {
+      operator: 'does-not-contain',
+      field: 'tags',
+      value: 'urgent ',
+    };
+    const fn = compileExpression(expr);
+    expect(fn({tags: ['urgent', 'important']})).toBe(false);
+    expect(fn({tags: ['urgent ']})).toBe(false);
+  });
+
+  it('handles whitespace in contains-regex expression', () => {
+    const expr = {
+      operator: 'contains-regex',
+      field: 'tags',
+      value: '^urgent\\s+$',
+    };
+    const fn = compileExpression(expr);
+    // Regex explicitly expecting whitespace should be accurate - no stripping here
+    expect(fn({tags: ['urgent', 'important']})).toBe(false);
+    expect(fn({tags: ['urgent ']})).toBe(true);
+  });
+
+  it('handles whitespace in does-not-contain-regex expression', () => {
+    const expr = {
+      operator: 'does-not-contain-regex',
+      field: 'tags',
+      value: '^urgent\\s+$',
+    };
+    const fn = compileExpression(expr);
+    // Regex explicitly expecting whitespace should be accurate - no stripping here
+    expect(fn({tags: ['urgent', 'important']})).toBe(true);
+    expect(fn({tags: ['urgent ']})).toBe(false);
   });
 });

--- a/app/src/conditionals.ts
+++ b/app/src/conditionals.ts
@@ -184,7 +184,7 @@ const sanitizeComparisonInput = (input: string): string => {
  * @param value The value to check
  * @returns True iff is an array of strings
  */
-const isStringArray = (value: unknown): value is string[] => 
+export const isStringArray = (value: unknown): value is string[] => 
   Array.isArray(value) && value.every(item => typeof item === 'string');
 
 /**

--- a/app/src/conditionals.ts
+++ b/app/src/conditionals.ts
@@ -169,3 +169,222 @@ registerCompiler('and', (expression: ConditionalExpression) => {
     return () => true;
   }
 });
+
+/**
+ * Trims whitespace in order to sanitize comparisons
+ * @param input The input string to sanitize
+ * @returns The output with whitespace trimmed
+ */
+const sanitizeComparisonInput = (input: string): string => {
+  return input.trim();
+};
+
+/**
+ * This condition checks that the list contains the targeted entry. If an error
+ * occurs or other edge case, returns false to reflect 'not' containing.
+ */
+registerCompiler('contains', (expression: ConditionalExpression) => {
+  return (values: RecordValues) => {
+    if (expression.field && expression.field in values) {
+      try {
+        // cast the types into their desired values but be 'careful'
+        const valuePresent = values[expression.field]! as
+          | string[]
+          | undefined
+          | null;
+        const target = expression.value as string | undefined | null;
+
+        // empty string is okay - be explicit
+        if (target === undefined || target === null) {
+          // The condition has been setup incorrectly - this should be defined
+          return false;
+        }
+
+        // If the list undefined or empty, return false since contains will
+        // always be false
+        if (!valuePresent) {
+          return false;
+        }
+
+        // Try seeing if it contains it
+        if (
+          valuePresent
+            .map(v => sanitizeComparisonInput(v))
+            .includes(sanitizeComparisonInput(target))
+        ) {
+          return true;
+        }
+
+        // Otherwise, back out
+        return false;
+      } catch (e) {
+        // Exception occurred - just console the error and return false - this
+        // condition has not evaluated properly
+        console.error(
+          'Exception during comparison occurred - contains operation - returning false',
+          e
+        );
+        return false;
+      }
+    } else return false;
+  };
+});
+
+/**
+ * This condition checks that the list does not contain the targeted entry.
+ * Chooses to be error tolerant to only match on the exact case. If an error
+ * occurs or other edge case, returns true to reflect 'not' containing.
+ */
+registerCompiler('does-not-contain', (expression: ConditionalExpression) => {
+  return (values: RecordValues) => {
+    if (expression.field && expression.field in values) {
+      try {
+        // cast the types into their desired values but be 'careful'
+        const valuePresent = values[expression.field]! as
+          | string[]
+          | undefined
+          | null;
+        const target = expression.value as string | undefined | null;
+
+        // empty string is okay - be explicit
+        if (target === undefined || target === null) {
+          // The condition has been setup incorrectly - since we are doing
+          // exclusion let's return OK
+          return true;
+        }
+
+        // If the list undefined or empty, return true since not-contains will
+        // always be true
+        if (!valuePresent) {
+          return true;
+        }
+
+        // Try seeing if it contains it - if it does return false (since we wan't not contains)
+        if (
+          valuePresent
+            .map(v => sanitizeComparisonInput(v))
+            .includes(sanitizeComparisonInput(target))
+        ) {
+          return false;
+        }
+
+        // Otherwise - it doesn't contain it - all good
+        return true;
+      } catch (e) {
+        // Exception occurred - just console the error and return true - this
+        // condition has not evaluated properly
+        console.error(
+          'Exception during comparison occurred - not-contains operation - returning true',
+          e
+        );
+        return true;
+      }
+    } else return false;
+  };
+});
+
+/**
+ * This condition checks that the list contains the targeted entry matching the
+ * specified regex. If an error occurs or other edge case, returns false to
+ * reflect 'not' containing.
+ */
+registerCompiler('contains-regex', (expression: ConditionalExpression) => {
+  return (values: RecordValues) => {
+    if (expression.field && expression.field in values) {
+      try {
+        // cast the types into their desired values but be 'careful'
+        const valuePresent = values[expression.field]! as
+          | string[]
+          | undefined
+          | null;
+        const target = expression.value as string | undefined | null;
+
+        // empty string is okay - be explicit
+        if (target === undefined || target === null) {
+          // The condition has been setup incorrectly - this should be defined
+          return false;
+        }
+
+        // Compile search regex
+        const re = new RegExp(target);
+
+        // If the list undefined or empty, return false since contains will
+        // always be false
+        if (!valuePresent) {
+          return false;
+        }
+
+        // Try seeing if any element matches
+        if (valuePresent.some(v => re.test(v))) {
+          return true;
+        }
+
+        // Otherwise, back out
+        return false;
+      } catch (e) {
+        // Exception occurred - just console the error and return false - this
+        // condition has not evaluated properly
+        console.error(
+          'Exception during comparison occurred - contains-regex operation - returning false',
+          e
+        );
+        return false;
+      }
+    } else return false;
+  };
+});
+
+/**
+ * This condition checks that the list does not contain the targeted entry.
+ * Chooses to be error tolerant to only match on the exact case. If an error
+ * occurs or other edge case, returns true to reflect 'not' containing.
+ */
+registerCompiler(
+  'does-not-contain-regex',
+  (expression: ConditionalExpression) => {
+    return (values: RecordValues) => {
+      if (expression.field && expression.field in values) {
+        try {
+          // cast the types into their desired values but be 'careful'
+          const valuePresent = values[expression.field]! as
+            | string[]
+            | undefined
+            | null;
+          const target = expression.value as string | undefined | null;
+
+          // empty string is okay - be explicit
+          if (target === undefined || target === null) {
+            // The condition has been setup incorrectly - since we are doing
+            // exclusion let's return OK
+            return true;
+          }
+
+          // Compile search regex
+          const re = new RegExp(target);
+
+          // If the list undefined or empty, return true since not-contains will
+          // always be true
+          if (!valuePresent) {
+            return true;
+          }
+
+          // Try seeing if any element matches - if it does return false (since we wan't not contains)
+          if (valuePresent.some(v => re.test(v))) {
+            return false;
+          }
+
+          // Otherwise - it doesn't contain it - all good
+          return true;
+        } catch (e) {
+          // Exception occurred - just console the error and return true - this
+          // condition has not evaluated properly
+          console.error(
+            'Exception during comparison occurred - not-contains-regex operation - returning true',
+            e
+          );
+          return true;
+        }
+      } else return false;
+    };
+  }
+);

--- a/app/src/conditionals.ts
+++ b/app/src/conditionals.ts
@@ -180,6 +180,14 @@ const sanitizeComparisonInput = (input: string): string => {
 };
 
 /**
+ * Checks if the item is a string array
+ * @param value The value to check
+ * @returns True iff is an array of strings
+ */
+const isStringArray = (value: unknown): value is string[] => 
+  Array.isArray(value) && value.every(item => typeof item === 'string');
+
+/**
  * This condition checks that the list contains the targeted entry. If an error
  * occurs or other edge case, returns false to reflect 'not' containing.
  */
@@ -195,7 +203,7 @@ registerCompiler('contains', (expression: ConditionalExpression) => {
         const target = expression.value as string | undefined | null;
 
         // empty string is okay - be explicit
-        if (target === undefined || target === null) {
+        if (target === undefined || target === null || !isStringArray(valuePresent)) {
           // The condition has been setup incorrectly - this should be defined
           return false;
         }
@@ -247,7 +255,7 @@ registerCompiler('does-not-contain', (expression: ConditionalExpression) => {
         const target = expression.value as string | undefined | null;
 
         // empty string is okay - be explicit
-        if (target === undefined || target === null) {
+        if (target === undefined || target === null || !isStringArray(valuePresent)) {
           // The condition has been setup incorrectly - since we are doing
           // exclusion let's return OK
           return true;
@@ -300,7 +308,7 @@ registerCompiler('contains-regex', (expression: ConditionalExpression) => {
         const target = expression.value as string | undefined | null;
 
         // empty string is okay - be explicit
-        if (target === undefined || target === null) {
+        if (target === undefined || target === null || !isStringArray(valuePresent)) {
           // The condition has been setup incorrectly - this should be defined
           return false;
         }
@@ -353,7 +361,7 @@ registerCompiler(
           const target = expression.value as string | undefined | null;
 
           // empty string is okay - be explicit
-          if (target === undefined || target === null) {
+          if (target === undefined || target === null || !isStringArray(valuePresent)) {
             // The condition has been setup incorrectly - since we are doing
             // exclusion let's return OK
             return true;

--- a/designer/src/components/condition.tsx
+++ b/designer/src/components/condition.tsx
@@ -61,6 +61,13 @@ const allOperators = new Map([
   ['less', 'Less than'],
   ['less-equal', 'Less than or equal'],
   ['regex', 'Matches regular expression'],
+  ['contains', 'List contains this value'],
+  ['does-not-contain', 'List does not contain this value'],
+  ['contains-regex', 'List contains a value matching this regex'],
+  [
+    'does-not-contain-regex',
+    'List does not contain any value matching this regex',
+  ],
 ]);
 
 const getFieldLabel = (f: FieldType) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,7 +219,7 @@
         "stream": "^0.0.2",
         "typescript": "^5.5.4",
         "uuid": "9.0.0",
-        "vite": "^4.5.5",
+        "vite": "^4.5.9",
         "vite-plugin-svgr": "^3.2.0",
         "vite-tsconfig-paths": "^4.2.1",
         "vitest": "^0.34.4",
@@ -323,7 +323,7 @@
         "eslint-plugin-react-refresh": "^0.4.3",
         "jsdom": "^22.1.0",
         "typescript": "^5.5.4",
-        "vite": "^4.5.5",
+        "vite": "^4.5.6",
         "vitest": "^1.0.1",
         "webdriverio": "^8.32.2"
       },
@@ -43669,9 +43669,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
+      "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",


### PR DESCRIPTION
# feat: multi select conditions

## JIRA Ticket

[634](https://jira.csiro.au/browse/BSS-634)

## Description

Implements the following designer conditions - necessary for the updated rapid impact (as well as subsequent detailed surveys). 

- contains (the list contains this value)
- does not contain (the list does not contain this value/ it is not selected)
- contains regex (contains at least one selection matching this value)
- does not contain regex (the list does not contain any selection matching this value)

The values in the list and the specified filter value are white space stripped, but I haven't touched any existing work to ensure I don't effect legacy notebooks relying on this non-sanitised behaviour.

## How to Test

I implemented unit tests but they won't run due to broader issues in the app tests. However you can specifically run them with. 

```bash
cd app 
npm i
npx vitest src/conditionals.test.ts
```

I have made a test notebook which I'll attach which demonstrates these features. Everything appears to be working well. I'll also link a video showing it.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
