### PR TITLE
Remove useless stuff from home page and add links to web/mobile apps if available.

### DIFF
--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -61,6 +61,11 @@ function ios_url(): string {
   return url || '';
 }
 
+function designer_url(): string {
+  const url = process.env.DESIGNER_URL;
+  return url || '';
+}
+
 function is_testing() {
   const jest_worker_is_running = process.env.JEST_WORKER_ID !== undefined;
   const jest_imported = false; //typeof jest !== 'undefined';
@@ -286,6 +291,7 @@ export const CONDUCTOR_AUTH_PROVIDERS = get_providers_to_use();
 export const WEBAPP_PUBLIC_URL = app_url();
 export const ANDROID_APP_URL = android_url();
 export const IOS_APP_URL = ios_url();
+export const DESIGNER_URL = designer_url();
 
 /**
  * Checks the KEY_SOURCE env variable to ensure its a KEY_SOURCE or defaults to

--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -53,18 +53,12 @@ function app_url(): string {
 
 function android_url(): string {
   const url = process.env.ANDROID_APP_PUBLIC_URL;
-  if (url === '' || url === undefined) {
-    return 'http://localhost:3000';
-  }
-  return url;
+  return url || '';
 }
 
 function ios_url(): string {
   const url = process.env.IOS_APP_PUBLIC_URL;
-  if (url === '' || url === undefined) {
-    return 'http://localhost:3000';
-  }
-  return url;
+  return url || '';
 }
 
 function is_testing() {

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -78,11 +78,6 @@ add_auth_routes(app, CONDUCTOR_AUTH_PROVIDERS);
 app.get('/', async (req, res) => {
   if (databaseValidityReport.valid) {
     if (req.user && req.user._id) {
-      // Handlebars is pretty useless at including render logic in templates, just
-      // parse the raw, pre-processed string in...
-      const rendered_project_roles = render_project_roles(
-        req.user.project_roles
-      );
       const provider = Object.keys(req.user.profiles)[0];
       // No need for a refresh here
       const token = await generateUserToken(req.user, false);
@@ -90,12 +85,13 @@ app.get('/', async (req, res) => {
       res.render('home', {
         user: req.user,
         token: token.token,
-        project_roles: rendered_project_roles,
-        other_roles: req.user.other_roles,
         cluster_admin: userIsClusterAdmin(req.user),
         can_create_notebooks: userCanCreateNotebooks(req.user),
         provider: provider,
         developer: DEVELOPER_MODE,
+        ANDROID_APP_URL: ANDROID_APP_URL,
+        IOS_APP_URL: IOS_APP_URL,
+        WEBAPP_PUBLIC_URL: WEBAPP_PUBLIC_URL,
       });
     } else {
       res.redirect('/auth/');

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -34,6 +34,7 @@ import {
   CONDUCTOR_AUTH_PROVIDERS,
   CONDUCTOR_PUBLIC_URL,
   COUCHDB_INTERNAL_URL,
+  DESIGNER_URL,
   DEVELOPER_MODE,
   IOS_APP_URL,
   WEBAPP_PUBLIC_URL,
@@ -183,6 +184,7 @@ app.get('/notebooks/', requireAuthentication, async (req, res) => {
       cluster_admin: userIsClusterAdmin(user),
       can_create_notebooks: userCanCreateNotebooks(user),
       developer: DEVELOPER_MODE,
+      DESIGNER_URL: DESIGNER_URL,
     });
   } else {
     res.status(401).end();
@@ -223,6 +225,7 @@ app.get(
           return {label: uiSpec.viewsets[key].label, id: key};
         }),
         developer: DEVELOPER_MODE,
+        DESIGNER_URL: DESIGNER_URL,
       });
     } else {
       res.sendStatus(404);

--- a/api/views/home.handlebars
+++ b/api/views/home.handlebars
@@ -1,33 +1,27 @@
-<div>
-    <div class="btn-group mt-2 mb-4 w-100" role="group">
-        <a href="/send-token/" class="w-100 btn btn-outline-primary" >Return to App<i class="bi bi-arrow-return-left"></i></a>
+
+<div class="card-deck">
+
+  <div class="card">
+    <div class="card-header">
+      <h4 class="card-title">Welcome to Fieldmark Conductor</h4>
     </div>
-</div>
+    <div class="card-body">
+      <p class="card-text">Conductor is the web server supporting the Fieldmark app. Here you
+        can manage your notebooks and notebook users.</p>
 
-<div class="card-group">
-  
-        <div class="card">
-          <div class="card-header">
-            Assigned Roles
-          </div>
-          <div class="card-body">
-              {{{ project_roles }}}
-            <ul>
-              {{#each other_roles}}
-                <li>{{ this }}</li>
-              {{/each}}
-            </ul>
-        </div>
-
-        <div class="card">
-          <div class="card-header">
-            Switching User?
-          </div>
-          <div class="card-body">
-              <p class="card-text">To sign in as a different user, you need to
-                 <a href="/logout/">logout</a> first.</p>
-          </div>
-        </div>
+      <ul>
+        {{#if WEBAPP_PUBLIC_URL}}
+        <li><a href="{{WEBAPP_PUBLIC_URL}}">Fieldmark on the Web</a></li>
+        {{/if}}
+        {{#if IOS_APP_URL}}
+        <li>Install <a href="{{IOS_APP_URL}}">Fieldmark for IOS</a> (App Store)</li>
+        {{/if}}
+        {{#if ANDROID_APP_URL}}
+        <li>Install <a href="{{ANDROID_APP_URL}}">Fieldmark for Android</a> (Google Play)</li>
+        {{/if}}
+      </ul>          
+    </div>
+  </div>
 
       <div class="card">
       <div class="card-header">

--- a/api/views/layouts/main.handlebars
+++ b/api/views/layouts/main.handlebars
@@ -110,13 +110,11 @@
 
   <footer class="footer mt-auto py-3 bg-light">
     <div class="container">
-        <p style="font-size: 12px">Access to <strong>the Fieldmark™ Demonstration App</strong> is provided for the purpose of 
-        creating and testing <strong>trial notebooks</strong> only. For
-    field trials, users are responsible for testing all aspects of notebook functionality including notebook set up, data
-    collection, saving and exporting data. <strong>No warranty is provided for data loss.</strong> Do not store sensitive or highly sensitive
-    data according to the Australian Privacy Act on this server, as we cannot guarantee access controls on this server. The
-    server may be reset without notice. Access to the <strong>Fieldmark™ Demonstration App</strong> may be revoked at short notice. Records
-    created in shared notebooks will be visible to other users.</p>
+        <p style="font-size: 12px">
+          Fieldmark is a product of <a href="https://fieldnote.au/">Electronic Field Notebooks Pty Ltd</a>.
+          || <a href="https://fieldnote.au/terms-of-service/">Terms of Service</a>
+          || <a href="https://fieldnote.au/privacy/">Privacy Policy</a>.
+        </p>
 
     <p class="mt-5 mb-3" style="font-size: 12px">The <a href="https://faims.edu.au/">FAIMS 3.0 Electronic Field Notebooks project</a> 
     received investment ( <a href="https://dx.doi.org/10.47486/PL110">doi: 10.47486/PL110</a>) from 

--- a/api/views/notebook-landing.handlebars
+++ b/api/views/notebook-landing.handlebars
@@ -27,6 +27,9 @@
       <h3>Download Notebook JSON definition</h3>
       <p><a download href="/api/notebooks/{{notebook.project_id}}">{{notebook.project_id}}.json</a></p>
 
+      {{#if DESIGNER_URL}}
+        <p>You can update your notebook by uploading the JSON to <a href="{{DESIGNER_URL}}">Designer</a></p>
+      {{/if}}
     </div>
 
     <div class="col">

--- a/api/views/notebooks.handlebars
+++ b/api/views/notebooks.handlebars
@@ -10,6 +10,10 @@
     New Notebook
   </button>
 
+  {{#if DESIGNER_URL}}
+    <p>Create a new notebook JSON file with <a href="{{DESIGNER_URL}}">Designer</a></p>
+  {{/if}}
+
 <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">


### PR DESCRIPTION
# Remove useless stuff from home page and add links to web/mobile apps if available.

## JIRA Ticket

None

## Description

For the new release of Fieldmark we want a slightly nicer home page on Conductor. 

## Proposed Changes

Removes the unused return to app button and list of notebook roles. Adds links
to the various apps if configured.  

## How to Test

Add the following to `api/.env`:

```bash
WEBAPP_PUBLIC_URL=http://localhost:3000
ANDROID_APP_PUBLIC_URL=https://play.google.com/store/apps/details?id=org.fedarch.faims3
IOS_APP_PUBLIC_URL=https://apps.apple.com/au/app/fieldmark/id1592632372
DESIGNER_URL=https://designer.testing.fieldmark.app
```

You should see these links on the Conductor home page.

## Additional Information

Will soon be superceded by "New Conductor".

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
