### PR TITLE
Bump IOS to 1.0.5 for new release

### DIFF
--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -57,7 +57,7 @@ fi
 #version=$(grep '"version":' $PROJECT_DIR/package.json | cut -d: -f 2 | sed -e 's/[", ]//g')
 # since we previously published 1.0.0 on app store we need a higher version
 # number, set that here until we get the main version above this
-version=1.0.4
+version=1.0.5
 buildNumber=$(date -u "+%Y%m%d%H%M")
 
 if test -f /usr/libexec/PlistBuddy; then


### PR DESCRIPTION
# Bump IOS to 1.0.5 for new release


## Description

Need to release a new version on IOS so bump it's version number.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
