### PR TITLE
feat: hrid redesign, designer settings, template editor and TemplatedStringField changes

### DIFF
--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -277,28 +277,6 @@ function make_html_safe(s: string): string {
   return handlebars.escapeExpression(s);
 }
 
-function render_project_roles(roles: AllProjectRoles): handlebars.SafeString {
-  const all_project_sections = [];
-  for (const project in roles) {
-    const project_sections = [];
-    for (const role of roles[project]) {
-      project_sections.push('<li>' + make_html_safe(role) + '</li>');
-    }
-    const safe_name = make_html_safe(project);
-    all_project_sections.push(
-      '<h6>Roles for project "' +
-        `<a href="./notebooks/${safe_name}/">` +
-        safe_name +
-        '</a>' +
-        '"</h6>' +
-        '<ul>' +
-        project_sections.join('') +
-        '</ul>'
-    );
-  }
-  return new handlebars.SafeString(all_project_sections.join(''));
-}
-
 app.get('/send-token/', (req, res) => {
   if (req.user) {
     res.render('send-token', {

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -20,12 +20,8 @@
  */
 import {NonUniqueProjectID} from '@faims3/data-model';
 import {body, validationResult} from 'express-validator';
-import handlebars from 'handlebars';
 import QRCode from 'qrcode';
 import {app} from './core';
-import {AllProjectRoles} from './datamodel/users';
-
-// BBS 20221101 Adding this as a proxy for the pouch db url
 import {add_auth_providers} from './auth_providers';
 import {add_auth_routes} from './auth_routes';
 import {generateUserToken} from './authkeys/create';
@@ -272,10 +268,6 @@ app.get(
     }
   }
 );
-
-function make_html_safe(s: string): string {
-  return handlebars.escapeExpression(s);
-}
 
 app.get('/send-token/', (req, res) => {
   if (req.user) {

--- a/app/.env.dist
+++ b/app/.env.dist
@@ -7,8 +7,9 @@ VITE_CONDUCTOR_URL=http://localhost:8080
 # Configuration options for PouchDB
 VITE_POUCH_BATCHES_LIMIT=10
 VITE_POUCH_BATCH_SIZE=1000
-# Include a BugSnag API key to enable bug reporting via that service
-VITE_BUGSNAG_KEY=<your bugsnag API key>
+# Include a BugSnag API key to enable bug reporting via that service - replace
+# false with actual key
+VITE_BUGSNAG_KEY=false
 # Set to true to enable some debugging messaging
 VITE_DEBUG_APP=true
 # Set to true for verbose debug messages from PouchDB

--- a/app/.env.dist
+++ b/app/.env.dist
@@ -9,7 +9,7 @@ VITE_POUCH_BATCHES_LIMIT=10
 VITE_POUCH_BATCH_SIZE=1000
 # Include a BugSnag API key to enable bug reporting via that service - replace
 # false with actual key
-VITE_BUGSNAG_KEY=false
+# VITE_BUGSNAG_KEY=false
 # Set to true to enable some debugging messaging
 VITE_DEBUG_APP=true
 # Set to true for verbose debug messages from PouchDB

--- a/app/package.json
+++ b/app/package.json
@@ -98,6 +98,7 @@
         "@worker-tools/json-stream": "^0.1.0-pre.12",
         "animate.css": "^4.1.1",
         "assert": "^2.0.0",
+        "base64-arraybuffer": "^1.0.2",
         "buffer": "^6.0.3",
         "clsx": "1.2.1",
         "fast-json-stable-stringify": "2.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -98,7 +98,6 @@
         "@worker-tools/json-stream": "^0.1.0-pre.12",
         "animate.css": "^4.1.1",
         "assert": "^2.0.0",
-        "base64-arraybuffer": "^1.0.2",
         "buffer": "^6.0.3",
         "clsx": "1.2.1",
         "fast-json-stable-stringify": "2.1.0",

--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -196,7 +196,11 @@ function cluster_admin_group_name(): string {
 // If VITE_BUGSNAG_KEY is not defined then we don't use Bugsnag
 function get_bugsnag_key(): string | false {
   const bugsnag_key = import.meta.env.VITE_BUGSNAG_KEY;
-  if (bugsnag_key === '' || bugsnag_key === undefined) {
+  if (
+    bugsnag_key === '' ||
+    bugsnag_key === undefined ||
+    bugsnag_key === 'false'
+  ) {
     return false;
   }
   return bugsnag_key;

--- a/app/src/gui/components/record/RecordData.tsx
+++ b/app/src/gui/components/record/RecordData.tsx
@@ -77,7 +77,6 @@ export default function RecordData(props: RecordDataTypes) {
     setDataTab(newValue);
   };
   const theme = useTheme();
-  console.log(props.is_link_ready);
 
   return (
     <Box bgcolor={grey[100]}>

--- a/app/src/gui/components/record/RecordData.tsx
+++ b/app/src/gui/components/record/RecordData.tsx
@@ -77,6 +77,7 @@ export default function RecordData(props: RecordDataTypes) {
     setDataTab(newValue);
   };
   const theme = useTheme();
+  console.log(props.is_link_ready);
 
   return (
     <Box bgcolor={grey[100]}>

--- a/app/src/gui/components/record/branchingLogic.tsx
+++ b/app/src/gui/components/record/branchingLogic.tsx
@@ -44,7 +44,13 @@ export function getFieldsMatchingCondition(
   if (modified.length > 0 || fieldNames.length === 0) {
     // filter the whole set of views
     const result = allFields.filter(field => {
-      return ui_specification.fields[field].conditionFn(values);
+      const fieldDetails = ui_specification.fields[field];
+      return (
+        // Visibility condition function
+        fieldDetails.conditionFn(values) &&
+        // Hidden explicitly in element props - e.g. templated field
+        !fieldDetails['component-parameters']?.ElementProps?.hidden
+      );
     });
     return result;
   } else {

--- a/app/src/gui/components/record/branchingLogic.tsx
+++ b/app/src/gui/components/record/branchingLogic.tsx
@@ -49,7 +49,7 @@ export function getFieldsMatchingCondition(
         // Visibility condition function
         fieldDetails.conditionFn(values) &&
         // Hidden explicitly in element props - e.g. templated field
-        !fieldDetails['component-parameters']?.ElementProps?.hidden
+        !fieldDetails['component-parameters']?.hidden
       );
     });
     return result;

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -35,7 +35,7 @@ import {Alert, Box, Divider, Typography} from '@mui/material';
 import {Form, Formik} from 'formik';
 import React from 'react';
 import {NavigateFunction} from 'react-router-dom';
-import {object, ValidationError} from 'yup';
+import {ValidationError} from 'yup';
 import * as ROUTES from '../../../constants/routes';
 import {INDIVIDUAL_NOTEBOOK_ROUTE} from '../../../constants/routes';
 import {
@@ -53,6 +53,11 @@ import {
   getFieldsForViewSet,
   getReturnedTypesForViewSet,
 } from '../../../uiSpecification';
+import {
+  getRecordContextFromRecord,
+  recomputeDerivedFields,
+  ValuesObject,
+} from '../../../utils/formUtilities';
 import CircularLoading from '../ui/circular_loading';
 import {getValidationSchemaForViewset} from '../validation';
 import {
@@ -70,12 +75,6 @@ import {
 } from './relationships/RelatedInformation';
 import UGCReport from './UGCReport';
 import {getUsefulFieldNameFromUiSpec, ViewComponent} from './view';
-import {
-  formatTimestamp,
-  getRecordContextFromRecord,
-  recomputeDerivedFields,
-  ValuesObject,
-} from '../../../utils/formUtilities';
 
 type RecordFormProps = {
   navigate: NavigateFunction;
@@ -1297,23 +1296,21 @@ class RecordForm extends React.Component<any, RecordFormState> {
                   JSON.stringify(this.state.lastProcessedValues);
 
                 if (valuesChanged) {
-                  // deep copy which can be set
-                  const copyValues = JSON.parse(JSON.stringify(values));
                   // Process the derive fields updates
                   const changed = recomputeDerivedFields({
                     context: this.state.recordContext,
-                    values: copyValues,
+                    values: values,
                     uiSpecification: this.props.ui_specification,
                   });
 
                   // Only update if processing actually changed something
                   if (changed) {
                     // Update form values
-                    setValues(copyValues);
+                    setValues(values);
                   }
 
                   // Store the processed values
-                  this.setState({lastProcessedValues: copyValues});
+                  this.setState({lastProcessedValues: values});
                 }
 
                 const layout =

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -818,15 +818,11 @@ class RecordForm extends React.Component<any, RecordFormState> {
 
     // Now do an in-place update of object values to ensure that we have the
     // latest templated fields which may require on current runtime values
-    console.log('Running pre-save template update.');
-    const changed = recomputeDerivedFields({
+    recomputeDerivedFields({
       values: values,
       context: mergedRecordContext,
       uiSpecification: ui_specification,
     });
-    if (changed) {
-      console.info('Template values were changed during pre-save render.');
-    }
 
     const doc = {
       record_id: this.props.record_id,

--- a/app/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/app/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -18,10 +18,8 @@
  *   This is the file is to set the values for persistent state
  */
 import {
-  getFieldToIdsMap,
   getFirstRecordHead,
   getFullRecordData,
-  getHridFieldMap,
   getMetadataForSomeRecords,
   LinkedRelation,
   LocationState,
@@ -36,14 +34,10 @@ import {
 } from '@faims3/data-model';
 import * as ROUTES from '../../../../constants/routes';
 import {logError} from '../../../../logging';
-import {
-  getHridFromValuesAndSpec,
-  ValuesObject,
-} from '../../../../utils/formUtilities';
+import {getUiSpecForProject} from '../../../../uiSpecification';
+import {getHridFromValuesAndSpec} from '../../../../utils/formUtilities';
 import getLocalDate from '../../../fields/LocalDate';
 import {ParentLinkProps, RecordLinkProps} from './types';
-import {getUiSpecForProject} from '../../../../uiSpecification';
-import {projectIsActivated} from '../../../../sync/projects';
 
 /**
  * Generate an object containing information to be stored in
@@ -750,37 +744,6 @@ export async function getParentPersistenceData({
     }
   }
   return parentRecords;
-}
-
-/**
- * Returns the value to be used as the HRID - either the value of a specified
- * field, OR the record_id.
- * @param record_id The record ID which is a fallback HRID
- * @param values The values in the current response
- * @param hridFieldName The specific HRID field name if available
- * @returns The value to be used as the HRID
- */
-function getHRIDValue(
-  record_id: string,
-  values: {[field_name: string]: any} | undefined,
-  // if we know a specific hridFieldName - then use this
-  hridFieldName: string | undefined
-) {
-  if (values === undefined) return record_id;
-
-  // See if we can use the specified hrid field name
-  if (hridFieldName !== undefined && hridFieldName !== '') {
-    if (values[hridFieldName] !== undefined) {
-      return values[hridFieldName];
-    }
-  }
-
-  const possibleHRIDFields = Object.getOwnPropertyNames(values).filter(
-    (f: string) => f.startsWith('hrid')
-  );
-
-  if (possibleHRIDFields.length === 1) return values[possibleHRIDFields[0]];
-  else return record_id;
 }
 
 export async function getDetailRelatedInformation(

--- a/app/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/app/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -367,7 +367,7 @@ export async function getRelatedRecords(
   links.forEach((link: any, index: number) => {
     if (!link || typeof link !== 'object' || !('record_id' in link)) {
       throw new Error(
-        `Invalid link at ${multiple ? `index ${index}` : 'value'}: must be an object with record_id property`
+        `Invalid link at ${multiple ? `index ${index}` : 'value'}: must be an object with record_id property. Link was ${JSON.stringify(link)}`
       );
     }
   });
@@ -442,17 +442,18 @@ async function get_field_RelatedFields(
 ): Promise<Array<RecordLinkProps>> {
   // hrid field map
   const hridFieldMap = getHridFieldMap(ui_specification);
-
+  
   for (const index in fields) {
+    const field = fields[index]['field'];
+    const child_record = fields[index]['value'];
+
     // Get the view and viewset ID
     const {viewSetId} = getIdsByFieldName({
       uiSpecification: ui_specification,
-      fieldName: index,
+      fieldName: field,
     });
     const hridFieldName = hridFieldMap[viewSetId];
 
-    const field = fields[index]['field'];
-    const child_record = fields[index]['value'];
 
     const related_type =
       ui_specification['fields'][field]['component-parameters']['related_type'];

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -18,34 +18,30 @@
  *   TODO
  */
 
-import React, {useEffect} from 'react';
-
-import {FieldProps} from 'formik';
-
-import * as ROUTES from '../../constants/routes';
 import {
-  generateFAIMSDataID,
   FAIMSTypeName,
-  LocationState,
-  RecordReference,
+  generateFAIMSDataID,
   getPossibleRelatedRecords,
+  LocationState,
   RecordMetadata,
-  ProjectUIModel,
+  RecordReference,
 } from '@faims3/data-model';
+import {Grid, SelectChangeEvent, Typography} from '@mui/material';
+import {FieldProps} from 'formik';
+import React, {useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
-import {Grid, Typography} from '@mui/material';
+import * as ROUTES from '../../constants/routes';
+import {selectActiveToken} from '../../context/slices/authSlice';
+import {useAppSelector} from '../../context/store';
+import {logError} from '../../logging';
 import {
-  getRelatedRecords,
   addRecordLink,
+  getRelatedRecords,
   remove_link_from_list,
   removeRecordLink,
 } from '../components/record/relationships/RelatedInformation';
-import {DataGridFieldLinksComponent} from '../components/record/relationships/field_level_links/datagrid';
-import {SelectChangeEvent} from '@mui/material';
 import CreateLinkComponent from '../components/record/relationships/create_links';
-import {logError} from '../../logging';
-import {useAppSelector} from '../../context/store';
-import {selectActiveToken} from '../../context/slices/authSlice';
+import {DataGridFieldLinksComponent} from '../components/record/relationships/field_level_links/datagrid';
 
 function get_default_relation_label(
   multiple: boolean,

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -136,7 +136,7 @@ interface RelatedRecordSelectorProps extends FieldProps {
 
 export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
   const activeToken = useAppSelector(selectActiveToken)!.parsedToken;
-  const project_id = props.form.values['_project_id'];
+  const project_id = props.form.values['_project_id'] as string;
   const record_id = props.form.values['_id'];
   const field_name = props.field.name;
 
@@ -338,7 +338,11 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
       field_id: field_name,
       relation_type_vocabPair: relationshipPair,
     };
-    addRecordLink(selectedRecord, current_record, props.relation_type)
+    addRecordLink({
+      child_record: selectedRecord,
+      parent: current_record,
+      relation_type: props.relation_type,
+    })
       .then(child_record => {
         if (child_record !== null) {
           if (!multiple) setRecordsInformation([child_record]);

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -30,6 +30,7 @@ import {
   RecordReference,
   getPossibleRelatedRecords,
   RecordMetadata,
+  ProjectUIModel,
 } from '@faims3/data-model';
 import {useLocation} from 'react-router-dom';
 import {Grid, Typography} from '@mui/material';

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -335,9 +335,10 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
       relation_type_vocabPair: relationshipPair,
     };
     addRecordLink({
-      child_record: selectedRecord,
+      childRecord: selectedRecord,
       parent: current_record,
-      relation_type: props.relation_type,
+      relationType: props.relation_type,
+      projectId: project_id,
     })
       .then(child_record => {
         if (child_record !== null) {

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -18,25 +18,25 @@
  */
 
 import {Camera, CameraResultType, Photo} from '@capacitor/camera';
-import AddCircleIcon from '@mui/icons-material/AddCircle';
 import {Capacitor} from '@capacitor/core';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ImageIcon from '@mui/icons-material/Image';
-import Button from '@mui/material/Button';
 import {Alert, Box, Link, Paper, Typography, useTheme} from '@mui/material';
+import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
+import {Buffer} from 'buffer';
 import {FieldProps} from 'formik';
 import React from 'react';
-import * as ROUTES from '../../constants/routes';
 import {useNavigate} from 'react-router';
 import {APP_NAME, NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
+import * as ROUTES from '../../constants/routes';
 import {logError} from '../../logging';
 import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
 import FieldWrapper from './fieldWrapper';
-import {Buffer} from 'buffer';
 
 /**
  * Converts a base64 encoded image to a Blob object using Buffer
@@ -363,13 +363,6 @@ export const TakePhoto: React.FC<
       props.form.setFieldError(props.field.name, err.message);
     }
   };
-
-  const error = props.form.errors[props.field.name];
-  const errorText = error ? (
-    <span {...props.ErrorTextProps}>{error as string}</span>
-  ) : (
-    <span {...props.NoErrorTextProps}></span>
-  );
 
   const images = props.form.values[props.field.name] ?? [];
   const disabled = props.disabled ?? false;

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -28,7 +28,6 @@ import {Alert, Box, Link, Paper, Typography, useTheme} from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
-import {decode} from 'base64-arraybuffer';
 import {FieldProps} from 'formik';
 import React from 'react';
 import * as ROUTES from '../../constants/routes';
@@ -37,20 +36,24 @@ import {APP_NAME, NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
 import {logError} from '../../logging';
 import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
 import FieldWrapper from './fieldWrapper';
+import {Buffer} from 'buffer';
 
 /**
- * Converts a base64 encoded image to a Blob object using fetch API instead of
- * deprecated atob
+ * Converts a base64 encoded image to a Blob object using Buffer
  * @param image - Photo object containing base64 string and format information
  * @returns Promise resolving to a Blob object representing the image
  * @throws Error if base64String is undefined
  */
 async function base64ImageToBlob(image: Photo): Promise<Blob> {
-  if (image.base64String === undefined) {
-    throw Error('No photo data found');
+  if (!image.base64String) {
+    throw new Error('No photo data found');
   }
 
-  return new Blob([new Uint8Array(decode(image.base64String))], {
+  // Convert base64 to buffer
+  const buffer = Buffer.from(image.base64String, 'base64');
+
+  // Create blob from buffer
+  return new Blob([buffer], {
     type: `image/${image.format}`,
   });
 }

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -18,7 +18,7 @@
  */
 
 import {Camera, CameraResultType, Photo} from '@capacitor/camera';
-import {Capacitor, ExceptionCode} from '@capacitor/core';
+import {Capacitor} from '@capacitor/core';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -28,6 +28,7 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
+import {decode} from 'base64-arraybuffer';
 import {FieldProps} from 'formik';
 import React from 'react';
 import {useNavigate} from 'react-router';
@@ -35,7 +36,6 @@ import {APP_NAME, NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
 import * as ROUTES from '../../constants/routes';
 import {logError} from '../../logging';
 import FaimsAttachmentManagerDialog from '../components/ui/Faims_Attachment_Manager_Dialog';
-import {decode} from 'base64-arraybuffer';
 
 /**
  * Converts a base64 encoded image to a Blob object using fetch API instead of
@@ -272,7 +272,7 @@ const ImageGallery = ({
                 '. Ignoring in gallery. Error: ',
                 e
               );
-              throw(e)
+              throw e;
             }
           } else {
             return (

--- a/app/src/gui/fields/TemplatedStringField.tsx
+++ b/app/src/gui/fields/TemplatedStringField.tsx
@@ -1,21 +1,24 @@
 /*
  * Copyright 2021, 2022 Macquarie University
  *
- * Licensed under the Apache License Version 2.0 (the, "License");
- * you may not use, this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License Version 2.0 (the, "License"); you may not
+ * use, this file except in compliance with the License. You may obtain a copy
+ * of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
- * See, the License, for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND either express or implied. See, the
+ * License, for the specific language governing permissions and limitations
+ * under the License.
  *
- * Filename: TemplatedStringField.tsx
- * Description:
- *   A field that constructs a value via a template from other field values
+ * Filename: TemplatedStringField.tsx Description: A field that constructs a
+ * value via a template from other field values
+ *
+ * NOTE: this is now just a stale text field which is read only - templated
+ * field values are now managed through the form.tsx render loop and implemented
+ * universally in formUtilities.ts
  */
 
 import React from 'react';

--- a/app/src/gui/fields/TemplatedStringField.tsx
+++ b/app/src/gui/fields/TemplatedStringField.tsx
@@ -21,20 +21,8 @@
 import React from 'react';
 import MuiTextField from '@mui/material/TextField';
 import {TextFieldProps} from 'formik-mui';
-import Mustache from 'mustache';
-import getLocalDate from './LocalDate';
-
-interface FieldValues {
-  [field_name: string]: any;
-}
-
-function render_template(template: string, values: FieldValues): string {
-  return Mustache.render(template, values);
-}
 
 interface Props {
-  template: string;
-  disabled?: boolean;
   value?: string;
 }
 
@@ -53,45 +41,6 @@ export class TemplatedStringField extends React.Component<
     };
   }
 
-  // compute the value on startup and on any update
-  componentDidMount(): void {
-    this.updateValue();
-  }
-
-  componentDidUpdate() {
-    this.updateValue();
-  }
-
-  /**
-   * Update the field value based on the values of other
-   * fields in the form and the configured template string
-   */
-  updateValue() {
-    if (this.props.disabled === true) return;
-    const {template, ...textFieldProps} = this.props;
-
-    // gather the field values together that will be used as
-    // placeholder names in the template
-    const field_values: FieldValues = {};
-    for (const field_name in textFieldProps.form.values) {
-      if (field_name !== textFieldProps.field.name) {
-        let value = textFieldProps.form.values[field_name];
-        if (typeof value === 'function')
-          value = getLocalDate(value).replace('T', ' ');
-        field_values[field_name] = value;
-      }
-    }
-    // compute the new value and update if it has changed
-    const value = render_template(template, field_values);
-    if (value !== this.state.value) {
-      this.setState({value: value});
-      this.props.form.setFieldValue(this.props.field.name, value, true);
-      if (value !== '')
-        if (this.props.form.errors[this.props.field.name] !== undefined)
-          this.props.form.setFieldError(this.props.field.name, undefined);
-    }
-  }
-
   render() {
     return (
       <>
@@ -99,6 +48,7 @@ export class TemplatedStringField extends React.Component<
           value={this.props.value}
           id={this.props.id}
           label={this.props.label}
+          disabled={true}
           variant="outlined"
           inputProps={{readOnly: true}}
           fullWidth

--- a/app/src/gui/fields/multiselect.tsx
+++ b/app/src/gui/fields/multiselect.tsx
@@ -24,15 +24,10 @@ import {
   Checkbox,
   FormControl,
   FormControlLabel,
-  FormHelperText,
-  InputLabel,
   ListItemText,
   MenuItem,
-  OutlinedInput,
   Select,
-  Typography,
 } from '@mui/material';
-import {useTheme} from '@mui/material/styles';
 import {FieldProps} from 'formik';
 import {TextFieldProps} from 'formik-mui';
 import {ReactNode} from 'react';
@@ -86,8 +81,6 @@ export const ExpandedChecklist = ({
   options,
   value,
   onChange,
-  label,
-  helperText,
   exclusiveOptions = [],
 }: ExpandedChecklistProps) => {
   const selectedExclusiveOption = value.find(v => exclusiveOptions.includes(v));
@@ -146,12 +139,8 @@ export const MuiMultiSelect = ({
   options,
   value,
   onChange,
-  label,
-  helperText,
   exclusiveOptions = [],
 }: MuiMultiSelectProps) => {
-  const theme = useTheme();
-
   const handleChange = (event: any) => {
     const selectedValues = event.target.value;
 

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -203,12 +203,11 @@ function DraftEdit(props: DraftEditProps) {
             relation_type_vocabPair: props.state.relation_type_vocabPair,
           },
         };
-        const newParent = await getParentPersistenceData(
-          uiSpec,
-          project_id,
+        const newParent = await getParentPersistenceData({
+          uiSpecification: uiSpec,
+          projectId: project_id,
           parent,
-          record_id
-        );
+        });
         setParentLinks(newParent);
         setIs_link_ready(true);
       } else {

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -170,6 +170,7 @@ export default function Record() {
           setRevisions(all_revisions);
         })
         .catch(logError);
+    // TODO update this
       getHRIDforRecordID(project_id!, record_id!).then(hrid => {
         setHrid(hrid);
         setBreadcrumbs([

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -170,7 +170,6 @@ export default function Record() {
           setRevisions(all_revisions);
         })
         .catch(logError);
-    // TODO update this
       getHRIDforRecordID(project_id!, record_id!).then(hrid => {
         setHrid(hrid);
         setBreadcrumbs([
@@ -255,6 +254,7 @@ export default function Record() {
   useEffect(() => {
     // this is function to get child information
 
+    // TODO This is not resolving properly!
     const getrelated_Info = async () => {
       try {
         if (uiSpec !== null && type !== null) {
@@ -265,6 +265,7 @@ export default function Record() {
             false
           );
           if (latest_record !== null) {
+            console.log(JSON.stringify(latest_record, undefined, 2));
             //add checking for deleted record, so it can be direct to notebook page
             if (latest_record.deleted === true) {
               dispatch(
@@ -277,6 +278,7 @@ export default function Record() {
                 pathname: ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + project_id,
               });
             }
+            console.log('Running new relationship');
             const newRelationship = await getDetailRelatedInformation(
               uiSpec,
               type,
@@ -286,6 +288,7 @@ export default function Record() {
               record_id!,
               updatedrevision_id!
             );
+            console.log('Got it back');
             setRelatedRecords(newRelationship);
             const newParent = await getParentPersistenceData(
               uiSpec,
@@ -334,6 +337,7 @@ export default function Record() {
           setIs_link_ready(true);
         }
       } catch (error) {
+        console.error(error);
         logError(error);
         //setIs_link_ready(true);
       }

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -253,8 +253,6 @@ export default function Record() {
 
   useEffect(() => {
     // this is function to get child information
-
-    // TODO This is not resolving properly!
     const getrelated_Info = async () => {
       try {
         if (uiSpec !== null && type !== null) {
@@ -265,7 +263,6 @@ export default function Record() {
             false
           );
           if (latest_record !== null) {
-            console.log(JSON.stringify(latest_record, undefined, 2));
             //add checking for deleted record, so it can be direct to notebook page
             if (latest_record.deleted === true) {
               dispatch(
@@ -278,7 +275,6 @@ export default function Record() {
                 pathname: ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + project_id,
               });
             }
-            console.log('Running new relationship');
             const newRelationship = await getDetailRelatedInformation(
               uiSpec,
               type,
@@ -288,7 +284,6 @@ export default function Record() {
               record_id!,
               updatedrevision_id!
             );
-            console.log('Got it back');
             setRelatedRecords(newRelationship);
             const newParent = await getParentPersistenceData(
               uiSpec,

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -285,12 +285,11 @@ export default function Record() {
               updatedrevision_id!
             );
             setRelatedRecords(newRelationship);
-            const newParent = await getParentPersistenceData(
-              uiSpec,
-              project_id!,
-              latest_record.relationship ?? null,
-              record_id!
-            );
+            const newParent = await getParentPersistenceData({
+              uiSpecification: uiSpec,
+              projectId: project_id!,
+              parent: latest_record.relationship ?? null,
+            });
             setParentLinks(newParent);
             let newBreadcrumbs = [
               // {link: ROUTES.INDEX, title: 'Home'},
@@ -382,12 +381,11 @@ export default function Record() {
           if (uiSpec !== null) {
             setRelatedRecords(result.newRelationship);
 
-            getParentPersistenceData(
-              uiSpec,
-              project_id!,
-              result.new_relation ?? {},
-              record_id!
-            ).then(newParent => {
+            getParentPersistenceData({
+              uiSpecification: uiSpec,
+              projectId: project_id!,
+              parent: result.new_relation,
+            }).then(newParent => {
               setParentLinks(newParent);
             });
           }

--- a/app/src/logging.tsx
+++ b/app/src/logging.tsx
@@ -125,6 +125,7 @@ export const ErrorPage = () => {
 
 export const logError = (error: any) => {
   if (BUGSNAG_KEY) {
+    console.error(error);
     Bugsnag.notify(error);
   } else {
     console.error('LogError:', error);

--- a/app/src/logging.tsx
+++ b/app/src/logging.tsx
@@ -125,7 +125,6 @@ export const ErrorPage = () => {
 
 export const logError = (error: any) => {
   if (BUGSNAG_KEY) {
-    console.error(error);
     Bugsnag.notify(error);
   } else {
     console.error('LogError:', error);

--- a/app/src/sync/draft-storage.ts
+++ b/app/src/sync/draft-storage.ts
@@ -31,10 +31,13 @@ import {
   EncodedDraft,
   DraftMetadataList,
   attachment_to_file,
+  getIdsByFieldName,
+  getHridFieldNameForViewset,
 } from '@faims3/data-model';
 import {DEBUG_APP} from '../buildconfig';
 import {local_pouch_options} from './connection';
 import {logError} from '../logging';
+import {getUiSpecForProject} from '../uiSpecification';
 
 export type DraftDB = PouchDB.Database<EncodedDraft>;
 
@@ -265,7 +268,7 @@ export async function listDraftMetadata(
   try {
     const records = await listDraftsEncoded(project_id, filter);
     const out: DraftMetadataList = {};
-    records.forEach(record => {
+    records.forEach(async record => {
       out[record._id] = {
         project_id: project_id,
         _id: record._id,
@@ -273,8 +276,7 @@ export async function listDraftMetadata(
         existing: record.existing,
         updated: new Date(record.updated),
         type: record.type,
-    // TODO update this
-        hrid: getDraftHRID(record) ?? record._id,
+        hrid: (await getDraftHRID(record)) ?? record._id,
         record_id: record.record_id,
       };
     });
@@ -285,21 +287,39 @@ export async function listDraftMetadata(
   }
 }
 
-    // TODO update this
-function getDraftHRID(record: EncodedDraft): string | null {
-  let hrid_name: string | null = null;
-  for (const possible_name of Object.keys(record.fields)) {
-    if (possible_name.startsWith(HRID_STRING)) {
-      hrid_name = possible_name;
-      break;
+async function getDraftHRID(record: EncodedDraft): Promise<string | null> {
+  // Need to find a way here to determine the correct field name to use - we
+  // need the uispec at this point
+  const uiSpecification = await getUiSpecForProject(record.project_id, false);
+  const fieldNames = Array.from(Object.keys(record.fields));
+  const sampleFieldName = fieldNames.length > 0 ? fieldNames[0] : undefined;
+  let hridFieldName = undefined;
+  if (sampleFieldName) {
+    const {viewSetId} = getIdsByFieldName({
+      uiSpecification,
+      fieldName: sampleFieldName,
+    });
+    // get the HRID for the view set - might not succeed
+    hridFieldName = getHridFieldNameForViewset({
+      uiSpecification,
+      viewSetId,
+    });
+  }
+
+  if (!hridFieldName) {
+    for (const possible_name of Object.keys(record.fields)) {
+      if (possible_name.startsWith(HRID_STRING)) {
+        hridFieldName = possible_name;
+        break;
+      }
     }
   }
 
-  if (hrid_name === null) {
+  if (!hridFieldName) {
     return null;
   }
 
-  const hrid_id = record.fields[hrid_name] as string | undefined | null;
+  const hrid_id = record.fields[hridFieldName] as string | undefined | null;
   if (hrid_id === undefined || hrid_id === null) {
     return null;
   }

--- a/app/src/sync/draft-storage.ts
+++ b/app/src/sync/draft-storage.ts
@@ -273,6 +273,7 @@ export async function listDraftMetadata(
         existing: record.existing,
         updated: new Date(record.updated),
         type: record.type,
+    // TODO update this
         hrid: getDraftHRID(record) ?? record._id,
         record_id: record.record_id,
       };
@@ -284,6 +285,7 @@ export async function listDraftMetadata(
   }
 }
 
+    // TODO update this
 function getDraftHRID(record: EncodedDraft): string | null {
   let hrid_name: string | null = null;
   for (const possible_name of Object.keys(record.fields)) {

--- a/app/src/uiSpecification.ts
+++ b/app/src/uiSpecification.ts
@@ -29,7 +29,8 @@ import {
 } from './conditionals';
 
 export async function getUiSpecForProject(
-  project_id: ProjectID
+  project_id: ProjectID,
+  compile: boolean = true
 ): Promise<ProjectUIModel> {
   try {
     const projdb = await getProjectDB(project_id);
@@ -44,7 +45,9 @@ export async function getUiSpecForProject(
       viewsets: encUIInfo.viewsets,
       visible_types: encUIInfo.visible_types,
     };
-    compileUiSpecConditionals(uiSpec);
+    if (compile) {
+      compileUiSpecConditionals(uiSpec);
+    }
     return uiSpec;
   } catch (err) {
     console.warn('failed to find ui specification for', project_id, err);

--- a/app/src/uiSpecification.ts
+++ b/app/src/uiSpecification.ts
@@ -30,7 +30,7 @@ import {
 
 export async function getUiSpecForProject(
   project_id: ProjectID,
-  compile: boolean = true
+  compile = true
 ): Promise<ProjectUIModel> {
   try {
     const projdb = await getProjectDB(project_id);

--- a/app/src/users.ts
+++ b/app/src/users.ts
@@ -172,8 +172,6 @@ export async function shouldDisplayRecord(
 ): Promise<boolean> {
   // TODO - consider the context in which this is being run - should only be
   // active user notebooks!
-  console.log(full_proj_id);
-  console.log('Record metadata: ', record_metadata);
   // TODO understand why this is coming through as a full project instead of just project id
   const split_id = split_full_project_id(full_proj_id);
   const user_id = contents.username;

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -1,12 +1,11 @@
 import {ListingsObject} from '@faims3/data-model/src/types';
-import {useQuery, UseQueryResult} from '@tanstack/react-query';
-import React, {useEffect, useRef, useState} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useNavigate} from 'react-router';
+import {useSearchParams} from 'react-router-dom';
 import * as ROUTES from '../constants/routes';
 import {OfflineFallbackComponent} from '../gui/components/ui/OfflineFallback';
 import {directory_db} from '../sync/databases';
-import {useCallback} from 'react';
-import {useSearchParams} from 'react-router-dom';
 
 export const usePrevious = <T extends {}>(value: T): T | undefined => {
   /**

--- a/app/src/utils/formUtilities.test.ts
+++ b/app/src/utils/formUtilities.test.ts
@@ -402,7 +402,7 @@ describe('recomputeDerivedFields', () => {
 
 describe('getHridFromValuesAndSpec', () => {
   // This is used to help test out the old/new hrid - it is a subset of ProjectUIModel
-  let baseUISpec = {
+  const baseUISpec = {
     fields: {
       regularFieldA: {},
       hridOldFieldA: {},
@@ -422,7 +422,7 @@ describe('getHridFromValuesAndSpec', () => {
   };
 
   it('finds old hrid field properly', () => {
-    let values: ValuesObject = {
+    const values: ValuesObject = {
       hridOldFieldA: 'test',
     };
     const result = getHridFromValuesAndSpec({
@@ -434,7 +434,7 @@ describe('getHridFromValuesAndSpec', () => {
   });
 
   it('finds old hrid field properly on B view', () => {
-    let values: ValuesObject = {
+    const values: ValuesObject = {
       hridOldFieldB: 'test',
     };
     const result = getHridFromValuesAndSpec({
@@ -446,7 +446,7 @@ describe('getHridFromValuesAndSpec', () => {
   });
 
   it('returns undefined if old hrid is not present', () => {
-    let values: ValuesObject = {};
+    const values: ValuesObject = {};
     const result = getHridFromValuesAndSpec({
       values,
       uiSpecification: baseUISpec as unknown as ProjectUIModel,
@@ -491,7 +491,7 @@ describe('getHridFromValuesAndSpec', () => {
   });
 
   it('prioritises new hrid over old', () => {
-    let values: ValuesObject = {
+    const values: ValuesObject = {
       newHridFieldA: 'new',
       hridOldFieldA: 'old',
     };
@@ -499,7 +499,7 @@ describe('getHridFromValuesAndSpec', () => {
     // set hrid field for A
     baseUISpec.viewsets['A'].hridField = 'newHridFieldA';
 
-    let result = getHridFromValuesAndSpec({
+    const result = getHridFromValuesAndSpec({
       values,
       uiSpecification: baseUISpec as unknown as ProjectUIModel,
     });

--- a/app/src/utils/formUtilities.test.ts
+++ b/app/src/utils/formUtilities.test.ts
@@ -1,0 +1,376 @@
+import {expect, it, describe} from 'vitest';
+import {
+  formatTimestamp,
+  getRecordContextFromRecord,
+  recomputeDerivedFields,
+} from './formUtilities';
+import {ProjectUIModel, Record} from '@faims3/data-model';
+import {RecordContext} from '../gui/components/record/form';
+
+/**
+ * Test suite for form utility functions including time stamp and templating logic
+ */
+
+describe('formatTimestamp', () => {
+  it('formats a valid timestamp correctly in UTC', () => {
+    const timestamp = 1705324200000;
+    expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 1:10pm');
+  });
+
+  it('handles morning times correctly in UTC', () => {
+    const timestamp = 1705306200000;
+    expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 8:10am');
+  });
+
+  it('handles noon correctly in UTC', () => {
+    const timestamp = 1705315200000;
+    expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 10:40am');
+  });
+
+  it('handles midnight correctly in UTC', () => {
+    const timestamp = 1705276800000;
+    expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 12:00am');
+  });
+
+  it('handles different timezones', () => {
+    const timestamp = 1705324200000;
+    expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 1:10pm');
+    expect(formatTimestamp(timestamp, 'Australia/Sydney')).toBe('16-01-24 12:10am');
+  });
+
+  it('handles invalid inputs gracefully', () => {
+    expect(formatTimestamp(null)).toBe('');
+    expect(formatTimestamp(undefined)).toBe('');
+    expect(formatTimestamp(NaN)).toBe('');
+    expect(formatTimestamp(Infinity)).toBe('');
+    expect(formatTimestamp('invalid')).toBe('');
+  });
+
+  it('handles string timestamps', () => {
+    const timestamp = '1705324200000';
+    expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 1:10pm');
+  });
+
+  it('defaults to local timezone when no timezone specified', () => {
+    const timestamp = 1705324200000;
+    const result = formatTimestamp(timestamp);
+    expect(result).toMatch(/^\d{2}-\d{2}-\d{2} \d{1,2}:\d{2}(am|pm)$/);
+  });
+});
+
+describe('getRecordContextFromRecord', () => {
+  it('creates context from a valid record', () => {
+    const record = {
+      created: new Date(1705324200000),
+      created_by: 'John Smith',
+    } as Record;
+
+    const context = getRecordContextFromRecord({record});
+    expect(context.createdTime).toBe(1705324200000);
+    expect(context.createdBy).toBe('John Smith');
+  });
+
+  it('handles missing fields gracefully', () => {
+    const record = {} as Record;
+    const context = getRecordContextFromRecord({record});
+    expect(context.createdTime).toBeUndefined();
+    expect(context.createdBy).toBeUndefined();
+  });
+});
+
+describe('recomputeDerivedFields', () => {
+  const baseUISpec = {
+    fields: {
+      'regular-field': {
+        'component-name': 'TextField',
+      },
+      'templated-name': {
+        'component-name': 'TemplatedStringField',
+        'component-parameters': {
+          template: 'Created by {{_CREATOR_NAME}} on {{_CREATED_TIME}}',
+        },
+      },
+      'templated-complex': {
+        'component-name': 'TemplatedStringField',
+        'component-parameters': {
+          template: 'Status: {{status}}, Area: {{area}}, ID: {{id}}',
+        },
+      },
+    },
+  } as Partial<ProjectUIModel>;
+
+  it('updates templated fields with context variables', () => {
+    const values = {
+      'regular-field': 'Normal value',
+      'templated-name': 'Old value',
+    };
+
+    const context: RecordContext = {
+      createdBy: 'Jane Doe',
+      createdTime: 1705324200000,
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: baseUISpec as unknown as ProjectUIModel,
+      context,
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-name']).toMatch(
+      /^Created by Jane Doe on \d{2}-\d{2}-\d{2} \d{1,2}:\d{2}(am|pm)$/
+    );
+    expect(values['regular-field']).toBe('Normal value');
+  });
+
+  it('handles conditional templates with #if sections', () => {
+    const conditionalUISpec = {
+      fields: {
+        'templated-status': {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: 'Status: {{#isActive}}Active{{/isActive}}{{^isActive}}Inactive{{/isActive}}',
+          },
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      'templated-status': 'Old value',
+      isActive: true,
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: conditionalUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-status']).toBe('Status: Active');
+
+    values.isActive = false;
+    const changed2 = recomputeDerivedFields({
+      values,
+      uiSpecification: conditionalUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed2).toBe(true);
+    expect(values['templated-status']).toBe('Status: Inactive');
+  });
+
+  it('handles nested conditional templates', () => {
+    const nestedConditionalUISpec = {
+      fields: {
+        'templated-nested': {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: '{{#hasPermission}}{{#isAdmin}}Admin{{/isAdmin}}{{^isAdmin}}User{{/isAdmin}}{{/hasPermission}}{{^hasPermission}}No Access{{/hasPermission}}',
+          },
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      'templated-nested': 'Old value',
+      hasPermission: true,
+      isAdmin: true,
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: nestedConditionalUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-nested']).toBe('Admin');
+
+    values.isAdmin = false;
+    const changed2 = recomputeDerivedFields({
+      values,
+      uiSpecification: nestedConditionalUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed2).toBe(true);
+    expect(values['templated-nested']).toBe('User');
+
+    values.hasPermission = false;
+    const changed3 = recomputeDerivedFields({
+      values,
+      uiSpecification: nestedConditionalUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed3).toBe(true);
+    expect(values['templated-nested']).toBe('No Access');
+  });
+
+  it('handles arrays in templates with #each', () => {
+    const arrayUISpec = {
+      fields: {
+        'templated-list': {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: 'Items: {{#items}}{{name}}{{^last}}, {{/last}}{{/items}}',
+          },
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      'templated-list': 'Old value',
+      items: [
+        { name: 'First', last: false },
+        { name: 'Second', last: false },
+        { name: 'Third', last: true }
+      ],
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: arrayUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-list']).toBe('Items: First, Second, Third');
+  });
+
+  it('updates templated fields with form values', () => {
+    const values = {
+      'regular-field': 'Normal value',
+      'templated-complex': 'Old value',
+      status: 'Active',
+      area: 'Zone A',
+      id: '12345',
+    };
+
+    const context: RecordContext = {};
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: baseUISpec as unknown as ProjectUIModel,
+      context,
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-complex']).toBe(
+      'Status: Active, Area: Zone A, ID: 12345'
+    );
+  });
+
+  it('handles missing template parameter', () => {
+    const invalidUISpec = {
+      fields: {
+        'templated-invalid': {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {},
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      'templated-invalid': 'Original value',
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: invalidUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(false);
+    expect(values['templated-invalid']).toBe('Original value');
+  });
+
+  it('does not update when values are unchanged', () => {
+    const simpleUISpec = {
+      fields: {
+        'templated-greeting': {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: 'Hello {{name}}!',
+          },
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      'templated-greeting': 'Hello Jane!',
+      name: 'Jane',
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: simpleUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(false);
+    expect(values['templated-greeting']).toBe('Hello Jane!');
+  });
+
+  it('handles circular references and self-references', () => {
+    const circularUISpec = {
+      fields: {
+        'templated-circular': {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: 'Value: {{templated-circular}}',
+          },
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      'templated-circular': 'Initial',
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: circularUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-circular']).toBe('Value: ');
+  });
+
+  it('handles multiple templated fields in correct order', () => {
+    const multiTemplateUISpec = {
+      fields: {
+        template1: {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: 'First {{value}}',
+          },
+        },
+        template2: {
+          'component-name': 'TemplatedStringField',
+          'component-parameters': {
+            template: 'Second {{value}}',
+          },
+        },
+      },
+    } as Partial<ProjectUIModel>;
+
+    const values = {
+      template1: 'Old1',
+      template2: 'Old2',
+      value: 'Test',
+    };
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: multiTemplateUISpec as unknown as ProjectUIModel,
+      context: {},
+    });
+
+    expect(changed).toBe(true);
+    expect(values['template1']).toBe('First Test');
+    expect(values['template2']).toBe('Second Test');
+  });
+});

--- a/app/src/utils/formUtilities.test.ts
+++ b/app/src/utils/formUtilities.test.ts
@@ -35,7 +35,9 @@ describe('formatTimestamp', () => {
   it('handles different timezones', () => {
     const timestamp = 1705324200000;
     expect(formatTimestamp(timestamp, 'GMT')).toBe('15-01-24 1:10pm');
-    expect(formatTimestamp(timestamp, 'Australia/Sydney')).toBe('16-01-24 12:10am');
+    expect(formatTimestamp(timestamp, 'Australia/Sydney')).toBe(
+      '16-01-24 12:10am'
+    );
   });
 
   it('handles invalid inputs gracefully', () => {
@@ -129,7 +131,8 @@ describe('recomputeDerivedFields', () => {
         'templated-status': {
           'component-name': 'TemplatedStringField',
           'component-parameters': {
-            template: 'Status: {{#isActive}}Active{{/isActive}}{{^isActive}}Inactive{{/isActive}}',
+            template:
+              'Status: {{#isActive}}Active{{/isActive}}{{^isActive}}Inactive{{/isActive}}',
           },
         },
       },
@@ -166,7 +169,8 @@ describe('recomputeDerivedFields', () => {
         'templated-nested': {
           'component-name': 'TemplatedStringField',
           'component-parameters': {
-            template: '{{#hasPermission}}{{#isAdmin}}Admin{{/isAdmin}}{{^isAdmin}}User{{/isAdmin}}{{/hasPermission}}{{^hasPermission}}No Access{{/hasPermission}}',
+            template:
+              '{{#hasPermission}}{{#isAdmin}}Admin{{/isAdmin}}{{^isAdmin}}User{{/isAdmin}}{{/hasPermission}}{{^hasPermission}}No Access{{/hasPermission}}',
           },
         },
       },
@@ -223,9 +227,9 @@ describe('recomputeDerivedFields', () => {
     const values = {
       'templated-list': 'Old value',
       items: [
-        { name: 'First', last: false },
-        { name: 'Second', last: false },
-        { name: 'Third', last: true }
+        {name: 'First', last: false},
+        {name: 'Second', last: false},
+        {name: 'Third', last: true},
       ],
     };
 
@@ -372,5 +376,24 @@ describe('recomputeDerivedFields', () => {
     expect(changed).toBe(true);
     expect(values['template1']).toBe('First Test');
     expect(values['template2']).toBe('Second Test');
+  });
+
+  it('uses default "Unknown User and Unknown Time"', () => {
+    const values = {
+      'templated-name': 'Old value',
+    };
+
+    const context: RecordContext = {};
+
+    const changed = recomputeDerivedFields({
+      values,
+      uiSpecification: baseUISpec as unknown as ProjectUIModel,
+      context,
+    });
+
+    expect(changed).toBe(true);
+    expect(values['templated-name']).toMatch(
+      /^Created by Unknown User on Unknown Time$/
+    );
   });
 });

--- a/app/src/utils/formUtilities.ts
+++ b/app/src/utils/formUtilities.ts
@@ -58,7 +58,7 @@ export function formatTimestamp(
   }
 
   try {
-    let date = new Date(timestampNum);
+    const date = new Date(timestampNum);
 
     // If timezone is specified, convert to that timezone
     if (timezone) {

--- a/app/src/utils/formUtilities.ts
+++ b/app/src/utils/formUtilities.ts
@@ -92,7 +92,7 @@ const CREATED_TIME_ID = '_CREATED_TIME';
 /**
  * Converts the RecordContext into an object mapping from key -> value for use
  * in template replacement
- * @param context 
+ * @param context
  * @returns The context values to inject
  */
 function contextToTemplate(context: RecordContext): ValuesObject {
@@ -129,7 +129,7 @@ function renderTemplate({
 }): string {
   // generate context vars from record context
   const contextVars = contextToTemplate(context);
-  let filteredValues: ValuesObject = {};
+  const filteredValues: ValuesObject = {};
   for (const [k, v] of Object.entries({...values, ...contextVars})) {
     if (!(k in excludedFields)) {
       // Filter out any excluded fields
@@ -144,7 +144,7 @@ function renderTemplate({
 /**
  * Given the existing values, ui spec and context, updates the values.
  * Recomputes derived template field properties.
- * 
+ *
  * Filters out any template fields
  *
  * @param values
@@ -161,8 +161,8 @@ export function recomputeDerivedFields({
   context: RecordContext;
 }): boolean {
   // compute fields to be updated
-  let fieldsToBeUpdated: {template: string; fieldName: string}[] = [];
-  let filterFields: string[] = [];
+  const fieldsToBeUpdated: {template: string; fieldName: string}[] = [];
+  const filterFields: string[] = [];
 
   for (const fieldName of Object.keys(uiSpecification.fields)) {
     // Get info about it

--- a/app/src/utils/formUtilities.ts
+++ b/app/src/utils/formUtilities.ts
@@ -126,15 +126,10 @@ const CREATED_TIME_ID = '_CREATED_TIME';
  */
 function contextToTemplate(context: RecordContext): ValuesObject {
   const vals: ValuesObject = {};
-  if (context.createdBy) {
-    vals[CREATOR_NAME_ID] = context.createdBy;
-  }
-
-  if (context.createdTime) {
-    const displayTimestamp = formatTimestamp(context.createdTime);
-    vals[CREATED_TIME_ID] = displayTimestamp;
-  }
-
+  vals[CREATOR_NAME_ID] = context.createdBy ?? 'Unknown User';
+  vals[CREATED_TIME_ID] = context.createdTime
+    ? formatTimestamp(context.createdTime)
+    : 'Unknown Time';
   return vals;
 }
 

--- a/app/src/utils/formUtilities.ts
+++ b/app/src/utils/formUtilities.ts
@@ -1,0 +1,216 @@
+import {ProjectUIModel, Record} from '@faims3/data-model';
+import Mustache from 'mustache';
+import {RecordContext} from '../gui/components/record/form';
+
+/**
+ * Converts a record (real or draft) into record context used in the form
+ * @param record
+ * @returns The form context which can be injected
+ */
+export function getRecordContextFromRecord({
+  record,
+}: {
+  record: Record;
+}): RecordContext {
+  return {
+    // The author
+    createdBy: record?.created_by,
+    // The created time (epoch ms timestamp)
+    createdTime: record?.created?.getTime(),
+  };
+}
+
+// TEMPLATE RENDERING
+// ------------------
+
+/**
+ * Formats a timestamp into a date-time string in the format "DD/MM/YY H:MMam/pm"
+ *
+ * @param timestamp - Unix timestamp in milliseconds (e.g., from Date.now())
+ * @returns Formatted date-time string or empty string if input is invalid
+ *
+ * @throws Never - Returns empty string for all error cases
+ *
+ * Handles the following edge cases:
+ * - Invalid inputs (null, undefined, NaN, Infinity)
+ * - String timestamps (converts to numbers)
+ * - Invalid date objects
+ * - Out of range values for date components
+ */
+export function formatTimestamp(
+  timestamp: string | number | null | undefined
+): string {
+  // Handle invalid inputs
+  if (timestamp === null || timestamp === undefined) {
+    return '';
+  }
+
+  // Convert string timestamps to numbers
+  const timestampNum =
+    typeof timestamp === 'string' ? Number(timestamp) : timestamp;
+
+  // Validate if timestamp is a valid number
+  if (isNaN(timestampNum) || !isFinite(timestampNum)) {
+    return '';
+  }
+
+  try {
+    const date = new Date(timestampNum);
+
+    // Validate if date is valid
+    if (date.toString() === 'Invalid Date') {
+      return '';
+    }
+
+    // Get date components with safe fallbacks
+    const day = String(date.getDate() || 0).padStart(2, '0');
+    const month = String(date.getMonth() + 1 || 0).padStart(2, '0');
+    const year = String(date.getFullYear() || 0).slice(-2);
+
+    // Get time components with safe fallbacks
+    let hours = date.getHours() || 0;
+    const minutes = String(date.getMinutes() || 0).padStart(2, '0');
+    const ampm = hours >= 12 ? 'pm' : 'am';
+
+    // Convert hours to 12-hour format
+    hours = hours % 12;
+    hours = hours || 12; // Convert 0 to 12
+
+    return `${day}-${month}-${year} ${hours}:${minutes}${ampm}`;
+  } catch (error) {
+    return '';
+  }
+}
+
+const TEMPLATED_STRING_FIELD_NAME = 'TemplatedStringField';
+export type ValuesObject = {[fieldName: string]: any};
+
+// What system variables can we inject
+const CREATOR_NAME_ID = '_CREATOR_NAME';
+const CREATED_TIME_ID = '_CREATED_TIME';
+
+/**
+ * Converts the RecordContext into an object mapping from key -> value for use
+ * in template replacement
+ * @param context 
+ * @returns The context values to inject
+ */
+function contextToTemplate(context: RecordContext): ValuesObject {
+  const vals: ValuesObject = {};
+  if (context.createdBy) {
+    vals[CREATOR_NAME_ID] = context.createdBy;
+  }
+
+  if (context.createdTime) {
+    const displayTimestamp = formatTimestamp(context.createdTime);
+    vals[CREATED_TIME_ID] = displayTimestamp;
+  }
+
+  return vals;
+}
+
+/**
+ * Renders a mustache template into a string
+ * @param template The template string
+ * @param values The form values to use in replacmeent
+ * @param context The record context
+ * @param excludedFields Fields to exclude from replacement
+ */
+function renderTemplate({
+  template,
+  values,
+  context,
+  excludedFields,
+}: {
+  template: string;
+  values: ValuesObject;
+  context: RecordContext;
+  excludedFields: string[];
+}): string {
+  // generate context vars from record context
+  const contextVars = contextToTemplate(context);
+  let filteredValues: ValuesObject = {};
+  for (const [k, v] of Object.entries({...values, ...contextVars})) {
+    if (!(k in excludedFields)) {
+      // Filter out any excluded fields
+      filteredValues[k] = v;
+    }
+  }
+
+  // Render
+  return Mustache.render(template, filteredValues);
+}
+
+/**
+ * Given the existing values, ui spec and context, updates the values.
+ * Recomputes derived template field properties.
+ * 
+ * Filters out any template fields
+ *
+ * @param values
+ * @param uiSpecification
+ * @param context
+ */
+export function recomputeDerivedFields({
+  values,
+  uiSpecification,
+  context,
+}: {
+  values: ValuesObject;
+  uiSpecification: ProjectUIModel;
+  context: RecordContext;
+}): boolean {
+  // compute fields to be updated
+  let fieldsToBeUpdated: {template: string; fieldName: string}[] = [];
+  let filterFields: string[] = [];
+
+  for (const fieldName of Object.keys(uiSpecification.fields)) {
+    // Get info about it
+    const fieldDetails = uiSpecification.fields[fieldName];
+    // We are looking for these fields "component-name": "TemplatedStringField"
+    if (fieldDetails['component-name'] === TEMPLATED_STRING_FIELD_NAME) {
+      // We should always filter out templated strings from template expansion
+      filterFields.push(fieldName);
+
+      // We found a templated field
+      if (fieldName in values) {
+        // check we have a template prop
+        const template = fieldDetails['component-parameters']?.template;
+        if (!template) {
+          console.warn(
+            'TemplatedStringField missing template prop - cannot render.'
+          );
+          continue;
+        }
+
+        if (typeof template !== 'string') {
+          console.warn('TemplatedStringField template prop is not a string.');
+          continue;
+        }
+        fieldsToBeUpdated.push({fieldName, template});
+      }
+    }
+  }
+
+  // notify if something changes
+  let changeDetected = false;
+
+  // For each field, recompute given broader context and then update
+  for (const {fieldName, template} of fieldsToBeUpdated) {
+    // Generate the updated value
+    const rendered = renderTemplate({
+      context,
+      template,
+      values,
+      excludedFields: filterFields,
+    });
+    // Update the value if it's changed
+    const previousFieldValue = values[fieldName];
+    if (previousFieldValue !== rendered) {
+      values[fieldName] = rendered;
+      changeDetected = true;
+    }
+  }
+
+  return changeDetected;
+}

--- a/designer/package.json
+++ b/designer/package.json
@@ -32,6 +32,7 @@
         "lexical": "^0.12.4",
         "lodash": "^4.17.21",
         "mdi-material-ui": "^7.7.0",
+        "mustache": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-json-view-lite": "^1.1.0",

--- a/designer/src/components/Fields/BaseFieldEditor.tsx
+++ b/designer/src/components/Fields/BaseFieldEditor.tsx
@@ -62,7 +62,6 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
   };
 
   const setFieldLabel = (newField: FieldType, label: string) => {
-    console.log('setFieldLabel', newField, label);
     newField['component-parameters'].label = label;
   };
 
@@ -121,7 +120,6 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
   };
 
   const conditionChanged = (condition: ConditionType | null) => {
-    console.log('Field Condition Changed', condition);
     if (condition) {
       const newState: StateType = {...state, condition: condition};
       updateFieldFromState(newState);

--- a/designer/src/components/Fields/HiddenToggle.tsx
+++ b/designer/src/components/Fields/HiddenToggle.tsx
@@ -17,12 +17,7 @@ import {FieldType} from '../../state/initial';
  * hidden in the form. It provides a simple checkbox interface with an
  * explanation tooltip.
  *
- * The component:
- * - Reads the current hidden state from Redux store
- * - Allows toggling the hidden state
- * - Updates the field in the Redux store
- * - Provides helpful explanation via tooltip
- * - Maintains consistent styling with other field editors
+ * Toggles the component ['component-parameters'].ElementProps.hidden
  *
  * @component
  * @param {Object} props - Component props

--- a/designer/src/components/Fields/HiddenToggle.tsx
+++ b/designer/src/components/Fields/HiddenToggle.tsx
@@ -1,0 +1,104 @@
+import InfoIcon from '@mui/icons-material/Info';
+import {
+  Alert,
+  Box,
+  Checkbox,
+  FormControlLabel,
+  Paper,
+  Stack,
+  Tooltip,
+  Grid,
+} from '@mui/material';
+import {useAppDispatch, useAppSelector} from '../../state/hooks';
+import {FieldType} from '../../state/initial';
+
+/**
+ * HiddenFieldEditor is a component for managing whether a field should be
+ * hidden in the form. It provides a simple checkbox interface with an
+ * explanation tooltip.
+ *
+ * The component:
+ * - Reads the current hidden state from Redux store
+ * - Allows toggling the hidden state
+ * - Updates the field in the Redux store
+ * - Provides helpful explanation via tooltip
+ * - Maintains consistent styling with other field editors
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {string} props.fieldName - Name of the field being edited
+ */
+export const HiddenFieldEditor = ({fieldName}: {fieldName: string}) => {
+  // Get field state from Redux store
+  const field = useAppSelector(
+    state => state.notebook['ui-specification'].fields[fieldName]
+  );
+  const dispatch = useAppDispatch();
+
+  // Get current hidden state, defaulting to false if not set
+  const isHidden = field['component-parameters'].ElementProps?.hidden ?? false;
+
+  /**
+   * Updates the hidden state in Redux store
+   * @param {boolean} newValue - New hidden state value
+   */
+  const updateHiddenState = (newValue: boolean) => {
+    const newField = JSON.parse(JSON.stringify(field)) as FieldType;
+
+    // Ensure ElementProps exists and update hidden property
+    newField['component-parameters'].ElementProps = {
+      ...(newField['component-parameters'].ElementProps ?? {}),
+      hidden: newValue,
+    };
+
+    dispatch({
+      type: 'ui-specification/fieldUpdated',
+      payload: {fieldName, newField},
+    });
+  };
+
+  return (
+    <Grid container>
+      <Paper sx={{width: '100%', mt: 2, p: 3}}>
+        <Box>
+          {/* Info alert explaining the feature */}
+          <Alert
+            severity="info"
+            sx={{
+              mb: 2,
+              backgroundColor: 'rgb(229, 246, 253)',
+              '& .MuiAlert-icon': {
+                color: 'rgb(1, 67, 97)',
+              },
+            }}
+          >
+            Control whether this field is hidden in the form. Hidden fields can
+            still be used in TemplatedString fields, and are available in
+            exported data, but won't be visible to users.
+          </Alert>
+
+          {/* Hidden toggle checkbox with tooltip */}
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isHidden}
+                onChange={e => updateHiddenState(e.target.checked)}
+                size="small"
+              />
+            }
+            label={
+              <Stack direction="row" spacing={1} alignItems="center">
+                <span>Hide this field in the form</span>
+                <Tooltip title="When hidden, this field won't be visible in the form interface but can still be used for calculations, conditions, or other background operations.">
+                  <InfoIcon color="action" fontSize="small" />
+                </Tooltip>
+              </Stack>
+            }
+          />
+        </Box>
+      </Paper>
+    </Grid>
+  );
+};
+
+export default HiddenFieldEditor;

--- a/designer/src/components/Fields/HiddenToggle.tsx
+++ b/designer/src/components/Fields/HiddenToggle.tsx
@@ -31,7 +31,7 @@ export const HiddenFieldEditor = ({fieldName}: {fieldName: string}) => {
   const dispatch = useAppDispatch();
 
   // Get current hidden state, defaulting to false if not set
-  const isHidden = field['component-parameters'].ElementProps?.hidden ?? false;
+  const isHidden = field['component-parameters'].hidden ?? false;
 
   /**
    * Updates the hidden state in Redux store
@@ -41,8 +41,8 @@ export const HiddenFieldEditor = ({fieldName}: {fieldName: string}) => {
     const newField = JSON.parse(JSON.stringify(field)) as FieldType;
 
     // Ensure ElementProps exists and update hidden property
-    newField['component-parameters'].ElementProps = {
-      ...(newField['component-parameters'].ElementProps ?? {}),
+    newField['component-parameters'] = {
+      ...newField['component-parameters'],
       hidden: newValue,
     };
 

--- a/designer/src/components/Fields/OptionsEditor.tsx
+++ b/designer/src/components/Fields/OptionsEditor.tsx
@@ -521,7 +521,7 @@ export const OptionsEditor = ({
                 border: '1px solid rgba(0, 0, 0, 0.12)',
                 boxShadow: 'none',
                 borderRadius: 1,
-                maxHeight: '400px',
+                maxHeight: '1000px',
                 overflow: 'auto',
               }}
             >

--- a/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
+++ b/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
@@ -22,7 +22,7 @@ type PropType = {
  * Enhanced TemplatedStringFieldEditor with visual Mustache template building support.
  * Allows users to create and edit templates using a visual builder or direct text input.
  */
-export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
+export const TemplatedStringFieldEditor = ({fieldName}: PropType) => {
   const field = useAppSelector(
     state => state.notebook['ui-specification'].fields[fieldName]
   );

--- a/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
+++ b/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
@@ -78,10 +78,6 @@ export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
     };
     newField['component-parameters'].helperText = newState.helperText;
     newField['component-parameters'].template = newState.template;
-    newField['component-parameters'].ElementProps = {
-      ...newField['component-parameters'].ElementProps,
-      hidden: newState.ElementProps?.hidden,
-    };
     dispatch({
       type: 'ui-specification/fieldUpdated',
       payload: {fieldName, newField},
@@ -89,19 +85,8 @@ export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
   };
 
   const updateProperty = (prop: string, value: string | boolean) => {
-    if (prop === 'hidden') {
-      const newState = {
-        ...state,
-        ElementProps: {
-          ...state.ElementProps,
-          hidden: value as boolean,
-        },
-      };
-      updateFieldFromState(newState);
-    } else {
-      const newState = {...state, [prop]: value};
-      updateFieldFromState(newState);
-    }
+    const newState = {...state, [prop]: value};
+    updateFieldFromState(newState);
   };
 
   const handleTemplateChange = (template: string) => {

--- a/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
+++ b/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
@@ -1,18 +1,13 @@
+import {Edit as EditIcon} from '@mui/icons-material';
 import {
   Alert,
   Box,
   Button,
   Card,
-  FormControl,
   Grid,
-  IconButton,
-  InputLabel,
-  MenuItem,
-  Select,
   TextField,
   Typography,
 } from '@mui/material';
-import {Edit as EditIcon} from '@mui/icons-material';
 import {MutableRefObject, useRef, useState} from 'react';
 import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {ComponentParameters, FieldType} from '../../state/initial';

--- a/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
+++ b/designer/src/components/Fields/TemplatedStringFieldEditor.tsx
@@ -24,13 +24,6 @@ export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
   const field = useAppSelector(
     state => state.notebook['ui-specification'].fields[fieldName]
   );
-  const formHasHRID = useAppSelector(state => {
-    return Object.keys(state.notebook['ui-specification'].fields).some(
-      fieldName => {
-        return fieldName.startsWith('hrid') && fieldName.endsWith(viewId);
-      }
-    );
-  });
   const allFields = useAppSelector(
     state => state.notebook['ui-specification'].fields
   );
@@ -40,10 +33,6 @@ export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
   const [alertMessage, setAlertMessage] = useState('');
 
   const state = field['component-parameters'];
-
-  const isHRID = () => {
-    return fieldName.startsWith('hrid') && fieldName.endsWith(viewId);
-  };
 
   const getFieldLabel = (f: FieldType) => {
     return (
@@ -60,32 +49,9 @@ export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
     };
     newField['component-parameters'].helperText = newState.helperText;
     newField['component-parameters'].template = newState.template;
-    newField['component-parameters'].hrid = newState.hrid;
     dispatch({
       type: 'ui-specification/fieldUpdated',
       payload: {fieldName, newField},
-    });
-  };
-
-  const setHRID = (newState: boolean) => {
-    let newFieldName = state.InputLabelProps
-      ? state.InputLabelProps.label
-      : fieldName;
-    if (newState) {
-      // need to check whether there is already an HRID field in this form
-      // if so we show an alert
-      if (formHasHRID) {
-        setAlertMessage(
-          'There is already an HRID field in this form.  You can only have one HRID field per form.'
-        );
-        return;
-      } else {
-        newFieldName = 'hrid' + viewId;
-      }
-    }
-    dispatch({
-      type: 'ui-specification/fieldRenamed',
-      payload: {viewId, fieldName, newFieldName},
     });
   };
 
@@ -141,22 +107,6 @@ export const TemplatedStringFieldEditor = ({fieldName, viewId}: PropType) => {
               helperText="Help text shown along with the field (like this text)."
               onChange={e => updateProperty('helperText', e.target.value)}
             />
-          </Grid>
-          <Grid item sm={6} xs={12} sx={{mx: 1.5, my: 2}}>
-            <FormControlLabel
-              required
-              control={
-                <Checkbox
-                  checked={isHRID()}
-                  onChange={e => setHRID(e.target.checked)}
-                />
-              }
-              label="Use as Human Readable ID"
-            />
-
-            <Typography variant="body2" color="text.secondary">
-              HRID is the primary identifier for the record.
-            </Typography>
           </Grid>
         </Card>
 

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -2,9 +2,11 @@ import {
   Add as AddIcon,
   Code as CodeIcon,
   Delete as DeleteIcon,
+  Error as ErrorIcon,
   Preview as PreviewIcon,
 } from '@mui/icons-material';
 import {
+  Alert,
   Box,
   Button,
   Card,
@@ -24,23 +26,30 @@ import {
   Tab,
   Tabs,
   TextField,
+  Tooltip,
+  Typography,
 } from '@mui/material';
-import React, {useEffect, useState} from 'react';
+import Mustache from 'mustache';
+import React, {useCallback, useEffect, useState} from 'react';
 
-// Types for template building blocks
-type BlockType = 'text' | 'variable' | 'if' | 'unless' | 'each' | 'helper';
+/**
+ * Supported block types in the template builder
+ */
+type BlockType = 'text' | 'variable' | 'if' | 'unless';
 
-type HelperType = 'uppercase' | 'lowercase' | 'dateFormat' | 'numberFormat';
-
+/**
+ * Represents a single building block in the template
+ */
 interface TemplateBlock {
   id: string;
   type: BlockType;
   content: string;
   children?: TemplateBlock[];
-  helper?: HelperType;
-  helperArgs?: string[];
 }
 
+/**
+ * Represents a variable that can be used in the template
+ */
 interface Variable {
   name: string;
   displayName: string;
@@ -48,175 +57,99 @@ interface Variable {
   value?: string; // For preview purposes
 }
 
+/**
+ * Props for the MustacheTemplateBuilder component
+ */
 interface MustacheBuilderProps {
+  /** Initial template string to populate the builder */
   initialTemplate?: string;
+  /** Available field variables */
   variables: Variable[];
+  /** Available system variables */
   systemVariables: Variable[];
+  /** Callback fired when template is saved */
   onSave: (template: string) => void;
+  /** Controls dialog visibility */
   open: boolean;
+  /** Callback fired when dialog is closed */
   onClose: () => void;
 }
 
 /**
- * Parses a Mustache template string into template blocks
+ * Safely parses a Mustache template string into TemplateBlock format
  */
-const parseTemplate = (template: string): TemplateBlock[] => {
-  const blocks: TemplateBlock[] = [];
-  let currentText = '';
-
-  // Helper to add accumulated text as a block
-  const addTextBlock = () => {
-    if (currentText) {
-      blocks.push({
-        id: Math.random().toString(36).substring(2, 9),
-        type: 'text',
-        content: currentText,
-      });
-      currentText = '';
-    }
-  };
-
-  // Helper to parse a section (like if/unless/each) until its closing tag
-  const parseSection = (
-    template: string,
-    startIndex: number
-  ): [TemplateBlock | null, number] => {
-    const tagMatch = template.slice(startIndex).match(/^\{\{([#^])([^}]+)\}\}/);
-    if (!tagMatch) return [null, startIndex];
-
-    const [fullTag, prefix, content] = tagMatch;
-    const tagType =
-      prefix === '#' ? (content === 'each' ? 'each' : 'if') : 'unless';
-    const tagContent = content.trim();
-
-    // Find the matching closing tag
-    const searchStart = startIndex + fullTag.length;
-    let nested = 0;
-    let currentPos = searchStart;
-
-    while (currentPos < template.length) {
-      const openTag = template.slice(currentPos).match(/\{\{[#^]/);
-      const closeTag = template
-        .slice(currentPos)
-        .match(`\\{\\{/${tagContent}\\}\\}`);
-
-      if (!closeTag) break; // No matching close tag found
-
-      if (!openTag || closeTag.index! < openTag.index!) {
-        if (nested === 0) {
-          // Parse the content between tags recursively
-          const innerContent = template.slice(
-            searchStart,
-            currentPos + closeTag.index!
-          );
-          const children = parseTemplate(innerContent);
-
-          return [
-            {
-              id: Math.random().toString(36).substring(2, 9),
-              type: tagType,
-              content: tagContent,
-              children,
-            },
-            currentPos + closeTag.index! + closeTag[0].length,
-          ];
-        }
-        nested--;
-      } else {
-        nested++;
-      }
-      currentPos =
-        currentPos + (openTag ? openTag.index! + 2 : closeTag.index! + 3);
-    }
-
-    return [null, startIndex + fullTag.length];
-  };
-
-  let currentPos = 0;
-  while (currentPos < template.length) {
-    const nextTag = template.slice(currentPos).match(/\{\{([#^])?([^}]+)\}\}/);
-
-    if (!nextTag) {
-      currentText += template.slice(currentPos);
-      break;
-    }
-
-    const [fullTag, prefix, content] = nextTag;
-    const tagStart = currentPos + nextTag.index!;
-
-    // Add any text before the tag
-    if (tagStart > currentPos) {
-      currentText += template.slice(currentPos, tagStart);
-    }
-
-    // Handle different tag types
-    if (prefix === '#' || prefix === '^') {
-      addTextBlock();
-      const [sectionBlock, newPos] = parseSection(template, tagStart);
-      if (sectionBlock) {
-        blocks.push(sectionBlock);
-      }
-      currentPos = newPos;
-    } else {
-      // Handle regular variables and helpers
-      addTextBlock();
-      if (content.includes(' ')) {
-        // Helper
-        const [helper, variable] = content.trim().split(/\s+/);
-        blocks.push({
+const parseTemplate = (
+  template: string
+): {blocks: TemplateBlock[]; error: string | null} => {
+  try {
+    const tokens = Mustache.parse(template);
+    const blocks = tokens
+      .map(convertMustacheTokenToBlock)
+      .filter(isTemplateBlock);
+    return {blocks, error: null};
+  } catch (error) {
+    return {
+      blocks: [
+        {
           id: Math.random().toString(36).substring(2, 9),
-          type: 'helper',
-          helper: helper as HelperType,
-          content: variable,
-        });
-      } else {
-        // Variable
-        blocks.push({
-          id: Math.random().toString(36).substring(2, 9),
-          type: 'variable',
-          content: content.trim(),
-        });
-      }
-      currentPos = tagStart + fullTag.length;
-    }
+          type: 'text',
+          content: template || '',
+        },
+      ],
+      error: error instanceof Error ? error.message : 'Invalid template syntax',
+    };
   }
-
-  addTextBlock();
-  return blocks;
-};
-
-const HELPER_FUNCTIONS: Record<
-  HelperType,
-  {
-    display: string;
-    description: string;
-    example: string;
-  }
-> = {
-  uppercase: {
-    display: 'Uppercase',
-    description: 'Convert text to uppercase',
-    example: '{{uppercase name}}',
-  },
-  lowercase: {
-    display: 'Lowercase',
-    description: 'Convert text to lowercase',
-    example: '{{lowercase name}}',
-  },
-  dateFormat: {
-    display: 'Date Format',
-    description: 'Format a date (YYYY-MM-DD)',
-    example: '{{dateFormat date "YYYY-MM-DD"}}',
-  },
-  numberFormat: {
-    display: 'Number Format',
-    description: 'Format a number',
-    example: '{{numberFormat number "0.00"}}',
-  },
 };
 
 /**
- * Component for displaying and editing a single template block
+ * Converts a Mustache AST token into our TemplateBlock format
+ */
+const convertMustacheTokenToBlock = (token: any): TemplateBlock | null => {
+  const [tokenType, content, ...rest] = token;
+
+  try {
+    switch (tokenType) {
+      case 'text':
+        return {
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'text',
+          content: content,
+        };
+
+      case '#':
+        return {
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'if',
+          content: content,
+          children: rest[2].map(convertMustacheTokenToBlock).filter(Boolean),
+        };
+
+      case '^':
+        return {
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'unless',
+          content: content,
+          children: rest[2].map(convertMustacheTokenToBlock).filter(Boolean),
+        };
+
+      default:
+        return null;
+    }
+  } catch (error) {
+    console.warn('Error converting token:', error);
+    return null;
+  }
+};
+
+/**
+ * Type guard for TemplateBlock
+ */
+function isTemplateBlock(block: TemplateBlock | null): block is TemplateBlock {
+  return block !== null;
+}
+
+/**
+ * Component for editing a single template block
  */
 const TemplateBlockEditor: React.FC<{
   block: TemplateBlock;
@@ -259,71 +192,32 @@ const TemplateBlockEditor: React.FC<{
             >
               <MenuItem value="text">Text</MenuItem>
               <MenuItem value="variable">Variable</MenuItem>
-              <MenuItem value="if">If Condition</MenuItem>
+              <MenuItem value="if">Conditional</MenuItem>
               <MenuItem value="unless">Unless</MenuItem>
-              <MenuItem value="each">Each Loop</MenuItem>
-              <MenuItem value="helper">Helper</MenuItem>
             </Select>
           </FormControl>
         </Grid>
 
         {block.type === 'variable' && (
           <Grid item xs={12} sm>
-            <FormControl fullWidth>
-              <InputLabel>Variable</InputLabel>
-              <Select
-                value={block.content}
-                label="Variable"
-                onChange={e => updateBlockContent(e.target.value)}
-              >
-                <MenuItem value="">Choose variable...</MenuItem>
-                {allVariables.map(v => (
-                  <MenuItem key={v.name} value={v.name}>
-                    {v.displayName} ({v.type})
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-        )}
-
-        {block.type === 'helper' && (
-          <>
-            <Grid item xs={12} sm={3}>
+            <Tooltip title="Select a variable to insert">
               <FormControl fullWidth>
-                <InputLabel>Helper</InputLabel>
-                <Select
-                  value={block.helper}
-                  label="Helper"
-                  onChange={e =>
-                    onUpdate({...block, helper: e.target.value as HelperType})
-                  }
-                >
-                  {Object.entries(HELPER_FUNCTIONS).map(([key, value]) => (
-                    <MenuItem key={key} value={key}>
-                      {value.display}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={12} sm={4}>
-              <FormControl fullWidth>
-                <InputLabel>Apply To</InputLabel>
+                <InputLabel>Variable</InputLabel>
                 <Select
                   value={block.content}
-                  label="Apply To"
+                  label="Variable"
                   onChange={e => updateBlockContent(e.target.value)}
                 >
+                  <MenuItem value="">Choose variable...</MenuItem>
                   {allVariables.map(v => (
                     <MenuItem key={v.name} value={v.name}>
-                      {v.displayName}
+                      {v.displayName} ({v.type})
                     </MenuItem>
                   ))}
                 </Select>
               </FormControl>
-            </Grid>
-          </>
+            </Tooltip>
+          </Grid>
         )}
 
         {block.type === 'text' && (
@@ -338,9 +232,7 @@ const TemplateBlockEditor: React.FC<{
           </Grid>
         )}
 
-        {(block.type === 'if' ||
-          block.type === 'unless' ||
-          block.type === 'each') && (
+        {(block.type === 'if' || block.type === 'unless') && (
           <Grid item xs={12} sm={4}>
             <FormControl fullWidth>
               <InputLabel>Variable</InputLabel>
@@ -366,9 +258,7 @@ const TemplateBlockEditor: React.FC<{
         </Grid>
       </Grid>
 
-      {(block.type === 'if' ||
-        block.type === 'unless' ||
-        block.type === 'each') && (
+      {(block.type === 'if' || block.type === 'unless') && (
         <Box sx={{mt: 2, mb: 1}}>
           {block.children?.map((child, index) => (
             <TemplateBlockEditor
@@ -405,78 +295,59 @@ const TemplateBlockEditor: React.FC<{
 };
 
 /**
- * Enhanced preview component with proper conditional handling
+ * Component for previewing the template with sample data
  */
 const TemplatePreview: React.FC<{
   template: TemplateBlock[];
   variables: Variable[];
   systemVariables: Variable[];
-}> = ({template, variables, systemVariables}) => {
-  const [previewValues, setPreviewValues] = useState<Record<string, string>>(
-    {}
-  );
+  onTemplateError?: (error: string | null) => void;
+}> = ({template, variables, systemVariables, onTemplateError}) => {
+  const [previewValues, setPreviewValues] = useState<Record<string, any>>({});
+  const [previewError, setPreviewError] = useState<string | null>(null);
   const allVariables = [...variables, ...systemVariables];
 
-  const evaluateCondition = (variableName: string): boolean => {
-    const value = previewValues[variableName];
-    // Consider the condition true if the value exists and isn't empty
-    return !!value && value.trim() !== '';
-  };
+  const compileTemplate = useCallback((blocks: TemplateBlock[]): string => {
+    return blocks
+      .map(block => {
+        switch (block.type) {
+          case 'text':
+            return block.content;
+          case 'variable':
+            return `{{${block.content}}}`;
+          case 'if':
+            return `{{#${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/${block.content}}}`;
+          case 'unless':
+            return `{{^${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/${block.content}}}`;
+          default:
+            return '';
+        }
+      })
+      .join('');
+  }, []);
 
-  const applyHelper = (helper: HelperType, value: string): string => {
-    switch (helper) {
-      case 'uppercase':
-        return value.toUpperCase();
-      case 'lowercase':
-        return value.toLowerCase();
-      case 'dateFormat':
-        try {
-          const date = new Date(value);
-          return date.toISOString().split('T')[0]; // YYYY-MM-DD
-        } catch {
-          return value;
-        }
-      case 'numberFormat':
-        try {
-          return parseFloat(value).toFixed(2);
-        } catch {
-          return value;
-        }
-    }
-  };
+  const compiledTemplate = compileTemplate(template);
 
-  const renderBlock = (block: TemplateBlock): string => {
-    switch (block.type) {
-      case 'text':
-        return block.content;
-      case 'variable':
-        return previewValues[block.content] || '';
-      case 'helper':
-        if (block.helper && block.content) {
-          const value = previewValues[block.content] || '';
-          return applyHelper(block.helper, value);
-        }
-        return '';
-      case 'if':
-        if (evaluateCondition(block.content)) {
-          return block.children?.map(renderBlock).join('') || '';
-        }
-        return '';
-      case 'unless':
-        if (!evaluateCondition(block.content)) {
-          return block.children?.map(renderBlock).join('') || '';
-        }
-        return '';
-      case 'each':
-        // For preview, we'll treat 'each' as a simple if condition
-        if (evaluateCondition(block.content)) {
-          return block.children?.map(renderBlock).join('') || '';
-        }
-        return '';
-      default:
-        return '';
+  const renderPreview = useCallback(() => {
+    try {
+      const result = Mustache.render(compiledTemplate, {
+        ...previewValues,
+      });
+      if (previewError) {
+        setPreviewError(null);
+        onTemplateError?.(null);
+      }
+      return result;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Error rendering template';
+      if (previewError !== errorMessage) {
+        setPreviewError(errorMessage);
+        onTemplateError?.(errorMessage);
+      }
+      return 'Preview unavailable - check the builder tab to fix template errors';
     }
-  };
+  }, [compiledTemplate, previewValues, previewError, onTemplateError]);
 
   return (
     <Box sx={{mt: 3}}>
@@ -500,6 +371,13 @@ const TemplatePreview: React.FC<{
         ))}
       </Grid>
 
+      {previewError && (
+        <Alert severity="error" sx={{mt: 2}}>
+          <Typography variant="subtitle2">Template Error:</Typography>
+          {previewError}
+        </Alert>
+      )}
+
       <Card sx={{mt: 3}}>
         <CardHeader title="Preview" />
         <CardContent>
@@ -513,7 +391,7 @@ const TemplatePreview: React.FC<{
               minHeight: '100px',
             }}
           >
-            {template.map(renderBlock).join('')}
+            {renderPreview()}
           </Paper>
         </CardContent>
       </Card>
@@ -523,6 +401,8 @@ const TemplatePreview: React.FC<{
 
 /**
  * Main Mustache template builder dialog component
+ * This component provides a user interface for building and editing Mustache templates
+ * with support for variables, text and conditionals.
  */
 export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
   initialTemplate,
@@ -534,21 +414,13 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
 }) => {
   const [template, setTemplate] = useState<TemplateBlock[]>([]);
   const [activeTab, setActiveTab] = useState(0);
+  const [parseError, setParseError] = useState<string | null>(null);
 
   useEffect(() => {
     if (initialTemplate) {
-      const parsedTemplate = parseTemplate(initialTemplate);
-      setTemplate(
-        parsedTemplate.length
-          ? parsedTemplate
-          : [
-              {
-                id: Math.random().toString(36).substring(2, 9),
-                type: 'text',
-                content: '',
-              },
-            ]
-      );
+      const {blocks, error} = parseTemplate(initialTemplate);
+      setTemplate(blocks);
+      setParseError(error);
     } else if (!template.length) {
       setTemplate([
         {
@@ -560,7 +432,7 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
     }
   }, [initialTemplate]);
 
-  const compileTemplate = (blocks: TemplateBlock[]): string => {
+  const compileTemplate = useCallback((blocks: TemplateBlock[]): string => {
     return blocks
       .map(block => {
         switch (block.type) {
@@ -568,39 +440,137 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
             return block.content;
           case 'variable':
             return `{{${block.content}}}`;
-          case 'helper':
-            return `{{${block.helper} ${block.content}}}`;
           case 'if':
-            return `{{#if ${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/if}}`;
+            return `{{#${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/${block.content}}}`;
           case 'unless':
-            return `{{^${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/unless}}`;
-          case 'each':
-            return `{{#each ${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/each}}`;
+            return `{{^${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/${block.content}}}`;
           default:
             return '';
         }
       })
       .join('');
-  };
+  }, []);
+
+  // Validates template syntax without blocking editing
+  const validateTemplate = useCallback(
+    (templateString: string): string | null => {
+      try {
+        // First try to parse the template
+        Mustache.parse(templateString);
+        return null;
+      } catch (error) {
+        // Return error but don't prevent further editing
+        return error instanceof Error
+          ? error.message
+          : 'Invalid template syntax';
+      }
+    },
+    []
+  );
 
   const handleSave = () => {
     const compiledTemplate = compileTemplate(template);
+    const error = validateTemplate(compiledTemplate);
+
+    if (error) {
+      setParseError(error);
+      setActiveTab(0); // Switch to builder tab to show error
+      return;
+    }
+
     onSave(compiledTemplate);
     onClose();
   };
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
-      <DialogTitle>Mustache Template Builder</DialogTitle>
+      <DialogTitle>
+        <Grid container alignItems="center" spacing={1}>
+          <Grid item>Mustache Template Builder</Grid>
+          {parseError && (
+            <Grid item>
+              <Tooltip title={parseError}>
+                <ErrorIcon color="error" />
+              </Tooltip>
+            </Grid>
+          )}
+        </Grid>
+      </DialogTitle>
 
       <DialogContent>
+        {/* Instructions */}
+        <Paper sx={{p: 2, mb: 3, bgcolor: 'background.default'}}>
+          <Typography variant="subtitle2" gutterBottom>
+            How to use this template editor:
+          </Typography>
+          <Typography variant="body2">
+            {
+              '• Add blocks using the + button. Each block can be text, a variable, or a condition'
+            }
+            <br />
+            {
+              '• Variables: Use {{variableName}} syntax to insert dynamic content'
+            }
+            <br />
+            {
+              '• Conditionals: Use {{#variableName}} to show content only when variable is true'
+            }
+            <br />
+            {
+              '• Unless: Use {{^variableName}} to show content only when variable is false'
+            }
+          </Typography>
+        </Paper>
+
+        {/* Live Template String Preview */}
+        <Paper
+          variant="outlined"
+          sx={{
+            p: 2,
+            mb: 2,
+            bgcolor: 'grey.50',
+            fontFamily: 'monospace',
+            whiteSpace: 'pre-wrap',
+            fontSize: '0.875rem',
+            maxHeight: '100px',
+            overflow: 'auto',
+          }}
+        >
+          <Typography
+            variant="caption"
+            display="block"
+            gutterBottom
+            color="text.secondary"
+          >
+            Template String:
+          </Typography>
+          {compileTemplate(template)}
+        </Paper>
+
+        {parseError && (
+          <Alert severity="error" sx={{mb: 2}}>
+            <Typography variant="subtitle2">Template Error:</Typography>
+            {parseError}
+          </Alert>
+        )}
+
         <Tabs
           value={activeTab}
           onChange={(_, newValue) => setActiveTab(newValue)}
           sx={{borderBottom: 1, borderColor: 'divider', mb: 2}}
         >
-          <Tab icon={<CodeIcon />} label="Builder" />
-          <Tab icon={<PreviewIcon />} label="Preview" />
+          <Tab
+            icon={<CodeIcon />}
+            label="Builder"
+            wrapped
+            sx={{minWidth: 120}}
+          />
+          <Tab
+            icon={<PreviewIcon />}
+            label="Preview"
+            wrapped
+            sx={{minWidth: 120}}
+          />
         </Tabs>
 
         {activeTab === 0 && (
@@ -615,6 +585,10 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
                   const newTemplate = [...template];
                   newTemplate[index] = updatedBlock;
                   setTemplate(newTemplate);
+                  // Don't automatically clear parse errors - let validation determine if error is fixed
+                  const compiledTemplate = compileTemplate(newTemplate);
+                  const error = validateTemplate(compiledTemplate);
+                  setParseError(error);
                 }}
                 onDelete={() => {
                   const newTemplate = [...template];
@@ -648,16 +622,30 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
             template={template}
             variables={variables}
             systemVariables={systemVariables}
+            onTemplateError={error => {
+              setParseError(error);
+              if (error) {
+                // If there's an error, show the builder tab so user can fix it
+                setActiveTab(0);
+              }
+            }}
           />
         )}
       </DialogContent>
 
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={handleSave} variant="contained" color="primary">
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          color="primary"
+          disabled={!!parseError}
+        >
           Save Template
         </Button>
       </DialogActions>
     </Dialog>
   );
 };
+
+export default MustacheTemplateBuilder;

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -116,6 +116,13 @@ const convertMustacheTokenToBlock = (token: any): TemplateBlock | null => {
           content: content,
         };
 
+      case 'name':
+        return {
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'variable',
+          content: content,
+        };
+
       case '#':
         return {
           id: Math.random().toString(36).substring(2, 9),
@@ -200,23 +207,21 @@ const TemplateBlockEditor: React.FC<{
 
         {block.type === 'variable' && (
           <Grid item xs={12} sm>
-            <Tooltip title="Select a variable to insert">
-              <FormControl fullWidth>
-                <InputLabel>Variable</InputLabel>
-                <Select
-                  value={block.content}
-                  label="Variable"
-                  onChange={e => updateBlockContent(e.target.value)}
-                >
-                  <MenuItem value="">Choose variable...</MenuItem>
-                  {allVariables.map(v => (
-                    <MenuItem key={v.name} value={v.name}>
-                      {v.displayName} ({v.type})
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Tooltip>
+            <FormControl fullWidth>
+              <InputLabel>Variable</InputLabel>
+              <Select
+                value={block.content}
+                label="Variable"
+                onChange={e => updateBlockContent(e.target.value)}
+              >
+                <MenuItem value="">Choose variable...</MenuItem>
+                {allVariables.map(v => (
+                  <MenuItem key={v.name} value={v.name}>
+                    {v.displayName} ({v.type})
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Grid>
         )}
 

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -4,6 +4,8 @@ import {
   Delete as DeleteIcon,
   Error as ErrorIcon,
   Preview as PreviewIcon,
+  ArrowDropUpRounded as ArrowDropUpRoundedIcon,
+  ArrowDropDownRounded as ArrowDropDownRoundedIcon,
 } from '@mui/icons-material';
 import {
   Alert,
@@ -164,8 +166,23 @@ const TemplateBlockEditor: React.FC<{
   systemVariables: Variable[];
   onUpdate: (block: TemplateBlock) => void;
   onDelete: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  isFirst?: boolean;
+  isLast?: boolean;
   level?: number;
-}> = ({block, variables, systemVariables, onUpdate, onDelete, level = 0}) => {
+}> = ({
+  block,
+  variables,
+  systemVariables,
+  onUpdate,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  isFirst,
+  isLast,
+  level = 0,
+}) => {
   const allVariables = [...variables, ...systemVariables];
 
   const updateBlockContent = (content: string) => {
@@ -257,9 +274,21 @@ const TemplateBlockEditor: React.FC<{
         )}
 
         <Grid item>
-          <IconButton onClick={onDelete} size="small" color="error">
-            <DeleteIcon />
-          </IconButton>
+          <Box sx={{display: 'flex', alignItems: 'center'}}>
+            {onMoveUp && !isFirst && (
+              <IconButton onClick={onMoveUp} size="small">
+                <ArrowDropUpRoundedIcon />
+              </IconButton>
+            )}
+            {onMoveDown && !isLast && (
+              <IconButton onClick={onMoveDown} size="small">
+                <ArrowDropDownRoundedIcon />
+              </IconButton>
+            )}
+            <IconButton onClick={onDelete} size="small" color="error">
+              <DeleteIcon />
+            </IconButton>
+          </Box>
         </Grid>
       </Grid>
 
@@ -281,6 +310,28 @@ const TemplateBlockEditor: React.FC<{
                 newChildren.splice(index, 1);
                 onUpdate({...block, children: newChildren});
               }}
+              onMoveUp={() => {
+                if (index > 0) {
+                  const newChildren = [...(block.children || [])];
+                  [newChildren[index - 1], newChildren[index]] = [
+                    newChildren[index],
+                    newChildren[index - 1],
+                  ];
+                  onUpdate({...block, children: newChildren});
+                }
+              }}
+              onMoveDown={() => {
+                if (index < (block.children?.length || 0) - 1) {
+                  const newChildren = [...(block.children || [])];
+                  [newChildren[index], newChildren[index + 1]] = [
+                    newChildren[index + 1],
+                    newChildren[index],
+                  ];
+                  onUpdate({...block, children: newChildren});
+                }
+              }}
+              isFirst={index === 0}
+              isLast={index === (block.children?.length || 0) - 1}
               level={level + 1}
             />
           ))}
@@ -599,6 +650,26 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
                   const newTemplate = [...template];
                   newTemplate.splice(index, 1);
                   setTemplate(newTemplate);
+                }}
+                onMoveUp={() => {
+                  if (index > 0) {
+                    const newTemplate = [...template];
+                    [newTemplate[index - 1], newTemplate[index]] = [
+                      newTemplate[index],
+                      newTemplate[index - 1],
+                    ];
+                    setTemplate(newTemplate);
+                  }
+                }}
+                onMoveDown={() => {
+                  if (index < template.length - 1) {
+                    const newTemplate = [...template];
+                    [newTemplate[index], newTemplate[index + 1]] = [
+                      newTemplate[index + 1],
+                      newTemplate[index],
+                    ];
+                    setTemplate(newTemplate);
+                  }
                 }}
               />
             ))}

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -35,6 +35,28 @@ import Mustache from 'mustache';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 /**
+ * Maintains a counter for generating unique block IDs within a session
+ */
+let blockCounter = 0;
+
+/**
+ * Generates a unique identifier for template blocks
+ * Format: block_[timestamp]_[counter]
+ * 
+ * @returns {string} A unique identifier string
+ */
+export const generateBlockId = (): string => {
+  // Get current timestamp
+  const timestamp = Date.now();
+  
+  // Increment counter
+  blockCounter++;
+  
+  // Create unique ID combining timestamp and counter
+  return `block_${timestamp}_${blockCounter}`;
+};
+
+/**
  * Supported block types in the template builder
  */
 type BlockType = 'text' | 'variable' | 'if' | 'unless';
@@ -93,7 +115,7 @@ const parseTemplate = (
     return {
       blocks: [
         {
-          id: Math.random().toString(36).substring(2, 9),
+          id: generateBlockId(),
           type: 'text',
           content: template || '',
         },
@@ -113,21 +135,21 @@ const convertMustacheTokenToBlock = (token: any): TemplateBlock | null => {
     switch (tokenType) {
       case 'text':
         return {
-          id: Math.random().toString(36).substring(2, 9),
+          id: generateBlockId(),
           type: 'text',
           content: content,
         };
 
       case 'name':
         return {
-          id: Math.random().toString(36).substring(2, 9),
+          id: generateBlockId(),
           type: 'variable',
           content: content,
         };
 
       case '#':
         return {
-          id: Math.random().toString(36).substring(2, 9),
+          id: generateBlockId(),
           type: 'if',
           content: content,
           children: rest[2].map(convertMustacheTokenToBlock).filter(Boolean),
@@ -135,7 +157,7 @@ const convertMustacheTokenToBlock = (token: any): TemplateBlock | null => {
 
       case '^':
         return {
-          id: Math.random().toString(36).substring(2, 9),
+          id: generateBlockId(),
           type: 'unless',
           content: content,
           children: rest[2].map(convertMustacheTokenToBlock).filter(Boolean),
@@ -191,7 +213,7 @@ const TemplateBlockEditor: React.FC<{
 
   const addChildBlock = () => {
     const newBlock: TemplateBlock = {
-      id: Math.random().toString(36).substring(2, 9),
+      id: generateBlockId(),
       type: 'text',
       content: '',
     };
@@ -516,7 +538,7 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
     } else if (!template.length) {
       setTemplate([
         {
-          id: Math.random().toString(36).substring(2, 9),
+          id: generateBlockId(),
           type: 'text',
           content: '',
         },
@@ -578,7 +600,7 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
     <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
       <DialogTitle>
         <Grid container alignItems="center" spacing={1}>
-          <Grid item>Mustache Template Builder</Grid>
+          <Grid item>Template Builder</Grid>
           {parseError && (
             <Grid item>
               <Tooltip title={parseError}>
@@ -605,11 +627,11 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
             }
             <br />
             {
-              '• Conditionals: Use {{#variableName}} to show content only when variable is true'
+              '• Conditional: Use {{#variableName}} to show content only when variable is defined'
             }
             <br />
             {
-              '• Unless: Use {{^variableName}} to show content only when variable is false'
+              '• Unless: Use {{^variableName}} to show content only when variable is undefined'
             }
           </Typography>
         </Paper>
@@ -716,7 +738,7 @@ export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
                 setTemplate([
                   ...template,
                   {
-                    id: Math.random().toString(36).substring(2, 9),
+                    id: generateBlockId(),
                     type: 'text',
                     content: '',
                   },

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -42,16 +42,16 @@ let blockCounter = 0;
 /**
  * Generates a unique identifier for template blocks
  * Format: block_[timestamp]_[counter]
- * 
+ *
  * @returns {string} A unique identifier string
  */
 export const generateBlockId = (): string => {
   // Get current timestamp
   const timestamp = Date.now();
-  
+
   // Increment counter
   blockCounter++;
-  
+
   // Create unique ID combining timestamp and counter
   return `block_${timestamp}_${blockCounter}`;
 };

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -1,0 +1,663 @@
+import {
+  Add as AddIcon,
+  Code as CodeIcon,
+  Delete as DeleteIcon,
+  Preview as PreviewIcon,
+} from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Tab,
+  Tabs,
+  TextField,
+} from '@mui/material';
+import React, {useEffect, useState} from 'react';
+
+// Types for template building blocks
+type BlockType = 'text' | 'variable' | 'if' | 'unless' | 'each' | 'helper';
+
+type HelperType = 'uppercase' | 'lowercase' | 'dateFormat' | 'numberFormat';
+
+interface TemplateBlock {
+  id: string;
+  type: BlockType;
+  content: string;
+  children?: TemplateBlock[];
+  helper?: HelperType;
+  helperArgs?: string[];
+}
+
+interface Variable {
+  name: string;
+  displayName: string;
+  type: 'field' | 'system';
+  value?: string; // For preview purposes
+}
+
+interface MustacheBuilderProps {
+  initialTemplate?: string;
+  variables: Variable[];
+  systemVariables: Variable[];
+  onSave: (template: string) => void;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Parses a Mustache template string into template blocks
+ */
+const parseTemplate = (template: string): TemplateBlock[] => {
+  const blocks: TemplateBlock[] = [];
+  let currentText = '';
+
+  // Helper to add accumulated text as a block
+  const addTextBlock = () => {
+    if (currentText) {
+      blocks.push({
+        id: Math.random().toString(36).substring(2, 9),
+        type: 'text',
+        content: currentText,
+      });
+      currentText = '';
+    }
+  };
+
+  // Helper to parse a section (like if/unless/each) until its closing tag
+  const parseSection = (
+    template: string,
+    startIndex: number
+  ): [TemplateBlock | null, number] => {
+    const tagMatch = template.slice(startIndex).match(/^\{\{([#^])([^}]+)\}\}/);
+    if (!tagMatch) return [null, startIndex];
+
+    const [fullTag, prefix, content] = tagMatch;
+    const tagType =
+      prefix === '#' ? (content === 'each' ? 'each' : 'if') : 'unless';
+    const tagContent = content.trim();
+
+    // Find the matching closing tag
+    const searchStart = startIndex + fullTag.length;
+    let nested = 0;
+    let currentPos = searchStart;
+
+    while (currentPos < template.length) {
+      const openTag = template.slice(currentPos).match(/\{\{[#^]/);
+      const closeTag = template
+        .slice(currentPos)
+        .match(`\\{\\{/${tagContent}\\}\\}`);
+
+      if (!closeTag) break; // No matching close tag found
+
+      if (!openTag || closeTag.index! < openTag.index!) {
+        if (nested === 0) {
+          // Parse the content between tags recursively
+          const innerContent = template.slice(
+            searchStart,
+            currentPos + closeTag.index!
+          );
+          const children = parseTemplate(innerContent);
+
+          return [
+            {
+              id: Math.random().toString(36).substring(2, 9),
+              type: tagType,
+              content: tagContent,
+              children,
+            },
+            currentPos + closeTag.index! + closeTag[0].length,
+          ];
+        }
+        nested--;
+      } else {
+        nested++;
+      }
+      currentPos =
+        currentPos + (openTag ? openTag.index! + 2 : closeTag.index! + 3);
+    }
+
+    return [null, startIndex + fullTag.length];
+  };
+
+  let currentPos = 0;
+  while (currentPos < template.length) {
+    const nextTag = template.slice(currentPos).match(/\{\{([#^])?([^}]+)\}\}/);
+
+    if (!nextTag) {
+      currentText += template.slice(currentPos);
+      break;
+    }
+
+    const [fullTag, prefix, content] = nextTag;
+    const tagStart = currentPos + nextTag.index!;
+
+    // Add any text before the tag
+    if (tagStart > currentPos) {
+      currentText += template.slice(currentPos, tagStart);
+    }
+
+    // Handle different tag types
+    if (prefix === '#' || prefix === '^') {
+      addTextBlock();
+      const [sectionBlock, newPos] = parseSection(template, tagStart);
+      if (sectionBlock) {
+        blocks.push(sectionBlock);
+      }
+      currentPos = newPos;
+    } else {
+      // Handle regular variables and helpers
+      addTextBlock();
+      if (content.includes(' ')) {
+        // Helper
+        const [helper, variable] = content.trim().split(/\s+/);
+        blocks.push({
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'helper',
+          helper: helper as HelperType,
+          content: variable,
+        });
+      } else {
+        // Variable
+        blocks.push({
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'variable',
+          content: content.trim(),
+        });
+      }
+      currentPos = tagStart + fullTag.length;
+    }
+  }
+
+  addTextBlock();
+  return blocks;
+};
+
+const HELPER_FUNCTIONS: Record<
+  HelperType,
+  {
+    display: string;
+    description: string;
+    example: string;
+  }
+> = {
+  uppercase: {
+    display: 'Uppercase',
+    description: 'Convert text to uppercase',
+    example: '{{uppercase name}}',
+  },
+  lowercase: {
+    display: 'Lowercase',
+    description: 'Convert text to lowercase',
+    example: '{{lowercase name}}',
+  },
+  dateFormat: {
+    display: 'Date Format',
+    description: 'Format a date (YYYY-MM-DD)',
+    example: '{{dateFormat date "YYYY-MM-DD"}}',
+  },
+  numberFormat: {
+    display: 'Number Format',
+    description: 'Format a number',
+    example: '{{numberFormat number "0.00"}}',
+  },
+};
+
+/**
+ * Component for displaying and editing a single template block
+ */
+const TemplateBlockEditor: React.FC<{
+  block: TemplateBlock;
+  variables: Variable[];
+  systemVariables: Variable[];
+  onUpdate: (block: TemplateBlock) => void;
+  onDelete: () => void;
+  level?: number;
+}> = ({block, variables, systemVariables, onUpdate, onDelete, level = 0}) => {
+  const allVariables = [...variables, ...systemVariables];
+
+  const updateBlockContent = (content: string) => {
+    onUpdate({...block, content});
+  };
+
+  const addChildBlock = () => {
+    const newBlock: TemplateBlock = {
+      id: Math.random().toString(36).substring(2, 9),
+      type: 'text',
+      content: '',
+    };
+    onUpdate({
+      ...block,
+      children: [...(block.children || []), newBlock],
+    });
+  };
+
+  return (
+    <Box sx={{pl: 3, borderLeft: '2px solid', borderColor: 'divider', mb: 2}}>
+      <Grid container spacing={2} alignItems="center">
+        <Grid item xs={12} sm="auto">
+          <FormControl fullWidth sx={{minWidth: 120}}>
+            <InputLabel>Block Type</InputLabel>
+            <Select
+              value={block.type}
+              label="Block Type"
+              onChange={e =>
+                onUpdate({...block, type: e.target.value as BlockType})
+              }
+            >
+              <MenuItem value="text">Text</MenuItem>
+              <MenuItem value="variable">Variable</MenuItem>
+              <MenuItem value="if">If Condition</MenuItem>
+              <MenuItem value="unless">Unless</MenuItem>
+              <MenuItem value="each">Each Loop</MenuItem>
+              <MenuItem value="helper">Helper</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+
+        {block.type === 'variable' && (
+          <Grid item xs={12} sm>
+            <FormControl fullWidth>
+              <InputLabel>Variable</InputLabel>
+              <Select
+                value={block.content}
+                label="Variable"
+                onChange={e => updateBlockContent(e.target.value)}
+              >
+                <MenuItem value="">Choose variable...</MenuItem>
+                {allVariables.map(v => (
+                  <MenuItem key={v.name} value={v.name}>
+                    {v.displayName} ({v.type})
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        )}
+
+        {block.type === 'helper' && (
+          <>
+            <Grid item xs={12} sm={3}>
+              <FormControl fullWidth>
+                <InputLabel>Helper</InputLabel>
+                <Select
+                  value={block.helper}
+                  label="Helper"
+                  onChange={e =>
+                    onUpdate({...block, helper: e.target.value as HelperType})
+                  }
+                >
+                  {Object.entries(HELPER_FUNCTIONS).map(([key, value]) => (
+                    <MenuItem key={key} value={key}>
+                      {value.display}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <FormControl fullWidth>
+                <InputLabel>Apply To</InputLabel>
+                <Select
+                  value={block.content}
+                  label="Apply To"
+                  onChange={e => updateBlockContent(e.target.value)}
+                >
+                  {allVariables.map(v => (
+                    <MenuItem key={v.name} value={v.name}>
+                      {v.displayName}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          </>
+        )}
+
+        {block.type === 'text' && (
+          <Grid item xs>
+            <TextField
+              fullWidth
+              value={block.content}
+              onChange={e => updateBlockContent(e.target.value)}
+              placeholder="Enter text..."
+              size="small"
+            />
+          </Grid>
+        )}
+
+        {(block.type === 'if' ||
+          block.type === 'unless' ||
+          block.type === 'each') && (
+          <Grid item xs={12} sm={4}>
+            <FormControl fullWidth>
+              <InputLabel>Variable</InputLabel>
+              <Select
+                value={block.content}
+                label="Variable"
+                onChange={e => updateBlockContent(e.target.value)}
+              >
+                {allVariables.map(v => (
+                  <MenuItem key={v.name} value={v.name}>
+                    {v.displayName}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        )}
+
+        <Grid item>
+          <IconButton onClick={onDelete} size="small" color="error">
+            <DeleteIcon />
+          </IconButton>
+        </Grid>
+      </Grid>
+
+      {(block.type === 'if' ||
+        block.type === 'unless' ||
+        block.type === 'each') && (
+        <Box sx={{mt: 2, mb: 1}}>
+          {block.children?.map((child, index) => (
+            <TemplateBlockEditor
+              key={child.id}
+              block={child}
+              variables={variables}
+              systemVariables={systemVariables}
+              onUpdate={updatedChild => {
+                const newChildren = [...(block.children || [])];
+                newChildren[index] = updatedChild;
+                onUpdate({...block, children: newChildren});
+              }}
+              onDelete={() => {
+                const newChildren = [...(block.children || [])];
+                newChildren.splice(index, 1);
+                onUpdate({...block, children: newChildren});
+              }}
+              level={level + 1}
+            />
+          ))}
+          <Button
+            startIcon={<AddIcon />}
+            variant="outlined"
+            size="small"
+            onClick={addChildBlock}
+            sx={{mt: 1}}
+          >
+            Add Block
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+/**
+ * Enhanced preview component with proper conditional handling
+ */
+const TemplatePreview: React.FC<{
+  template: TemplateBlock[];
+  variables: Variable[];
+  systemVariables: Variable[];
+}> = ({template, variables, systemVariables}) => {
+  const [previewValues, setPreviewValues] = useState<Record<string, string>>(
+    {}
+  );
+  const allVariables = [...variables, ...systemVariables];
+
+  const evaluateCondition = (variableName: string): boolean => {
+    const value = previewValues[variableName];
+    // Consider the condition true if the value exists and isn't empty
+    return !!value && value.trim() !== '';
+  };
+
+  const applyHelper = (helper: HelperType, value: string): string => {
+    switch (helper) {
+      case 'uppercase':
+        return value.toUpperCase();
+      case 'lowercase':
+        return value.toLowerCase();
+      case 'dateFormat':
+        try {
+          const date = new Date(value);
+          return date.toISOString().split('T')[0]; // YYYY-MM-DD
+        } catch {
+          return value;
+        }
+      case 'numberFormat':
+        try {
+          return parseFloat(value).toFixed(2);
+        } catch {
+          return value;
+        }
+    }
+  };
+
+  const renderBlock = (block: TemplateBlock): string => {
+    switch (block.type) {
+      case 'text':
+        return block.content;
+      case 'variable':
+        return previewValues[block.content] || '';
+      case 'helper':
+        if (block.helper && block.content) {
+          const value = previewValues[block.content] || '';
+          return applyHelper(block.helper, value);
+        }
+        return '';
+      case 'if':
+        if (evaluateCondition(block.content)) {
+          return block.children?.map(renderBlock).join('') || '';
+        }
+        return '';
+      case 'unless':
+        if (!evaluateCondition(block.content)) {
+          return block.children?.map(renderBlock).join('') || '';
+        }
+        return '';
+      case 'each':
+        // For preview, we'll treat 'each' as a simple if condition
+        if (evaluateCondition(block.content)) {
+          return block.children?.map(renderBlock).join('') || '';
+        }
+        return '';
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <Box sx={{mt: 3}}>
+      <Grid container spacing={2}>
+        {allVariables.map(variable => (
+          <Grid item xs={12} sm={6} key={variable.name}>
+            <TextField
+              fullWidth
+              label={variable.displayName}
+              value={previewValues[variable.name] || ''}
+              onChange={e =>
+                setPreviewValues({
+                  ...previewValues,
+                  [variable.name]: e.target.value,
+                })
+              }
+              size="small"
+              placeholder={`Enter ${variable.displayName.toLowerCase()}...`}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      <Card sx={{mt: 3}}>
+        <CardHeader title="Preview" />
+        <CardContent>
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 2,
+              bgcolor: 'grey.50',
+              fontFamily: 'monospace',
+              whiteSpace: 'pre-wrap',
+              minHeight: '100px',
+            }}
+          >
+            {template.map(renderBlock).join('')}
+          </Paper>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};
+
+/**
+ * Main Mustache template builder dialog component
+ */
+export const MustacheTemplateBuilder: React.FC<MustacheBuilderProps> = ({
+  initialTemplate,
+  variables,
+  systemVariables,
+  onSave,
+  open,
+  onClose,
+}) => {
+  const [template, setTemplate] = useState<TemplateBlock[]>([]);
+  const [activeTab, setActiveTab] = useState(0);
+
+  useEffect(() => {
+    if (initialTemplate) {
+      const parsedTemplate = parseTemplate(initialTemplate);
+      setTemplate(
+        parsedTemplate.length
+          ? parsedTemplate
+          : [
+              {
+                id: Math.random().toString(36).substring(2, 9),
+                type: 'text',
+                content: '',
+              },
+            ]
+      );
+    } else if (!template.length) {
+      setTemplate([
+        {
+          id: Math.random().toString(36).substring(2, 9),
+          type: 'text',
+          content: '',
+        },
+      ]);
+    }
+  }, [initialTemplate]);
+
+  const compileTemplate = (blocks: TemplateBlock[]): string => {
+    return blocks
+      .map(block => {
+        switch (block.type) {
+          case 'text':
+            return block.content;
+          case 'variable':
+            return `{{${block.content}}}`;
+          case 'helper':
+            return `{{${block.helper} ${block.content}}}`;
+          case 'if':
+            return `{{#if ${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/if}}`;
+          case 'unless':
+            return `{{^${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/unless}}`;
+          case 'each':
+            return `{{#each ${block.content}}}${block.children ? compileTemplate(block.children) : ''}{{/each}}`;
+          default:
+            return '';
+        }
+      })
+      .join('');
+  };
+
+  const handleSave = () => {
+    const compiledTemplate = compileTemplate(template);
+    onSave(compiledTemplate);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>Mustache Template Builder</DialogTitle>
+
+      <DialogContent>
+        <Tabs
+          value={activeTab}
+          onChange={(_, newValue) => setActiveTab(newValue)}
+          sx={{borderBottom: 1, borderColor: 'divider', mb: 2}}
+        >
+          <Tab icon={<CodeIcon />} label="Builder" />
+          <Tab icon={<PreviewIcon />} label="Preview" />
+        </Tabs>
+
+        {activeTab === 0 && (
+          <Box sx={{mt: 2}}>
+            {template.map((block, index) => (
+              <TemplateBlockEditor
+                key={block.id}
+                block={block}
+                variables={variables}
+                systemVariables={systemVariables}
+                onUpdate={updatedBlock => {
+                  const newTemplate = [...template];
+                  newTemplate[index] = updatedBlock;
+                  setTemplate(newTemplate);
+                }}
+                onDelete={() => {
+                  const newTemplate = [...template];
+                  newTemplate.splice(index, 1);
+                  setTemplate(newTemplate);
+                }}
+              />
+            ))}
+            <Button
+              startIcon={<AddIcon />}
+              variant="outlined"
+              onClick={() =>
+                setTemplate([
+                  ...template,
+                  {
+                    id: Math.random().toString(36).substring(2, 9),
+                    type: 'text',
+                    content: '',
+                  },
+                ])
+              }
+              sx={{mt: 2}}
+            >
+              Add Block
+            </Button>
+          </Box>
+        )}
+
+        {activeTab === 1 && (
+          <TemplatePreview
+            template={template}
+            variables={variables}
+            systemVariables={systemVariables}
+          />
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" color="primary">
+          Save Template
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/designer/src/components/design-panel.tsx
+++ b/designer/src/components/design-panel.tsx
@@ -44,14 +44,6 @@ export const DesignPanel = () => {
     Object.keys(viewSets).filter(form => !visibleTypes.includes(form))
   );
 
-  console.log('DesignPanel');
-  console.log(
-    'visible forms ',
-    visibleTypes,
-    '& unticked forms ',
-    untickedForms
-  );
-
   const maxKeys = Object.keys(viewSets).length;
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {

--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -46,7 +46,7 @@ import HiddenFieldEditor from './Fields/HiddenToggle';
 
 type FieldEditorProps = {
   fieldName: string;
-  viewSetId?: string;
+  viewsetId: string;
   viewId: string;
   expanded: boolean;
   addFieldCallback: (fieldName: string) => void;
@@ -56,6 +56,7 @@ type FieldEditorProps = {
 export const FieldEditor = ({
   fieldName,
   viewId,
+  viewsetId,
   expanded,
   addFieldCallback,
   handleExpandChange,
@@ -63,6 +64,7 @@ export const FieldEditor = ({
   const field = useAppSelector(
     state => state.notebook['ui-specification'].fields[fieldName]
   );
+
   const dispatch = useAppDispatch();
 
   const fieldComponent = field['component-name'];
@@ -289,6 +291,7 @@ export const FieldEditor = ({
               <TemplatedStringFieldEditor
                 fieldName={fieldName}
                 viewId={viewId}
+                viewsetId={viewsetId}
               />
               <HiddenFieldEditor fieldName={fieldName} />
             </>

--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -42,6 +42,7 @@ import {RichTextEditor} from './Fields/RichTextEditor';
 import {TakePhotoFieldEditor} from './Fields/TakePhotoField';
 import {TemplatedStringFieldEditor} from './Fields/TemplatedStringFieldEditor';
 import {TextFieldEditor} from './Fields/TextFieldEditor';
+import HiddenFieldEditor from './Fields/HiddenToggle';
 
 type FieldEditorProps = {
   fieldName: string;
@@ -256,7 +257,11 @@ export const FieldEditor = ({
             <OptionsEditor fieldName={fieldName} />
           )) ||
           (fieldComponent === 'MultiSelect' && (
-            <OptionsEditor fieldName={fieldName} showExpandedChecklist={true} showExclusiveOptions={true}/>
+            <OptionsEditor
+              fieldName={fieldName}
+              showExpandedChecklist={true}
+              showExclusiveOptions={true}
+            />
           )) ||
           (fieldComponent === 'AdvancedSelect' && (
             <AdvancedSelectEditor fieldName={fieldName} />
@@ -280,7 +285,13 @@ export const FieldEditor = ({
             <BasicAutoIncrementerEditor fieldName={fieldName} viewId={viewId} />
           )) ||
           (fieldComponent === 'TemplatedStringField' && (
-            <TemplatedStringFieldEditor fieldName={fieldName} viewId={viewId} />
+            <>
+              <TemplatedStringFieldEditor
+                fieldName={fieldName}
+                viewId={viewId}
+              />
+              <HiddenFieldEditor fieldName={fieldName} />
+            </>
           )) || <BaseFieldEditor fieldName={fieldName} />}
       </AccordionDetails>
     </Accordion>

--- a/designer/src/components/field-list.tsx
+++ b/designer/src/components/field-list.tsx
@@ -39,7 +39,7 @@ type Props = {
   viewId: string;
 };
 
-export const FieldList = ({viewSetId, viewId}: Props) => {
+export const FieldList = ({viewSetId: viewsetId, viewId}: Props) => {
   const fView = useAppSelector(
     state => state.notebook['ui-specification'].fviews[viewId]
   );
@@ -74,7 +74,7 @@ export const FieldList = ({viewSetId, viewId}: Props) => {
         fieldName: dialogState.name,
         fieldType: dialogState.type,
         viewId: viewId,
-        viewSetId: viewSetId,
+        viewSetId: viewsetId,
         addAfter: addAfterField,
       },
     });
@@ -158,7 +158,7 @@ export const FieldList = ({viewSetId, viewId}: Props) => {
           <FieldEditor
             key={fieldName}
             fieldName={fieldName}
-            viewSetId={viewSetId}
+            viewsetId={viewsetId}
             viewId={viewId}
             expanded={isExpanded[fieldName] ?? false}
             addFieldCallback={addFieldAfterCallback}

--- a/designer/src/components/field-list.tsx
+++ b/designer/src/components/field-list.tsx
@@ -40,8 +40,6 @@ type Props = {
 };
 
 export const FieldList = ({viewSetId, viewId}: Props) => {
-  console.log('FieldList', viewSetId, viewId);
-
   const fView = useAppSelector(
     state => state.notebook['ui-specification'].fviews[viewId]
   );
@@ -65,7 +63,6 @@ export const FieldList = ({viewSetId, viewId}: Props) => {
   };
 
   const addFieldAfterCallback = (fieldName: string) => {
-    console.log('adding a field after', fieldName);
     setAddAfterField(fieldName);
     setDialogOpen(true);
   };
@@ -107,23 +104,6 @@ export const FieldList = ({viewSetId, viewId}: Props) => {
     // section, so reset all fields to be closed
     setIsExpanded(allClosed);
   }, [fView.label]);
-
-  // can't do this with another useEffect because it might fire before
-  // or after the other one, it then opens up random fields
-  //
-  // useEffect(() => {
-  //   // if fViews.fields changes we check if there is a new
-  //   // field (just added) and open it up
-  //   fView.fields.forEach((fieldName: string) => {
-  //     console.log('checking', fieldName, isExpanded[fieldName]);
-  //     if (isExpanded[fieldName] === undefined) {
-  //       setIsExpanded({
-  //         ...isExpanded,
-  //         [fieldName]: true,
-  //       });
-  //     }
-  //   });
-  // }, [fView.fields]);
 
   const handleExpandChange = (fieldName: string) => {
     return (_event: React.SyntheticEvent, expanded: boolean) => {

--- a/designer/src/components/form-editor.tsx
+++ b/designer/src/components/form-editor.tsx
@@ -76,7 +76,7 @@ export const FormEditor = ({
     }
   );
   const sections = viewSet ? viewSet.views : [];
-  console.log('FormEditor', { viewSetId, sections });
+  console.log('FormEditor', {viewSetId, sections});
 
   const views = useAppSelector(
     state => state.notebook['ui-specification'].fviews

--- a/designer/src/components/form-editor.tsx
+++ b/designer/src/components/form-editor.tsx
@@ -83,8 +83,6 @@ export const FormEditor = ({
   );
   const dispatch = useAppDispatch();
 
-  console.log('FormEditor', viewSetId);
-
   const [activeStep, setActiveStep] = useState(0);
   const [newSectionName, setNewSectionName] = useState('New Section');
   const [alertMessage, setAlertMessage] = useState('');

--- a/designer/src/components/form-editor.tsx
+++ b/designer/src/components/form-editor.tsx
@@ -46,6 +46,7 @@ import {useAppDispatch, useAppSelector} from '../state/hooks';
 import {SectionEditor} from './section-editor';
 import {useState} from 'react';
 import {shallowEqual} from 'react-redux';
+import FormSettingsPanel from './form-settings';
 
 type Props = {
   viewSetId: string;
@@ -428,6 +429,9 @@ export const FormEditor = ({
         </Grid>
       </Grid>
 
+      <Grid container item xs={12}>
+        <FormSettingsPanel viewSetId={viewSetId} />
+      </Grid>
       <Grid item xs={12}>
         <Card variant="outlined">
           <Grid container spacing={2} p={3}>

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Card, CardContent, Typography, Select, MenuItem, FormControl, InputLabel, Autocomplete, TextField, IconButton, Collapse } from '@mui/material';
+import { useAppDispatch, useAppSelector } from '../state/hooks';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import SettingsIcon from '@mui/icons-material/Settings';
+
+type FormSettingsPanelProps = {
+  viewSetId: string;
+};
+
+export const FormSettingsPanel = ({ viewSetId }: FormSettingsPanelProps) => {
+  const dispatch = useAppDispatch();
+  const fields = useAppSelector(state => state.notebook['ui-specification'].fields);
+  const viewSet = useAppSelector(state => state.notebook['ui-specification'].viewsets[viewSetId]);
+  const fviews = useAppSelector(state => state.notebook['ui-specification'].fviews);
+  const [expanded, setExpanded] = React.useState(false);
+
+  const viewSetFields = React.useMemo(() => {
+    const fieldSet = new Set<string>();
+    viewSet.views.forEach(viewId => {
+      const view = fviews[viewId];
+      if (view) {
+        view.fields.forEach(fieldId => fieldSet.add(fieldId));
+      }
+    });
+    return Array.from(fieldSet);
+  }, [viewSet.views, fviews]);
+
+  const fieldOptions = viewSetFields
+    .map(fieldId => {
+      const field = fields[fieldId];
+      return field ? {
+        label: field['component-parameters'].label || fieldId,
+        value: fieldId
+      } : null;
+    })
+    .filter((x): x is { label: string, value: string } => x !== null);
+
+  const handleLayoutChange = (event: any) => {
+    dispatch({
+      type: 'ui-specification/viewSetLayoutUpdated',
+      payload: { 
+        viewSetId, 
+        layout: event.target.value as 'inline' | 'tabs' | undefined 
+      }
+    });
+  };
+
+  const handleSummaryFieldsChange = (_: any, newValue: Array<{ label: string, value: string }>) => {
+    dispatch({
+      type: 'ui-specification/viewSetSummaryFieldsUpdated',
+      payload: { 
+        viewSetId, 
+        fields: newValue.map(v => v.value)
+      }
+    });
+  };
+
+  const selectedFields = (viewSet.summary_fields || [])
+    .map(fieldId => fieldOptions.find(opt => opt.value === fieldId))
+    .filter((x): x is { label: string, value: string } => x !== null);
+
+  return (
+    <Card sx={{ 
+      width: '100%',
+      mt: 2,
+    }}>
+      <CardContent 
+        sx={{ 
+          display: 'flex',
+          alignItems: 'center',
+          px: 3,
+          py: 2,
+          backgroundColor: 'action.selected',
+          cursor: 'pointer',
+          '&:hover': {
+            backgroundColor: 'action.hover'
+          }
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <SettingsIcon sx={{ mr: 1, color: 'text.secondary' }} />
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>Form Settings</Typography>
+        <IconButton
+          sx={{
+            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 0.2s'
+          }}
+          size="small"
+        >
+          <ExpandMoreIcon />
+        </IconButton>
+      </CardContent>
+
+      <Collapse in={expanded}>
+        <CardContent sx={{ p: 3 }}>
+          <Typography color="text.secondary" sx={{ mb: 3 }}>
+            Configure form layout and display options
+          </Typography>
+
+          <FormControl fullWidth sx={{ mb: 4 }}>
+            <InputLabel>Layout Style</InputLabel>
+            <Select
+              value={viewSet.layout || 'tabs'}
+              label="Layout Style"
+              onChange={handleLayoutChange}
+            >
+              <MenuItem value="tabs">Tabs</MenuItem>
+              <MenuItem value="inline">Inline</MenuItem>
+            </Select>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Choose how form sections are displayed
+            </Typography>
+          </FormControl>
+
+          <FormControl fullWidth>
+            <Autocomplete
+              multiple
+              options={fieldOptions}
+              value={selectedFields}
+              onChange={handleSummaryFieldsChange}
+              getOptionLabel={(option) => option.label}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Summary Fields"
+                  placeholder="Select fields"
+                />
+              )}
+            />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Select fields to display in record summaries
+            </Typography>
+          </FormControl>
+        </CardContent>
+      </Collapse>
+    </Card>
+  );
+};
+
+export default FormSettingsPanel;

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -1,20 +1,85 @@
-import React from 'react';
-import { Card, CardContent, Typography, Select, MenuItem, FormControl, InputLabel, Autocomplete, TextField, IconButton, Collapse } from '@mui/material';
-import { useAppDispatch, useAppSelector } from '../state/hooks';
+/**
+ * FormSettingsPanel Component
+ *
+ * Provides configuration options for a form (viewset) including:
+ * - Layout style (tabs/inline)
+ * - Summary fields for record display
+ * - Human-readable ID field selection
+ *
+ * @param {string} viewSetId - ID of the viewset being configured
+ */
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import SettingsIcon from '@mui/icons-material/Settings';
+import {
+  Autocomplete,
+  Card,
+  CardContent,
+  Collapse,
+  IconButton,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import {useAppDispatch, useAppSelector} from '../state/hooks';
+import {FieldType} from '../state/initial';
 
 type FormSettingsPanelProps = {
   viewSetId: string;
 };
 
-export const FormSettingsPanel = ({ viewSetId }: FormSettingsPanelProps) => {
+/**
+ * Determines if a field can be used as an HRID field
+ * @param field - Field configuration to check
+ * @returns boolean indicating if field meets HRID requirements
+ */
+const isValidHridField = (field: FieldType): boolean => {
+  return (
+    field['type-returned'] === 'faims-core::String' &&
+    (field['component-parameters'].required || false)
+  );
+};
+
+/**
+ * Renders section header and description with consistent styling
+ */
+const SettingSection = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) => (
+  <div className="setting-section" style={{marginBottom: '2rem'}}>
+    <Typography variant="subtitle1" sx={{fontWeight: 'bold', mb: 1}}>
+      {title}
+    </Typography>
+    <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+      {description}
+    </Typography>
+    {children}
+  </div>
+);
+
+export const FormSettingsPanel = ({viewSetId}: FormSettingsPanelProps) => {
   const dispatch = useAppDispatch();
-  const fields = useAppSelector(state => state.notebook['ui-specification'].fields);
-  const viewSet = useAppSelector(state => state.notebook['ui-specification'].viewsets[viewSetId]);
-  const fviews = useAppSelector(state => state.notebook['ui-specification'].fviews);
+  const fields = useAppSelector(
+    state => state.notebook['ui-specification'].fields
+  );
+  const viewSet = useAppSelector(
+    state => state.notebook['ui-specification'].viewsets[viewSetId]
+  );
+  const fviews = useAppSelector(
+    state => state.notebook['ui-specification'].fviews
+  );
   const [expanded, setExpanded] = React.useState(false);
 
+  /**
+   * Collects all fields that belong to any view in the current viewset
+   */
   const viewSetFields = React.useMemo(() => {
     const fieldSet = new Set<string>();
     viewSet.views.forEach(viewId => {
@@ -26,65 +91,103 @@ export const FormSettingsPanel = ({ viewSetId }: FormSettingsPanelProps) => {
     return Array.from(fieldSet);
   }, [viewSet.views, fviews]);
 
+  /**
+   * Converts field IDs to option objects for select components
+   */
   const fieldOptions = viewSetFields
     .map(fieldId => {
       const field = fields[fieldId];
-      return field ? {
-        label: field['component-parameters'].label || fieldId,
-        value: fieldId
-      } : null;
+      return field
+        ? {
+            label: field['component-parameters'].label || fieldId,
+            value: fieldId,
+          }
+        : null;
     })
-    .filter((x): x is { label: string, value: string } => x !== null);
+    .filter((x): x is {label: string; value: string} => x !== null);
 
+  /**
+   * Filters field options to only those valid for HRID use
+   */
+  const hridFieldOptions = viewSetFields
+    .map(fieldId => {
+      const field = fields[fieldId];
+      return field && isValidHridField(field)
+        ? {
+            label: field['component-parameters'].label || fieldId,
+            value: fieldId,
+          }
+        : null;
+    })
+    .filter((x): x is {label: string; value: string} => x !== null);
+
+  /**
+   * Updates the form layout setting
+   */
   const handleLayoutChange = (event: any) => {
     dispatch({
       type: 'ui-specification/viewSetLayoutUpdated',
-      payload: { 
-        viewSetId, 
-        layout: event.target.value as 'inline' | 'tabs' | undefined 
-      }
+      payload: {
+        viewSetId,
+        layout: event.target.value as 'inline' | 'tabs' | undefined,
+      },
     });
   };
 
-  const handleSummaryFieldsChange = (_: any, newValue: Array<{ label: string, value: string }>) => {
+  /**
+   * Updates the selected summary fields
+   */
+  const handleSummaryFieldsChange = (
+    _: any,
+    newValue: Array<{label: string; value: string}>
+  ) => {
     dispatch({
       type: 'ui-specification/viewSetSummaryFieldsUpdated',
-      payload: { 
-        viewSetId, 
-        fields: newValue.map(v => v.value)
-      }
+      payload: {viewSetId, fields: newValue.map(v => v.value)},
+    });
+  };
+
+  /**
+   * Updates or clears the HRID field selection
+   */
+  const handleHridFieldChange = (
+    _: any,
+    newValue: {label: string; value: string} | null
+  ) => {
+    dispatch({
+      type: 'ui-specification/viewSetHridUpdated',
+      payload: {viewSetId, hridField: newValue?.value},
     });
   };
 
   const selectedFields = (viewSet.summary_fields || [])
     .map(fieldId => fieldOptions.find(opt => opt.value === fieldId))
-    .filter((x): x is { label: string, value: string } => x !== null);
+    .filter((x): x is {label: string; value: string} => x !== null);
+
+  const selectedHridField = viewSet.hridField
+    ? hridFieldOptions.find(opt => opt.value === viewSet.hridField) || null
+    : null;
 
   return (
-    <Card sx={{ 
-      width: '100%',
-      mt: 2,
-    }}>
-      <CardContent 
-        sx={{ 
+    <Card sx={{width: '100%', mt: 2}}>
+      <CardContent
+        sx={{
           display: 'flex',
           alignItems: 'center',
-          px: 3,
-          py: 2,
           backgroundColor: 'action.selected',
           cursor: 'pointer',
-          '&:hover': {
-            backgroundColor: 'action.hover'
-          }
+          '&:hover': {backgroundColor: 'action.hover'},
         }}
         onClick={() => setExpanded(!expanded)}
       >
-        <SettingsIcon sx={{ mr: 1, color: 'text.secondary' }} />
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>Form Settings</Typography>
+        <SettingsIcon sx={{mr: 1, color: 'text.secondary'}} />
+        <Typography variant="h6" sx={{flexGrow: 1}}>
+          Form Settings
+        </Typography>
         <IconButton
           sx={{
             transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 0.2s'
+            transition: 'transform 0.2s',
           }}
           size="small"
         >
@@ -93,45 +196,64 @@ export const FormSettingsPanel = ({ viewSetId }: FormSettingsPanelProps) => {
       </CardContent>
 
       <Collapse in={expanded}>
-        <CardContent sx={{ p: 3 }}>
-          <Typography color="text.secondary" sx={{ mb: 3 }}>
-            Configure form layout and display options
-          </Typography>
-
-          <FormControl fullWidth sx={{ mb: 4 }}>
-            <InputLabel>Layout Style</InputLabel>
+        <CardContent>
+          <SettingSection
+            title="Layout Style"
+            description="Choose how form sections are displayed. The 'tabs' layout will display questions split up into their sections. The 'inline' layout will display all questions in a single scrollable form."
+          >
             <Select
+              fullWidth
               value={viewSet.layout || 'tabs'}
-              label="Layout Style"
               onChange={handleLayoutChange}
             >
               <MenuItem value="tabs">Tabs</MenuItem>
               <MenuItem value="inline">Inline</MenuItem>
             </Select>
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Choose how form sections are displayed
-            </Typography>
-          </FormControl>
+          </SettingSection>
 
-          <FormControl fullWidth>
+          <SettingSection
+            title="Summary Fields"
+            description="Select the field(s) you would like to display in the record list table."
+          >
             <Autocomplete
               multiple
               options={fieldOptions}
               value={selectedFields}
               onChange={handleSummaryFieldsChange}
-              getOptionLabel={(option) => option.label}
-              renderInput={(params) => (
+              getOptionLabel={option => option.label}
+              renderInput={params => (
                 <TextField
                   {...params}
-                  label="Summary Fields"
-                  placeholder="Select fields"
+                  InputProps={{
+                    ...params.InputProps,
+                    sx: {'& .MuiInputLabel-root': {display: 'none'}},
+                  }}
                 />
               )}
             />
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Select fields to display in record summaries
-            </Typography>
-          </FormControl>
+          </SettingSection>
+
+          <SettingSection
+            title="Human-Readable ID Field"
+            description="A HRID is a human readable label for the record, which will be displayed in the record table. Select a required string field to use as the human-readable ID. You can use a TemplatedStringField to construct complex HRIDs."
+          >
+            <Autocomplete
+              fullWidth
+              options={hridFieldOptions}
+              value={selectedHridField}
+              onChange={handleHridFieldChange}
+              getOptionLabel={option => option.label}
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  InputProps={{
+                    ...params.InputProps,
+                    sx: {'& .MuiInputLabel-root': {display: 'none'}},
+                  }}
+                />
+              )}
+            />
+          </SettingSection>
         </CardContent>
       </Collapse>
     </Card>

--- a/designer/src/components/section-editor.tsx
+++ b/designer/src/components/section-editor.tsx
@@ -67,8 +67,6 @@ export const SectionEditor = ({
   );
   const dispatch = useAppDispatch();
 
-  console.log('SectionEditor', viewId, viewSet);
-
   const [open, setOpen] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [addMode, setAddMode] = useState(false);
@@ -112,7 +110,6 @@ export const SectionEditor = ({
   };
 
   const conditionChanged = (condition: ConditionType | null) => {
-    console.log('condition changed', condition);
     dispatch({
       type: 'ui-specification/sectionConditionChanged',
       payload: {viewId, condition},

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -402,16 +402,15 @@ const fields: {[key: string]: FieldType} = {
     'component-name': 'TemplatedStringField',
     'type-returned': 'faims-core::String',
     'component-parameters': {
-      label: 'Human Readable ID',
+      label: 'Templated String Field',
       fullWidth: true,
-      name: 'hrid-field',
+      name: 'templated-field',
       helperText: 'Human Readable ID',
       required: true,
       template: ' {{}}',
       InputProps: {
         type: 'text', // must be a valid html type
-      },
-      hrid: true,
+      }
     },
     validationSchema: [['yup.string'], ['yup.required']],
     initialValue: '',

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -410,7 +410,7 @@ const fields: {[key: string]: FieldType} = {
       template: ' {{}}',
       InputProps: {
         type: 'text', // must be a valid html type
-      }
+      },
     },
     validationSchema: [['yup.string'], ['yup.required']],
     initialValue: '',

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -405,7 +405,7 @@ const fields: {[key: string]: FieldType} = {
       label: 'Templated String Field',
       fullWidth: true,
       name: 'templated-field',
-      helperText: 'Human Readable ID',
+      helperText: 'Templated String Field',
       required: true,
       template: ' {{}}',
       InputProps: {

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -408,9 +408,7 @@ const fields: {[key: string]: FieldType} = {
       helperText: 'Templated String Field',
       required: true,
       template: ' {{}}',
-      InputProps: {
-        type: 'text', // must be a valid html type
-      },
+      hidden: true,
     },
     validationSchema: [['yup.string'], ['yup.required']],
     initialValue: '',

--- a/designer/src/notebook-schema.ts
+++ b/designer/src/notebook-schema.ts
@@ -243,7 +243,6 @@ export const schema = {
         variant_style: {type: 'string'},
         html_tag: {type: 'string'},
         content: {type: 'string'},
-        hrid: {type: 'boolean'},
         select: {type: 'boolean'},
         geoTiff: {type: 'string'},
         type: {type: 'string'},

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -31,13 +31,13 @@ export type ComponentParameters = {
   multiline?: boolean;
   multiple?: boolean;
   SelectProps?: unknown;
+  // Hide this field but keep values being updated etc.
+  hidden?: boolean;
   ElementProps?: {
     expandedChecklist?: boolean;
     // These items must correspond to values in the options[]. Only one of such
     // can be selecting, greying out/excluding other options
     exclusiveOptions?: Array<string>;
-    // This option is for TemplateField's to hide them
-    hidden?: boolean;
     options?: {
       value: string;
       label: string;

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -110,6 +110,10 @@ export type NotebookUISpec = {
     [key: string]: {
       views: string[];
       label: string;
+      // New optional settings
+      summary_fields?: string[];
+      layout?: 'inline' | 'tabs';
+      hridField?: string;
     };
   };
   visible_types: string[];

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -36,6 +36,8 @@ export type ComponentParameters = {
     // These items must correspond to values in the options[]. Only one of such
     // can be selecting, greying out/excluding other options
     exclusiveOptions?: Array<string>;
+    // This option is for TemplateField's to hide them
+    hidden?: boolean;
     options?: {
       value: string;
       label: string;

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -63,7 +63,6 @@ export type ComponentParameters = {
   variant_style?: string;
   html_tag?: string;
   content?: string;
-  hrid?: boolean;
   select?: boolean;
   geoTiff?: string;
   type?: string;

--- a/designer/src/state/migrateNotebook.ts
+++ b/designer/src/state/migrateNotebook.ts
@@ -47,6 +47,9 @@ export const migrateNotebook = (notebook: unknown) => {
   // fix bad autoincrementer initial value
   fixAutoIncrementerInitialValue(notebookCopy);
 
+  // fix old hrid format
+  fixOldHridPrefix(notebookCopy);
+
   return notebookCopy;
 };
 
@@ -265,4 +268,43 @@ const fixAutoIncrementerInitialValue = (notebook: Notebook) => {
   }
 
   notebook['ui-specification'].fields = fields;
+};
+
+/**
+ * Move any hrid prefix fields to hridField in the viewset settings.
+ * @param notebook A notebook that might be out of date, modified
+ */
+const fixOldHridPrefix = (notebook: Notebook) => {
+  const fieldToViewset: {[key: string]: string} = {};
+
+  // Build map of fields to their containing viewsets
+  for (const viewsetId of Object.keys(notebook['ui-specification'].viewsets)) {
+    const viewset = notebook['ui-specification'].viewsets[viewsetId];
+    for (const viewId of viewset.views) {
+      const view = notebook['ui-specification'].fviews[viewId];
+      for (const fieldName of view.fields) {
+        fieldToViewset[fieldName] = viewsetId;
+      }
+    }
+  }
+
+  // Process fields, moving HRID fields to viewset settings
+  for (const fieldName of Object.keys(notebook['ui-specification'].fields)) {
+    // Always strip off the hrid true property - this is no longer present
+    const params =
+      notebook['ui-specification'].fields[fieldName]['component-parameters'];
+    if (params && 'hrid' in params) {
+      delete params.hrid;
+    }
+
+    if (fieldName.startsWith('hrid')) {
+      const viewsetName = fieldToViewset[fieldName];
+      if (viewsetName) {
+        notebook['ui-specification'].viewsets[viewsetName].hridField =
+          fieldName;
+      }
+    }
+  }
+
+  return notebook;
 };

--- a/designer/src/state/migrateNotebook.ts
+++ b/designer/src/state/migrateNotebook.ts
@@ -73,7 +73,7 @@ export const validateNotebook = (n: unknown) => {
   const validate = ajv.compile<Notebook>(schema);
 
   const valid = validate(n);
-  console.log('valid', valid);
+  console.log('valid? ', valid);
   if (!valid) {
     if (validate.errors) {
       console.log('Validation Errors:', validate.errors);

--- a/designer/src/state/modifiedStatus-reducer.ts
+++ b/designer/src/state/modifiedStatus-reducer.ts
@@ -39,7 +39,6 @@ const modifiedStatusReducer = createSlice({
   reducers: {
     resetFlag: (_state, action) => {
       const newStatus = action.payload as boolean;
-      console.log('Reached modified reducer ' + newStatus);
       return newStatus;
     },
   },

--- a/designer/src/state/uiSpec-reducer.ts
+++ b/designer/src/state/uiSpec-reducer.ts
@@ -414,6 +414,35 @@ export const uiSpecificationReducer = createSlice({
         state.viewsets[viewSetId].label = label;
       }
     },
+    viewSetSummaryFieldsUpdated: (
+      state,
+      action: PayloadAction<{viewSetId: string; fields: string[]}>
+    ) => {
+      const {viewSetId, fields} = action.payload;
+      if (viewSetId in state.viewsets) {
+        // Update the viewset with the proposed summary fields
+        state.viewsets[viewSetId].summary_fields = fields;
+      }
+    },
+    viewSetLayoutUpdated: (
+      state,
+      action: PayloadAction<{viewSetId: string; layout?: 'inline' | 'tabs'}>
+    ) => {
+      const {viewSetId, layout} = action.payload;
+      if (viewSetId in state.viewsets) {
+        // Update the viewset with the proposed summary fields
+        state.viewsets[viewSetId].layout = layout;
+      }
+    },
+    viewSetHridUpdated: (
+      state,
+      action: PayloadAction<{viewSetId: string; hridField?: string}>
+    ) => {
+      const {viewSetId, hridField} = action.payload;
+      if (viewSetId in state.viewsets) {
+        state.viewsets[viewSetId].hridField = hridField;
+      }
+    },
     formVisibilityUpdated: (
       state,
       action: PayloadAction<{
@@ -455,6 +484,8 @@ export const {
   viewSetMoved,
   viewSetRenamed,
   formVisibilityUpdated,
+  viewSetLayoutUpdated,
+  viewSetSummaryFieldsUpdated,
 } = uiSpecificationReducer.actions;
 
 export default uiSpecificationReducer.reducer;

--- a/designer/src/state/uiSpec-reducer.ts
+++ b/designer/src/state/uiSpec-reducer.ts
@@ -162,21 +162,6 @@ export const uiSpecificationReducer = createSlice({
         newField['component-parameters'].form_id = viewId;
       }
 
-      if (fieldType === 'TemplatedStringField') {
-        // if there is no existing HRID field in this form, then
-        // this field becomes one by getting a name starting 'hrid'
-        let hasHRID = false;
-        for (const fieldName of state.fviews[viewId].fields) {
-          if (fieldName.startsWith('hrid') && fieldName.endsWith(viewId)) {
-            hasHRID = true;
-            break;
-          }
-        }
-        if (!hasHRID) {
-          fieldLabel = 'hrid' + viewId;
-        }
-      }
-
       // add in the meta field
       newField.meta = {
         annotation: {

--- a/designer/src/test-notebook.ts
+++ b/designer/src/test-notebook.ts
@@ -98,7 +98,6 @@ export const sampleNotebook: unknown = {
           InputLabelProps: {
             label: 'Identifier',
           },
-          hrid: true,
         },
         validationSchema: [['yup.string'], ['yup.required']],
         initialValue: '',

--- a/library/data-model/src/data_storage/index.ts
+++ b/library/data-model/src/data_storage/index.ts
@@ -589,7 +589,7 @@ export const hydrateRecord = async (
       type: record.revision.type,
     };
     return result;
-  } catch(e) {
+  } catch (e) {
     throw new Error(
       `Failed to get HRID of record ${record.record_id} revision ${record.revision}. ${e}`
     );

--- a/library/data-model/src/data_storage/index.ts
+++ b/library/data-model/src/data_storage/index.ts
@@ -589,9 +589,9 @@ export const hydrateRecord = async (
       type: record.revision.type,
     };
     return result;
-  } catch {
+  } catch(e) {
     throw new Error(
-      `Failed to get HRID of record ${record.record_id} revision ${record.revision}`
+      `Failed to get HRID of record ${record.record_id} revision ${record.revision}. ${e}`
     );
   }
 };

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -205,7 +205,7 @@ export async function getLatestRevision(
  * getting the HRID for that viewset which is either i) the top level configured
  * hridField for new notebooks or ii) a field starting with hrid...  for the old
  * style. Returns the value of the HRID field, not the field name.
- * 
+ *
  * If null is returned, typically a parent would use the record_id as a backup.
  *
  * @param project_id The project ID for which to ascertain the HRID

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -220,19 +220,24 @@ export async function getHRID(
   // Need to find a way here to determine the correct field name to use - we
   // need the uispec at this point
   const uiSpecification = await getUiSpecForProject({projectId: project_id});
-  const fieldNames = Array.from(Object.keys(revision.avps));
-  const sampleFieldName = fieldNames.length > 0 ? fieldNames[0] : undefined;
+
   let hridFieldName = undefined;
-  if (sampleFieldName) {
-    const {viewSetId} = getIdsByFieldName({
-      uiSpecification,
-      fieldName: sampleFieldName,
-    });
-    // get the HRID for the view set - might not succeed
-    hridFieldName = getHridFieldNameForViewset({
-      uiSpecification,
-      viewSetId,
-    });
+
+  // Only try and use the new hrid method if ui spec is available
+  if (uiSpecification) {
+    const fieldNames = Array.from(Object.keys(revision.avps));
+    const sampleFieldName = fieldNames.length > 0 ? fieldNames[0] : undefined;
+    if (sampleFieldName) {
+      const {viewSetId} = getIdsByFieldName({
+        uiSpecification,
+        fieldName: sampleFieldName,
+      });
+      // get the HRID for the view set - might not succeed
+      hridFieldName = getHridFieldNameForViewset({
+        uiSpecification,
+        viewSetId,
+      });
+    }
   }
 
   // only try the backup if necessary
@@ -339,7 +344,7 @@ export async function listRecordMetadata(
     return out;
   } catch (err) {
     console.log(err);
-    throw Error('failed to get metadata');
+    throw Error(`failed to get metadata. ${err}`);
   }
 }
 

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -198,6 +198,21 @@ export async function getLatestRevision(
   }
 }
 
+/**
+ * Returns the recommended HRID for this record (which is a revision) - this is
+ * achieved by a) get the ui spec for the project b) look at fields in the
+ * revision (via avp keys) c) determine which viewset these fields are in d)
+ * getting the HRID for that viewset which is either i) the top level configured
+ * hridField for new notebooks or ii) a field starting with hrid...  for the old
+ * style. Returns the value of the HRID field, not the field name.
+ * 
+ * If null is returned, typically a parent would use the record_id as a backup.
+ *
+ * @param project_id The project ID for which to ascertain the HRID
+ * @param revision The revision - this reflects a particular version of a
+ * response
+ * @returns The recommended HRID for this revision/record
+ */
 export async function getHRID(
   project_id: ProjectID,
   revision: Revision

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -225,18 +225,29 @@ export async function getHRID(
 
   // Only try and use the new hrid method if ui spec is available
   if (uiSpecification) {
+    // iterate through field names, trying our very best to find one that is
+    // described in the uispec appropriately. Unless the uispec is very broken,
+    // this should succeed.
     const fieldNames = Array.from(Object.keys(revision.avps));
-    const sampleFieldName = fieldNames.length > 0 ? fieldNames[0] : undefined;
-    if (sampleFieldName) {
-      const {viewSetId} = getIdsByFieldName({
-        uiSpecification,
-        fieldName: sampleFieldName,
-      });
-      // get the HRID for the view set - might not succeed
-      hridFieldName = getHridFieldNameForViewset({
-        uiSpecification,
-        viewSetId,
-      });
+    for (const candidateFieldName in fieldNames) {
+      try {
+        const {viewSetId} = getIdsByFieldName({
+          uiSpecification,
+          fieldName: candidateFieldName,
+        });
+        // get the HRID for the view set - might not succeed
+        hridFieldName = getHridFieldNameForViewset({
+          uiSpecification,
+          viewSetId,
+        });
+        if (hridFieldName) {
+          break;
+        }
+      } catch (e) {
+        console.log(
+          `Could not find suitable viewset/HRID for field name: ${candidateFieldName}. Error: ${e}.`
+        );
+      }
     }
   }
 

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -229,7 +229,7 @@ export async function getHRID(
     // described in the uispec appropriately. Unless the uispec is very broken,
     // this should succeed.
     const fieldNames = Array.from(Object.keys(revision.avps));
-    for (const candidateFieldName in fieldNames) {
+    for (const candidateFieldName of fieldNames) {
       try {
         const {viewSetId} = getIdsByFieldName({
           uiSpecification,

--- a/library/data-model/src/data_storage/internals.ts
+++ b/library/data-model/src/data_storage/internals.ts
@@ -193,6 +193,7 @@ export async function getLatestRevision(
   }
 }
 
+// TODO update this
 export async function getHRID(
   project_id: ProjectID,
   revision: Revision

--- a/library/data-model/src/index.ts
+++ b/library/data-model/src/index.ts
@@ -68,6 +68,7 @@ import {
 export * from './auth';
 
 export * from './data_storage/authDB';
+export * from './utils';
 
 export {
   HRID_STRING,

--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -450,14 +450,20 @@ export interface ProjectUIFields {
   [key: string]: any;
 }
 
+export interface ProjectUIViewset {
+  label?: string;
+  views: string[];
+  submit_label?: string;
+  is_visible?: boolean;
+  summary_fields?: Array<string>;
+  // Which field should be used as the hrid?
+  hridField?: string;
+  // Layout option
+  layout?: 'inline' | 'tabs';
+}
+
 export interface ProjectUIViewsets {
-  [type: string]: {
-    label?: string;
-    views: string[];
-    submit_label?: string;
-    is_visible?: boolean;
-    summary_fields?: Array<string>;
-  };
+  [type: string]: ProjectUIViewset;
 }
 
 export interface ConditionalExpression {

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -282,7 +282,7 @@ export async function getUiSpecForProject({
     };
     return uiSpec;
   } catch (err) {
-    console.log('failed to find ui specification for', projectId);
+    //console.log('failed to find ui specification for', projectId);
     return undefined;
   }
 }

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -1,0 +1,252 @@
+import {HRID_STRING} from './datamodel/core';
+import {ProjectUIModel, ProjectUIViewset} from './types';
+
+/**
+ * Retrieves a viewset from the UI specification by its ID
+ * @param {Object} params - The parameters object
+ * @param {ProjectUIModel} params.uiSpecification - The UI specification containing viewsets
+ * @param {string} params.viewSetId - The ID of the viewset to retrieve
+ * @returns {ProjectUIViewset} The requested viewset
+ * @throws {Error} If the viewset ID is not found in the specification
+ */
+export const getViewsetByViewsetId = ({
+  uiSpecification,
+  viewSetId,
+}: {
+  uiSpecification: ProjectUIModel;
+  viewSetId: string;
+}): ProjectUIViewset => {
+  const viewSet = uiSpecification.viewsets[viewSetId];
+  if (!viewSet) {
+    throw new Error(
+      `The viewset ID provided ${viewSetId} is not present in the given ui specification.`
+    );
+  }
+  return viewSet;
+};
+
+/**
+ * Retrieves a view from the UI specification by its ID
+ * @param {Object} params - The parameters object
+ * @param {ProjectUIModel} params.uiSpecification - The UI specification containing views
+ * @param {string} params.viewId - The ID of the view to retrieve
+ * @returns {Object} The requested view
+ * @throws {Error} If the view ID is not found in the specification
+ */
+export const getViewByViewId = ({
+  uiSpecification,
+  viewId,
+}: {
+  uiSpecification: ProjectUIModel;
+  viewId: string;
+}) => {
+  const view = uiSpecification.views[viewId];
+  if (!view) {
+    throw new Error(
+      `The view ID provided ${viewId} is not present in the given ui specification.`
+    );
+  }
+  return view;
+};
+
+/**
+ * Gets the field names associated with a specific view
+ * @param {Object} params - The parameters object
+ * @param params.uiSpecification - The UI specification containing views
+ * @param params.viewId - The ID of the view to get fields from
+ * @returns {string[]} Array of field names in the view
+ */
+export const getFieldNamesForView = ({
+  uiSpecification,
+  viewId,
+}: {
+  uiSpecification: ProjectUIModel;
+  viewId: string;
+}) => {
+  return getViewByViewId({uiSpecification, viewId}).fields;
+};
+
+/**
+ * Gets all field names across all views in a viewset
+ * @param {Object} params - The parameters object
+ * @param {ProjectUIModel} params.uiSpecification - The UI specification containing viewsets
+ * @param {string} params.viewSetId - The ID of the viewset to get fields from
+ * @returns {string[]} Combined array of field names from all views in the viewset
+ */
+export const getFieldNamesForViewset = ({
+  uiSpecification,
+  viewSetId,
+}: {
+  uiSpecification: ProjectUIModel;
+  viewSetId: string;
+}): string[] => {
+  const viewset = getViewsetByViewsetId({uiSpecification, viewSetId});
+  let fieldNames: string[] = [];
+  for (const viewId of viewset.views) {
+    fieldNames = [
+      ...fieldNames,
+      ...getFieldNamesForView({uiSpecification, viewId}),
+    ];
+  }
+  return fieldNames;
+};
+
+/**
+ * Gets the HRID field name for a viewset, either from explicit configuration or
+ * by finding a field that starts with the HRID prefix
+ * @param {Object} params - The parameters object
+ * @param {ProjectUIModel} params.uiSpecification - The UI specification
+ * containing viewsets
+ * @param {string} params.viewSetId - The ID of the viewset to search for HRID
+ * field
+ * @returns {string|undefined} The HRID field name if found, undefined otherwise
+ */
+export const getHridFieldNameForViewset = ({
+  uiSpecification,
+  viewSetId,
+}: {
+  uiSpecification: ProjectUIModel;
+  viewSetId: string;
+}): string | undefined => {
+  // Try and find the viewSet
+  const viewSet = getViewsetByViewsetId({uiSpecification, viewSetId});
+
+  // Then test if we have a specific predefined field name
+  const specificHridField = viewSet.hridField;
+  if (specificHridField) {
+    return specificHridField;
+  }
+
+  // If not, find all visible field names
+  const visibleFieldNames = getFieldNamesForViewset({
+    uiSpecification,
+    viewSetId,
+  });
+
+  // And then find the first matching
+  for (const fieldName of visibleFieldNames) {
+    if (fieldName.startsWith(HRID_STRING)) {
+      return fieldName;
+    }
+  }
+
+  // Otherwise return undefined and allow parent context to handle this issue
+  return undefined;
+};
+
+/**
+ * Finds the view and viewset IDs that contain a specific field by field name
+ * @param {Object} params - The parameters object
+ * @param {ProjectUIModel} params.uiSpecification - The UI specification to search
+ * @param {string} params.fieldName - The field name to locate
+ * @returns {Object} Object containing the matching viewId and viewSetId
+ * @throws {Error} If no view contains the field or if no viewset contains the matching view
+ */
+export const getIdsByFieldName = ({
+  uiSpecification,
+  fieldName,
+}: {
+  uiSpecification: ProjectUIModel;
+  fieldName: string;
+}): {viewId: string; viewSetId: string} => {
+  // Get all views
+  const views = uiSpecification.views;
+
+  // Iterate through and find which view has the specific field
+  let matchingViewId = undefined;
+  for (const viewId of Object.keys(views)) {
+    const fieldNamesForView = getFieldNamesForView({uiSpecification, viewId});
+    if (fieldNamesForView.includes(fieldName)) {
+      matchingViewId = viewId;
+      break;
+    }
+  }
+
+  // Now if we can't find it, throw an error
+  if (!matchingViewId) {
+    throw Error(
+      `Could not find a view which contains the field name ${fieldName}!`
+    );
+  }
+
+  // So we have a matching view - now find which view set it's in
+  let matchingViewSetId = undefined;
+  const viewSets = uiSpecification.viewsets;
+  for (const viewSetId of Object.keys(viewSets)) {
+    // Get the views for this view set
+    const viewSet = viewSets[viewSetId];
+    const views = viewSet.views;
+    if (views.includes(matchingViewId)) {
+      matchingViewSetId = viewSetId;
+      break;
+    }
+  }
+
+  if (!matchingViewSetId) {
+    throw Error(
+      `Could not find a viewset which contains the view with ID ${matchingViewId}!`
+    );
+  }
+
+  return {viewSetId: matchingViewSetId, viewId: matchingViewId};
+};
+
+/**
+ * Creates a mapping of viewset IDs to their corresponding HRID field names
+ * @param {ProjectUIModel} uiSpecification - The UI specification to analyze
+ * @returns {Record<string, string|undefined>} Map of viewset IDs to HRID field names
+ */
+export const getHridFieldMap = (
+  uiSpecification: ProjectUIModel
+): Record<string, string | undefined> => {
+  // Get all viewset IDs from the specification
+  const viewSetIds = Object.keys(uiSpecification.viewsets);
+
+  // Create mapping object
+  const hridFieldMap: Record<string, string | undefined> = {};
+
+  // Iterate through viewsets and get HRID field for each
+  for (const viewSetId of viewSetIds) {
+    const hridField = getHridFieldNameForViewset({
+      uiSpecification,
+      viewSetId,
+    });
+    hridFieldMap[viewSetId] = hridField;
+  }
+
+  return hridFieldMap;
+};
+
+/**
+ * Creates a mapping of field names to their containing view and viewset IDs
+ * @param {ProjectUIModel} uiSpecification - The UI specification to analyze
+ * @returns {Record<string, {viewId: string, viewSetId: string}>} Map of field names to their location IDs
+ */
+export const getFieldToIdsMap = (
+  uiSpecification: ProjectUIModel
+): Record<string, {viewId: string; viewSetId: string}> => {
+  // Initialize the mapping object
+  const fieldMap: Record<string, {viewId: string; viewSetId: string}> = {};
+
+  // Get all viewsets
+  const viewsetIds = Object.keys(uiSpecification.viewsets);
+
+  // For each viewset, get all fields and map them
+  for (const viewSetId of viewsetIds) {
+    const fieldNames = getFieldNamesForViewset({
+      uiSpecification,
+      viewSetId,
+    });
+
+    // For each field, find its view ID and add to map
+    for (const fieldName of fieldNames) {
+      const ids = getIdsByFieldName({
+        uiSpecification,
+        fieldName,
+      });
+      fieldMap[fieldName] = ids;
+    }
+  }
+
+  return fieldMap;
+};

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -260,13 +260,13 @@ export const getFieldToIdsMap = (
 /**
  * Gets the raw ui spec (no compiled conditionals) for the given project ID
  * @param projectId The project ID to fetch the ui spec for
- * @returns The ui specification (without compiled conditionals)
+ * @returns The ui specification (without compiled conditionals) or undefined if unavailable
  */
 export async function getUiSpecForProject({
   projectId,
 }: {
   projectId: ProjectID;
-}): Promise<ProjectUIModel> {
+}): Promise<ProjectUIModel | undefined> {
   try {
     const projdb = await getProjectDB(projectId);
     const encUIInfo: EncodedProjectUIModel = await projdb.get(
@@ -282,7 +282,7 @@ export async function getUiSpecForProject({
     };
     return uiSpec;
   } catch (err) {
-    console.error('failed to find ui specification for', projectId, err);
-    throw Error(`Could not find ui specification for ${projectId}`);
+    console.warn('failed to find ui specification for', projectId);
+    return undefined;
   }
 }

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -157,13 +157,6 @@ export const getIdsByFieldName = ({
 }): {viewId: string; viewSetId: string} => {
   // Get all views
   const views = uiSpecification.views;
-  const pprint = (obj: any) => {
-    console.warn(JSON.stringify(obj, undefined, 2));
-  };
-  console.log('Inputs');
-  pprint({uiSpecification, fieldName});
-  console.log('Views');
-  pprint(views)
 
   // Iterate through and find which view has the specific field
   let matchingViewId = undefined;

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -282,7 +282,7 @@ export async function getUiSpecForProject({
     };
     return uiSpec;
   } catch (err) {
-    console.warn('failed to find ui specification for', projectId);
+    console.log('failed to find ui specification for', projectId);
     return undefined;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -393,6 +393,7 @@
         "lexical": "^0.12.4",
         "lodash": "^4.17.21",
         "mdi-material-ui": "^7.7.0",
+        "mustache": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-json-view-lite": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,7 @@
         "@worker-tools/json-stream": "^0.1.0-pre.12",
         "animate.css": "^4.1.1",
         "assert": "^2.0.0",
+        "base64-arraybuffer": "^1.0.2",
         "buffer": "^6.0.3",
         "clsx": "1.2.1",
         "fast-json-stable-stringify": "2.1.0",
@@ -21790,6 +21791,14 @@
       "dependencies": {
         "b4a": "^1.6.6",
         "streamx": "^2.20.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,7 +1140,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^22.2.0",
-        "aws-cdk": "^2.141.0",
+        "aws-cdk": "^2.177.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
@@ -21103,9 +21103,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.158.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.158.0.tgz",
-      "integrity": "sha512-UcrxBG02RACrnTvfuyZiTuOz8gqOpnqjCMTdVmdpExv5qk9hddhtRAubNaC4xleHuNJnvskYqqVW+Y3Abh6zGQ==",
+      "version": "2.177.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.177.0.tgz",
+      "integrity": "sha512-TiBoyE5wMB5q4jX1bELwkklgbs5eLY1Phjfnb4Mof0K9tOSRJ9UEq6xEamF0esMS+TuYU7a/ESTpmKX3iYqA3w==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,6 @@
         "@worker-tools/json-stream": "^0.1.0-pre.12",
         "animate.css": "^4.1.1",
         "assert": "^2.0.0",
-        "base64-arraybuffer": "^1.0.2",
         "buffer": "^6.0.3",
         "clsx": "1.2.1",
         "fast-json-stable-stringify": "2.1.0",
@@ -21791,14 +21790,6 @@
       "dependencies": {
         "b4a": "^1.6.6",
         "streamx": "^2.20.0"
-      }
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {


### PR DESCRIPTION
# feat: hrid redesign, designer settings, template editor and TemplatedStringField changes

## JIRA Ticket

[BSS-398](https://jira.csiro.au/browse/BSS-398)

## Description

This PR addresses a number of limitations in the existing HRID implementation. Changes included

- implementation of new 'Form settings' module at the top of designer for forms which includes summary fields, layout settings and,
- new `hridField` selection at Form level which allows specific selection of any required text type field as a HRID
- removal of hrid prefix system from designer, and migration for old notebooks to adopt the new style (app is backwards compatible with old hrid prefix fields)
- updates to HRID methods in the app to look for the new HRID first, then fall back to previous logic or `record_id` as the last resort
- upgrades to the TemplatedStringField capability including
  - system context variables including created by and created at which can be injected in the editor and are populated when available at run time
  - (designer) whole new interactive template editor which includes variables, text, if, and unless blocks
  - (designer) template preview capability allowing you to test template resolution with different variable values
- addition of `hidden` prop which allows you to hide a field from display (this is equivalent to a conditionFn excluding it) @stevecassidy this may have implications for export but we can refine this - addition of a panel for designer to toggle this, only enabled on templated string field currently

## How to Test

Test designer by

- creating a text field
- creating a TemplatedStringField which references this field and/or system variables 
- do this manually and using the visual editor - test out the preview
- select this field as the HRID
- test out this works in the app

I'd also check the summary fields - make sure these work + layouts. 

Probably worth checking backwards compatibility with old HRID, and that the migration works - I've tried to test both and seem fine.

## Additional Information

Some corners were cut here, mostly due to the poor implementation quality of the HRID logic and general form record handling. 

i.e. 

- in many places, the fact that hrid was the prefix for the name of the field was heavily depended on in that context to determine which field to use (so I've had to reverse engineer from the ui_spec where available based on the uniqueness of field names between forms)
- the HRID is depended on/used too much in general across the app - there is no need for the HRID to be embedded into the data and depended on, it should be rendered when needed - it is just a transient 'view' over form data which should only be necessary for visualising the data or maybe during export

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
