### PR TITLE
feat: option to render multi select as expanded check list, edit and move options

### DIFF
--- a/app/src/gui/fields/multiselect.tsx
+++ b/app/src/gui/fields/multiselect.tsx
@@ -20,34 +20,121 @@
 
 import {ElementOption} from '@faims3/data-model';
 import {
+  Box,
   Checkbox,
   FormControl,
+  FormControlLabel,
   FormHelperText,
   InputLabel,
   ListItemText,
   MenuItem,
   OutlinedInput,
   Select,
+  Typography,
 } from '@mui/material';
+import {useTheme} from '@mui/material/styles';
 import {FieldProps} from 'formik';
 import {TextFieldProps} from 'formik-mui';
+import {ReactNode} from 'react';
 
+/**
+ * Base properties for multi-select components
+ */
 interface ElementProps {
   options: Array<ElementOption>;
+  expandedChecklist?: boolean;
 }
 
+/**
+ * Combined props for the main MultiSelect component
+ */
 interface Props {
   ElementProps: ElementProps;
   select_others?: string;
 }
 
-import {useTheme} from '@mui/material/styles';
+/**
+ * Props for the ExpandedChecklist component
+ */
+interface ExpandedChecklistProps {
+  options: Array<ElementOption>;
+  value: string[];
+  onChange: (values: string[]) => void;
+  label?: ReactNode;
+  helperText?: ReactNode;
+}
 
-export const MultiSelect = (props: FieldProps & Props & TextFieldProps) => {
-  const theme = useTheme();
-  const handleChange = (e: any) => {
-    props.form.setFieldValue(props.field.name, e.target.value, true);
+/**
+ * Props for the MuiMultiSelect component
+ */
+interface MuiMultiSelectProps {
+  options: Array<ElementOption>;
+  value: string[];
+  onChange: (values: string[]) => void;
+  label?: ReactNode;
+  helperText?: ReactNode;
+}
+
+/**
+ * A component that displays options as an expanded list of checkboxes
+ */
+export const ExpandedChecklist = ({
+  options,
+  value,
+  onChange,
+  label,
+  helperText,
+}: ExpandedChecklistProps) => {
+  const handleChange = (optionValue: string) => {
+    const newValues = value.includes(optionValue)
+      ? value.filter(v => v !== optionValue)
+      : [...value, optionValue];
+    onChange(newValues);
   };
+
+  return (
+    <FormControl sx={{width: '100%'}}>
+      {label && (
+        <Typography variant="subtitle1" gutterBottom>
+          {label}
+        </Typography>
+      )}
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+      <Box sx={{display: 'flex', flexDirection: 'column', gap: 1}}>
+        {options.map(option => (
+          <FormControlLabel
+            key={option.key || option.value}
+            control={
+              <Checkbox
+                checked={value.includes(option.value)}
+                onChange={() => handleChange(option.value)}
+              />
+            }
+            label={option.label}
+            sx={{
+              '& .MuiFormControlLabel-label': {
+                whiteSpace: 'normal',
+                wordWrap: 'break-word',
+              },
+            }}
+          />
+        ))}
+      </Box>
+    </FormControl>
+  );
+};
+
+/**
+ * A component that displays options in a Material-UI dropdown select
+ */
+export const MuiMultiSelect = ({
+  options,
+  value,
+  onChange,
+  label,
+  helperText,
+}: MuiMultiSelectProps) => {
+  const theme = useTheme();
 
   return (
     <FormControl sx={{m: 1, width: '100%'}}>
@@ -55,18 +142,18 @@ export const MultiSelect = (props: FieldProps & Props & TextFieldProps) => {
         id="multi-select-label"
         style={{backgroundColor: theme.palette.background.default}}
       >
-        {props.label}
+        {label}
       </InputLabel>
       <Select
         labelId="multi-select-label"
         multiple
-        label={props.label}
-        onChange={handleChange}
-        value={props.field.value}
-        input={<OutlinedInput label={props.label} />}
+        label={label}
+        onChange={(e: any) => onChange(e.target.value)}
+        value={value}
+        input={<OutlinedInput label={label} />}
         renderValue={selected => selected.join(', ')}
       >
-        {props.ElementProps.options.map((option: any) => (
+        {options.map(option => (
           <MenuItem
             key={option.key ? option.key : option.value}
             value={option.value}
@@ -75,46 +162,78 @@ export const MultiSelect = (props: FieldProps & Props & TextFieldProps) => {
               wordWrap: 'break-word',
             }}
           >
-            <Checkbox checked={props.field.value.includes(option.value)} />
+            <Checkbox checked={value.includes(option.value)} />
             <ListItemText primary={option.label} />
           </MenuItem>
         ))}
       </Select>
-      {props.helperText && <FormHelperText>{props.helperText}</FormHelperText>}
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
     </FormControl>
   );
 };
 
-// const uiSpec = {
-//   'component-namespace': 'faims-custom', // this says what web component to use to render/acquire value from
-//   'component-name': 'MultiSelect',
-//   'type-returned': 'faims-core::Array', // matches a type in the Project Model
-//   'component-parameters': {
-//     fullWidth: true,
-//     helperText: 'Choose items from the dropdown',
-//     variant: 'outlined',
-//     required: false,
-//     select: true,
-//     InputProps: {},
-//     SelectProps: {
-//       multiple: true,
-//     },
-//     ElementProps: {
-//       options: [
-//         {
-//           value: 'Default',
-//           label: 'Default',
-//         },
-//         {
-//           value: 'Default2',
-//           label: 'Default2',
-//         },
-//       ],
-//     },
-//     InputLabelProps: {
-//       label: 'Select Multiple',
-//     },
-//   },
-//   validationSchema: [['yup.array']],
-//   initialValue: [],
-// };
+/**
+ * Main MultiSelect component that switches between ExpandedChecklist and MuiMultiSelect
+ * based on the expandedChecklist prop
+ */
+export const MultiSelect = (props: FieldProps & Props & TextFieldProps) => {
+  const handleChange = (value: string[]) => {
+    props.form.setFieldValue(props.field.name, value, true);
+  };
+
+  const isExpandedChecklist = props.ElementProps.expandedChecklist ?? false;
+
+  const commonProps = {
+    options: props.ElementProps.options,
+    value: props.field.value,
+    onChange: handleChange,
+    label: props.label,
+    helperText: props.helperText,
+  };
+
+  return isExpandedChecklist ? (
+    <ExpandedChecklist {...commonProps} />
+  ) : (
+    <MuiMultiSelect {...commonProps} />
+  );
+};
+
+/*
+An example of ui-spec for this multi-select:
+{
+  'component-namespace': 'faims-custom', // this says what web component to use to render/acquire value from
+  'component-name': 'MultiSelect',
+  'type-returned': 'faims-core::Array', // matches a type in the Project Model
+  'component-parameters': {
+    fullWidth: true,
+    helperText: 'Choose items from the dropdown',
+    variant: 'outlined',
+    required: false,
+    select: true,
+    InputProps: {},
+    SelectProps: {
+      multiple: true,
+    },
+    ElementProps: {
+      // expanded check list form vs default dropdown
+      expandedChecklist : false,
+      options: [
+        {
+          value: 'Default',
+          label: 'Default',
+        },
+        {
+          value: 'Default2',
+          label: 'Default2',
+        },
+      ],
+    },
+    InputLabelProps: {
+      label: 'Select Multiple',
+    },
+  },
+  validationSchema: [['yup.array']],
+  initialValue: [],
+};
+
+*/

--- a/designer/src/components/Fields/OptionsEditor.tsx
+++ b/designer/src/components/Fields/OptionsEditor.tsx
@@ -12,34 +12,69 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import EditIcon from '@mui/icons-material/Edit';
 import {
-  Grid,
-  TextField,
-  List,
-  ListItem,
-  ListItemText,
   Alert,
   Button,
   Card,
+  Checkbox,
+  FormControlLabel,
+  Grid,
   IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Stack,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import AddCircleIcon from '@mui/icons-material/AddCircle';
-
-import {BaseFieldEditor} from './BaseFieldEditor';
-import {useAppSelector, useAppDispatch} from '../../state/hooks';
 import {useState} from 'react';
+import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {FieldType} from '../../state/initial';
+import {BaseFieldEditor} from './BaseFieldEditor';
 
-export const OptionsEditor = ({fieldName}: {fieldName: string}) => {
+/**
+ * OptionsEditor is a component for managing a list of options for radio buttons or multi-select fields.
+ * Provides functionality to add, remove, reorder, edit, and display options, with an additional feature
+ * to toggle between compact and expanded checklist views for multi-select fields.
+ *
+ * @param {string} fieldName - The name of the field being edited
+ * @param {boolean} [showExpandedChecklist] - Whether to show the expanded checklist toggle control
+ */
+export const OptionsEditor = ({
+  fieldName,
+  showExpandedChecklist,
+}: {
+  fieldName: string;
+  showExpandedChecklist?: boolean;
+}) => {
   const field = useAppSelector(
     state => state.notebook['ui-specification'].fields[fieldName]
   );
   const dispatch = useAppDispatch();
 
+  const isShowExpandedList =
+    field['component-parameters'].ElementProps?.expandedChecklist ?? false;
+  const showExpandedCheckListControl = showExpandedChecklist ?? false;
+
   const [newOption, setNewOption] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [editingOption, setEditingOption] = useState<{
+    value: string;
+    index: number;
+  } | null>(null);
+  const [editValue, setEditValue] = useState('');
 
+  /**
+   * Retrieves and normalizes the current list of options from the field configuration
+   */
   const getOptions = () => {
     let options;
     if (field['component-parameters'].ElementProps) {
@@ -48,16 +83,45 @@ export const OptionsEditor = ({fieldName}: {fieldName: string}) => {
     } else {
       field['component-parameters'].ElementProps = {options: []};
     }
-    if (options) return options;
-    else return [];
+    return options || [];
   };
 
   const options = getOptions();
 
+  /**
+   * Validates option text for emptiness and duplicates
+   * @param {string} text - The option text to validate
+   * @param {number} [currentIndex] - Index of option being edited (to exclude from duplicate check)
+   * @return Null if okay, string if error
+   */
+  const validateOptionText = (
+    text: string,
+    currentIndex?: number
+  ): string | null => {
+    if (text.trim().length === 0) {
+      return 'Option text cannot be empty';
+    }
+
+    const duplicateExists = options.some((element: string, index: number) => {
+      if (currentIndex !== undefined && index === currentIndex) return false;
+      return element.toLowerCase() === text.toLowerCase();
+    });
+
+    if (duplicateExists) {
+      return 'This option already exists in the list';
+    }
+
+    return null;
+  };
+
+  /**
+   * Updates the options list in the Redux store
+   * @param {string[]} updatedOptions - The new list of options
+   */
   const updateOptions = (updatedOptions: string[]) => {
-    // take a deep copy of the field
     const newField = JSON.parse(JSON.stringify(field)) as FieldType;
     newField['component-parameters'].ElementProps = {
+      ...newField['component-parameters'].ElementProps,
       options: updatedOptions.map((o, index) => {
         if (fieldName.includes('radio')) {
           return {
@@ -82,40 +146,98 @@ export const OptionsEditor = ({fieldName}: {fieldName: string}) => {
     });
   };
 
+  /**
+   * Toggles the expanded checklist view state
+   */
+  const toggleShowExpanded = () => {
+    const newField = JSON.parse(JSON.stringify(field)) as FieldType;
+    const existing =
+      newField['component-parameters'].ElementProps?.expandedChecklist ?? false;
+    const newValue = !existing;
+    newField['component-parameters'].ElementProps = {
+      ...(newField['component-parameters'].ElementProps ?? {}),
+      expandedChecklist: newValue,
+    };
+    dispatch({
+      type: 'ui-specification/fieldUpdated',
+      payload: {fieldName, newField},
+    });
+  };
+
+  /**
+   * Handles adding a new option
+   */
   const addOption = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const error = validateOptionText(newOption);
 
-    const emptyOption: boolean = newOption.trim().length === 0;
-    const duplicateOption: boolean = options.some((element: string) => {
-      // Making sure duplicate check is case insensitive.
-      // eg if the array has an element 'hi', then a user should not be able to add 'Hi' since that's a duplicate
-      const lowerElement = element.toLowerCase();
-      const lowerNewOption = newOption.toLowerCase();
-      return lowerElement === lowerNewOption;
-    });
-
-    if (emptyOption) {
-      setErrorMessage('Cannot add an empty option!');
-    } else if (duplicateOption) {
-      setErrorMessage('This option already exists in the list.');
+    if (error) {
+      setErrorMessage(error);
     } else {
       const newOptions = [...options, newOption];
       updateOptions(newOptions);
       setErrorMessage('');
+      setNewOption('');
     }
-    setNewOption('');
   };
 
+  /**
+   * Handles option deletion
+   */
   const removeOption = (option: string) => {
     const newOptions = options.filter((o: string) => o !== option);
     updateOptions(newOptions);
+  };
+
+  /**
+   * Handles option reordering
+   */
+  const moveOption = (index: number, direction: 'up' | 'down') => {
+    const newOptions = [...options];
+    const newIndex = direction === 'up' ? index - 1 : index + 1;
+
+    if (newIndex >= 0 && newIndex < options.length) {
+      [newOptions[index], newOptions[newIndex]] = [
+        newOptions[newIndex],
+        newOptions[index],
+      ];
+      updateOptions(newOptions);
+    }
+  };
+
+  /**
+   * Initiates option editing
+   */
+  const startEditing = (option: string, index: number) => {
+    setEditingOption({value: option, index});
+    setEditValue(option);
+    setErrorMessage('');
+  };
+
+  /**
+   * Handles edit submission
+   */
+  const handleEditSubmit = () => {
+    if (!editingOption) return;
+
+    const error = validateOptionText(editValue, editingOption.index);
+    if (error) {
+      setErrorMessage(error);
+      return;
+    }
+
+    const newOptions = [...options];
+    newOptions[editingOption.index] = editValue;
+    updateOptions(newOptions);
+    setEditingOption(null);
+    setErrorMessage('');
   };
 
   return (
     <BaseFieldEditor fieldName={fieldName}>
       <Grid item xs={12}>
         <Card variant="outlined">
-          <Grid container p={2}>
+          <Grid container p={2} spacing={2}>
             <Grid item xs={12} sm={6}>
               <Alert severity="info">Add and remove options as needed.</Alert>
               <form onSubmit={addOption}>
@@ -133,7 +255,7 @@ export const OptionsEditor = ({fieldName}: {fieldName: string}) => {
                     type="submit"
                     sx={{my: 1.5}}
                   >
-                    ADD{' '}
+                    ADD
                   </Button>
                 </Grid>
               </form>
@@ -141,29 +263,103 @@ export const OptionsEditor = ({fieldName}: {fieldName: string}) => {
             </Grid>
             <Grid item xs={12} sm={6}>
               <List>
-                {options.map((option: string) => {
-                  return (
-                    <ListItem
-                      key={option}
-                      secondaryAction={
+                {options.map((option: string, index: number) => (
+                  <ListItem
+                    key={option}
+                    secondaryAction={
+                      <Stack direction="row" spacing={1}>
+                        <IconButton
+                          size="small"
+                          disabled={index === 0}
+                          onClick={() => moveOption(index, 'up')}
+                          aria-label="move option up"
+                        >
+                          <ArrowUpwardIcon />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          disabled={index === options.length - 1}
+                          onClick={() => moveOption(index, 'down')}
+                          aria-label="move option down"
+                        >
+                          <ArrowDownwardIcon />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={() => startEditing(option, index)}
+                          aria-label="edit option"
+                        >
+                          <EditIcon />
+                        </IconButton>
                         <IconButton
                           edge="end"
-                          aria-label="delete"
+                          aria-label="delete option"
                           onClick={() => removeOption(option)}
                         >
                           <DeleteIcon />
                         </IconButton>
-                      }
-                    >
-                      <ListItemText primary={option} />
-                    </ListItem>
-                  );
-                })}
+                      </Stack>
+                    }
+                  >
+                    <ListItemText primary={option} />
+                  </ListItem>
+                ))}
               </List>
             </Grid>
+            {showExpandedCheckListControl && (
+              <Grid item xs={12}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={isShowExpandedList}
+                      onChange={toggleShowExpanded}
+                    />
+                  }
+                  label="Display multi-select as an expanded checklist?"
+                />
+              </Grid>
+            )}
           </Grid>
         </Card>
       </Grid>
+
+      <Dialog
+        open={!!editingOption}
+        onClose={() => {
+          setEditingOption(null);
+          setErrorMessage('');
+        }}
+      >
+        <DialogTitle>Edit Option</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Option Text"
+            fullWidth
+            value={editValue}
+            onChange={e => setEditValue(e.target.value)}
+          />
+          {errorMessage && (
+            <Alert severity="error" sx={{mt: 2}}>
+              {errorMessage}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setEditingOption(null);
+              setErrorMessage('');
+            }}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleEditSubmit} color="primary">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
     </BaseFieldEditor>
   );
 };

--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -256,7 +256,7 @@ export const FieldEditor = ({
             <OptionsEditor fieldName={fieldName} />
           )) ||
           (fieldComponent === 'MultiSelect' && (
-            <OptionsEditor fieldName={fieldName} />
+            <OptionsEditor fieldName={fieldName} showExpandedChecklist={true}/>
           )) ||
           (fieldComponent === 'AdvancedSelect' && (
             <AdvancedSelectEditor fieldName={fieldName} />

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -249,6 +249,7 @@ const fields: {[key: string]: FieldType} = {
         multiple: true,
       },
       ElementProps: {
+        expandedChecklist: false,
         options: [
           {
             value: 'Default',

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -32,6 +32,7 @@ export type ComponentParameters = {
   multiple?: boolean;
   SelectProps?: unknown;
   ElementProps?: {
+    expandedChecklist?: boolean,
     options?: {
       value: string;
       label: string;


### PR DESCRIPTION
# feat: option to render multi select as expanded check list, edit and move options

## JIRA Ticket

Multi select as list:
[BSS-573](https://jira.csiro.au/browse/BSS-573)

Allow reordering:
[BSS-644](https://jira.csiro.au/browse/BSS-644)

Allow editing: 
[BSS-643](https://jira.csiro.au/browse/BSS-643)


## Description

Updating multi select component in App, adding expandedChecklist option, implementing in designer, adding move and edit capabilities for options while there.

## How to Test

See the new checkbox in the designer for multi-select. 

See the move up/down and edit capabilities.

Create a notebook with multi selects of both types (true/false) and check it renders properly.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
