### PR TITLE
Fix: Designer bug when switching forms

### DIFF
--- a/designer/src/components/design-panel.tsx
+++ b/designer/src/components/design-panel.tsx
@@ -55,6 +55,7 @@ export const DesignPanel = () => {
   const maxKeys = Object.keys(viewSets).length;
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
+    console.log('Switching to tab', newValue);
     setTabIndex(newValue.toString());
   };
 

--- a/designer/src/components/design-panel.tsx
+++ b/designer/src/components/design-panel.tsx
@@ -55,7 +55,6 @@ export const DesignPanel = () => {
   const maxKeys = Object.keys(viewSets).length;
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    console.log('Switching to tab', newValue);
     setTabIndex(newValue.toString());
   };
 

--- a/designer/src/components/form-editor.tsx
+++ b/designer/src/components/form-editor.tsx
@@ -44,7 +44,7 @@ import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 
 import {useAppDispatch, useAppSelector} from '../state/hooks';
 import {SectionEditor} from './section-editor';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import {shallowEqual} from 'react-redux';
 
 type Props = {
@@ -74,6 +74,9 @@ export const FormEditor = ({
       return shallowEqual(left, right);
     }
   );
+  const sections = viewSet ? viewSet.views : [];
+  console.log('FormEditor', { viewSetId, sections });
+
   const views = useAppSelector(
     state => state.notebook['ui-specification'].fviews
   );
@@ -97,6 +100,11 @@ export const FormEditor = ({
   const [initialIndex, setInitialIndex] = useState(
     visibleTypes.indexOf(viewSetId)
   );
+
+  useEffect(() => {
+    // reset activeStep when viewSetId changes
+    setActiveStep(0);
+  }, [viewSetId]);
 
   const handleStep = (step: number) => () => {
     setActiveStep(step);
@@ -438,17 +446,17 @@ export const FormEditor = ({
                 alternativeLabel
                 sx={{my: 3}}
               >
-                {viewSet.views.map((view: string, index: number) => (
-                  <Step key={view}>
+                {sections.map((section: string, index: number) => (
+                  <Step key={section}>
                     <StepButton color="inherit" onClick={handleStep(index)}>
-                      <Typography>{views[view].label}</Typography>
+                      <Typography>{views[section].label}</Typography>
                     </StepButton>
                   </Step>
                 ))}
               </Stepper>
             </Grid>
 
-            {activeStep === viewSet.views.length ? (
+            {sections.length === 0 ? (
               <Grid item xs={12}>
                 <Grid
                   container

--- a/designer/src/components/section-editor.tsx
+++ b/designer/src/components/section-editor.tsx
@@ -67,7 +67,7 @@ export const SectionEditor = ({
   );
   const dispatch = useAppDispatch();
 
-  console.log('SectionEditor', viewId, viewSet);
+  console.log('SectionEditor', { viewId, viewSet, fView });
 
   const [open, setOpen] = useState(false);
   const [editMode, setEditMode] = useState(false);


### PR DESCRIPTION
# Fix: Designer bug when switching forms

## JIRA Ticket

[BSS-640](https://jira.csiro.au/browse/BSS-640)

## Description

This PR fixes a bug in the designer where switching from the second section of a form to a form with only one section incorrectly displays an empty form with the message, *"Form has been created. Add a section to get started."*

## Proposed Changes

- **Reset activeStep:**
  - Added a `useEffect` hook to reset `activeStep` to `0` when `viewSetId` changes
- **Conditional Rendering Fix:**  
  - Updated the rendering logic to check `sections.length === 0` instead of relying on `activeStep` to prevent incorrect state interpretation when switching tabs.
  - If `sections.length === 0`, the message *"Form has been created. Add a section to get started."* is displayed.  
  - Otherwise, the `SectionEditor` component renders the active section correctly. 

## How to Test

1. Run Designer.
2. Open a notebook with multiple forms where some have multiple sections.  
3. Go to the *Design* tab, select a form with multiple sections and switch to second section.  
4. Switch to a form with only one section.  
5. Verify that:  
   - The correct section is displayed.  
   - If no sections exist, the appropriate message appears.  
   - No crash occurs when switching forms.  

## Additional Information

The previous condition `activeStep === viewSet.views.length` checks if the active step matches the number of sections in the form. When switching tabs, if `activeStep` isn't reset, it might carry over from the previous form. Since the previous form had more sections than the new one, `activeStep` could be greater than or equal to the number of sections, leading to the incorrect identification of the form as having no sections. This causes the "*Form has been created. Add a section to get started*" message to display, even if the new form contains a section.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
