### PR TITLE
Add horizontal scrolling to sections in the designer

### DIFF
--- a/app/ios/App/App/Info.plist
+++ b/app/ios/App/App/Info.plist
@@ -17,20 +17,20 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.1.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>org.fedarch.faims3</string>
+			<string></string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>org.fedarch.faims3</string>
+				<string></string>
 			</array>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>202501170634</string>
+	<string>202502041522</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/app/ios/App/App/Info.plist
+++ b/app/ios/App/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+
+
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -14,26 +16,26 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string></string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
-	<key>CFBundleVersion</key>
-	<string>202502050754</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<key>LSRequiresIPhoneOS</key>
+ 	<key>CFBundlePackageType</key>
+ 	<string>APPL</string>
+ 	<key>CFBundleShortVersionString</key>
+ 	<string>1.0.4</string>
+ 	<key>CFBundleURLTypes</key>
+ 	<array>
+ 		<dict>
+ 			<key>CFBundleURLName</key>
+ 			<string>org.fedarch.faims3</string>
+ 			<key>CFBundleURLSchemes</key>
+ 			<array>
+ 				<string>org.fedarch.faims3</string>
+ 			</array>
+ 		</dict>
+ 	</array>
+ 	<key>CFBundleVersion</key>
+ 	<string>202501170634</string>
+ 	<key>ITSAppUsesNonExemptEncryption</key>
+ 	<false/>
+ 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>To scan QR codes and to allow you to add photos or videos to your form inputs.</string>

--- a/app/ios/App/App/Info.plist
+++ b/app/ios/App/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>202502041522</string>
+	<string>202502050754</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -171,35 +171,32 @@ export const FieldEditor = ({
               <Chip label="Required" size="small" color="primary" />
             )}
           </Grid>
+
           <Grid
-            container
             item
             xs={12}
             sm={4}
-            alignItems="center"
+            sx={{display: 'flex', alignItems: 'center'}}
             pl={{xs: 0, sm: 1}}
+            zeroMinWidth
           >
-            {field['component-parameters'].helperText &&
-            field['component-parameters'].helperText.length > 60 ? (
-              <Typography
-                variant="body2"
-                fontSize={12}
-                fontWeight={400}
-                fontStyle="italic"
-              >
-                {field['component-parameters'].helperText.substring(0, 59)}...
-              </Typography>
-            ) : (
-              <Typography
-                variant="body2"
-                fontSize={12}
-                fontWeight={400}
-                fontStyle="italic"
-              >
-                {field['component-parameters'].helperText}
-              </Typography>
-            )}
+            <Typography
+              variant="body2"
+              fontSize={12}
+              fontWeight={400}
+              fontStyle="italic"
+              noWrap
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                pr: 4,
+              }}
+            >
+              {field['component-parameters'].helperText}
+            </Typography>
           </Grid>
+
           <Grid item xs={12} sm={3}>
             <Stack direction="row" justifyContent={{sm: 'right', xs: 'left'}}>
               <Tooltip title="Delete Field">
@@ -256,7 +253,11 @@ export const FieldEditor = ({
             <OptionsEditor fieldName={fieldName} />
           )) ||
           (fieldComponent === 'MultiSelect' && (
-            <OptionsEditor fieldName={fieldName} showExpandedChecklist={true} showExclusiveOptions={true}/>
+            <OptionsEditor
+              fieldName={fieldName}
+              showExpandedChecklist={true}
+              showExclusiveOptions={true}
+            />
           )) ||
           (fieldComponent === 'AdvancedSelect' && (
             <AdvancedSelectEditor fieldName={fieldName} />

--- a/designer/src/components/form-editor.tsx
+++ b/designer/src/components/form-editor.tsx
@@ -311,7 +311,6 @@ export const FormEditor = ({
   }, [activeStep, scrollActiveStepIntoView]);
 
   useEffect(() => {
-    // event listener is used to scroll the active step into view when the window is resized.
     window.addEventListener('resize', scrollActiveStepIntoView);
     return () => window.removeEventListener('resize', scrollActiveStepIntoView);
   }, [scrollActiveStepIntoView]);


### PR DESCRIPTION
# feat: Add horizontal scrolling to sections in the designer

## JIRA Ticket
[BSS-681](https://jira.csiro.au/browse/BSS-681)

## Description
This PR improves the designer's _section stepper_ by ensuring sections become scrollable there are too many to fit within the viewport's horizontal width.
Additionally, it:
- Ensures **selected steps stay visible** when the viewport resizes.
- **Shows a gradient indicator at the right edge** when scrolling is possible.

## Proposed Changes
- **Keep the stepper's width** to at least **70% of the screen** until scrolling is necessary.
- **Make sure steps have a minimum spacing** (`120px`).
- **Use `scrollIntoView()`** to keep the active step visible when switching steps or resizing.
- **Add a scroll gradient indicator** when scrolling is possible.

## How to Test
1. Run the designer and open the design tab after loading a template or creating one.
2. **Check behaviour with few sections**:
   - Ensure they are evenly spaced, centred and take up enough space as to not leave the area feeling sparse.
3. **Check scrolling when there are many sections**:
   - Add multiple sections and verify that scrolling is possible.
4. **Test auto-scrolling for selected steps**:
   - Select a section and resize the window → It should remain visible.
5. **Verify the scroll gradient indicator**:
   - If scrolling is possible, a gradient should appear on the right.

## Checklist
- [X] I have confirmed all commits have been signed.
- [X] I have added JSDoc style comments to any new functions or classes.
- [X] Relevant documentation such as READMEs, guides, and class comments are updated.