### PR TITLE
feat: conditional error filtering

### DIFF
--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -18,23 +18,10 @@
  *   Record/Draft form file
  */
 
-import {Form, Formik} from 'formik';
-import React from 'react';
-
-import {Box, Divider, Typography, Alert} from '@mui/material';
-
-import {
-  getFieldsMatchingCondition,
-  getViewsMatchingCondition,
-} from './branchingLogic';
-import {firstDefinedFromList} from './helpers';
-
-import {getUsefulFieldNameFromUiSpec, ViewComponent} from './view';
-
-import {ActionType} from '../../../context/actions';
-
 import {
   Annotations,
+  generateFAIMSDataID,
+  getFirstRecordHead,
   getFullRecordData,
   ProjectID,
   ProjectUIModel,
@@ -44,10 +31,18 @@ import {
   RevisionID,
   upsertFAIMSData,
 } from '@faims3/data-model';
+import {Alert, Box, Divider, Typography} from '@mui/material';
+import {Form, Formik} from 'formik';
+import React from 'react';
 import {NavigateFunction} from 'react-router-dom';
+import {ValidationError} from 'yup';
 import * as ROUTES from '../../../constants/routes';
+import {INDIVIDUAL_NOTEBOOK_ROUTE} from '../../../constants/routes';
+import {ActionType} from '../../../context/actions';
 import {store} from '../../../context/store';
+import {percentComplete, requiredFields} from '../../../lib/form-utils';
 import {getFieldPersistentData} from '../../../local-data/field-persistent';
+import {logError} from '../../../logging';
 import RecordDraftState from '../../../sync/draft-state';
 import {
   getFieldNamesFromFields,
@@ -55,24 +50,24 @@ import {
   getReturnedTypesForViewSet,
 } from '../../../uiSpecification';
 import {getCurrentUserId} from '../../../users';
+import CircularLoading from '../ui/circular_loading';
 import {getValidationSchemaForViewset} from '../validation';
+import {
+  getFieldsMatchingCondition,
+  getViewsMatchingCondition,
+} from './branchingLogic';
 import {savefieldpersistentSetting} from './fieldPersistentSetting';
+import FormButtonGroup from './formButton';
+import {firstDefinedFromList} from './helpers';
 import RecordStepper from './recordStepper';
-
 import {
   generateLocationState,
   generateRelationship,
   getParentLinkInfo,
 } from './relationships/RelatedInformation';
-
-import {generateFAIMSDataID, getFirstRecordHead} from '@faims3/data-model';
-import {INDIVIDUAL_NOTEBOOK_ROUTE} from '../../../constants/routes';
-import {percentComplete, requiredFields} from '../../../lib/form-utils';
-import {logError} from '../../../logging';
-import CircularLoading from '../ui/circular_loading';
-import FormButtonGroup from './formButton';
 import UGCReport from './UGCReport';
-//import {RouteComponentProps} from 'react-router';
+import {getUsefulFieldNameFromUiSpec, ViewComponent} from './view';
+
 type RecordFormProps = {
   navigate: NavigateFunction;
   project_id: ProjectID;


### PR DESCRIPTION
# feat: conditional error filtering

## JIRA Ticket

[BSS-633](https://jira.csiro.au/browse/BSS-633)

## Problem

Previously, if you had a field which was not visible because of conditional logic (at the section or the field level), the `required` constraint was still enforced by the yup validation schema regardless of whether the field was visible. This meant that you could create states where it was impossible for a user to successfully/accurately fill out the form if you have fields which are **required and conditionally visible**. 

## Proposed change

Make `required` only enforced at the schema validation level for fields which are visible, taking into account section and field level constraints. 

## Implemented approach

The form logic is very fragile so I attempted to make a minimal intervention which solves the problem. This intervention takes over validation at the whole of Form level by using the `validate` argument to the formik `Form` component. This is doing the same thing as the previous schema validation (i.e. calling the Yup schema validate method) however it filters the errors that result from this based on the visibility conditions. 

The only thing I couldn't easily get access to was the `touched` part of the `formProps` (since the `formProps` are not available in the arguments to the formik `Form`, only in the children render function). This is used in some of the functions I rely on for visibility, though not in a particularly clear/well documented way. E.g. this is the `getViewsMatchingCondition` function in `branchingLogic.tsx`. It is not well documented and it is, at a quick read, very unclear what the utility of touched is: 

```typescript
export function getViewsMatchingCondition(
  ui_specification: ProjectUIModel,
  values: {[field_name: string]: any},
  views: string[],
  viewsetName: string,
  touched: {[field_name: string]: any} = {}
) {
  let modified = Object.keys(touched);
  if (values.updateField) modified.push(values.updateField);
  modified = modified.filter((f: string) =>
    is_controller_field(ui_specification, f)
  );
  const allViews = getViewsForViewSet(ui_specification, viewsetName);
  // run the checks if there are modified control fields or the original views are empty
  if (modified.length > 0 || views.length === 0) {
    // filter the whole set of views
    const result = allViews.filter(view => {
      const fn = ui_specification.views[view].conditionFn;
      if (fn !== undefined) return fn(values);
      else return true;
    });
    return result;
  } else {
    // shortcut return the existing set of views
    return views;
  }
}
```

Despite this, the functionality seems to work as expected just passing in `{}` as touched, which is also the default argument. 

## How to Test

I will attach a sample notebook which has conditional logic in the field and section level. Try changing the first text field to "ok" and ensure the required conditions are enforced as expected with the proposed behaviour. 

## (Later) A note on conditional fields which are no longer visible

Say you have two text fields. Field B is only visible if the value of field B == 'ok'. You put field A = ok so field B appears. You enter data into the conditional field B. You then change the value of field A such that field B is no longer visible. 
 
The current behaviour is that this value is retained but not visible. It will be retained in the data export. 
 
What is the ideal behaviour? I'm thinking that in the UI it's not a bad idea to retain the data, but when it's written to the DB you would strip out any erroneous left over conditional data so that your data is consistent with the schema. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
