### PR TITLE
Increment version to 1.1.0, remove ios specific version string

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faims3/api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "main": "build/src/index.js",
   "packageManager": "npm@10.7.0",

--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_DIR="${SCRIPT_DIR}/../"
+
 APP_NAME_PLACEHOLDER=APPNAME
 APP_ID_PLACEHOLDER=org.fedarch.faims3
 
@@ -54,10 +57,7 @@ fi
 # Setting the IOS build version
 # https://pgu.dev/2020/12/16/ios-build-versioning.html
 
-#version=$(grep '"version":' $PROJECT_DIR/package.json | cut -d: -f 2 | sed -e 's/[", ]//g')
-# since we previously published 1.0.0 on app store we need a higher version
-# number, set that here until we get the main version above this
-version=1.0.5
+version=$(grep '"version":' $PROJECT_DIR/package.json | cut -d: -f 2 | sed -e 's/[", ]//g')
 buildNumber=$(date -u "+%Y%m%d%H%M")
 
 if test -f /usr/libexec/PlistBuddy; then

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@faims3/app",
     "packageManager": "npm@10.7.0",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "private": true,
     "browserslist": {
         "production": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faims3",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "engines": {
     "node": "^20.9.0"


### PR DESCRIPTION

# Increment version to 1.1.0, remove ios specific version string

## JIRA Ticket

None

## Description

Increments the version number to 1.1.0 for future builds.  

Removes a special case version number for IOS,  now all apps will be on the same version number.

The rationale for doing this now is to avoid confusion with nightly builds pushed to the app stores. These are now clearly pre-release 1.1.0 builds rather than post release 1.0.0. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
