### PR TITLE
Fix/designer helper text overflow

### DIFF
--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -42,11 +42,10 @@ import {RichTextEditor} from './Fields/RichTextEditor';
 import {TakePhotoFieldEditor} from './Fields/TakePhotoField';
 import {TemplatedStringFieldEditor} from './Fields/TemplatedStringFieldEditor';
 import {TextFieldEditor} from './Fields/TextFieldEditor';
-import HiddenFieldEditor from './Fields/HiddenToggle';
 
 type FieldEditorProps = {
   fieldName: string;
-  viewsetId: string;
+  viewSetId: string;
   viewId: string;
   expanded: boolean;
   addFieldCallback: (fieldName: string) => void;
@@ -56,7 +55,7 @@ type FieldEditorProps = {
 export const FieldEditor = ({
   fieldName,
   viewId,
-  viewsetId,
+  viewSetId,
   expanded,
   addFieldCallback,
   handleExpandChange,
@@ -64,7 +63,6 @@ export const FieldEditor = ({
   const field = useAppSelector(
     state => state.notebook['ui-specification'].fields[fieldName]
   );
-
   const dispatch = useAppDispatch();
 
   const fieldComponent = field['component-name'];
@@ -174,35 +172,32 @@ export const FieldEditor = ({
               <Chip label="Required" size="small" color="primary" />
             )}
           </Grid>
+
           <Grid
-            container
             item
             xs={12}
             sm={4}
-            alignItems="center"
+            sx={{display: 'flex', alignItems: 'center'}}
             pl={{xs: 0, sm: 1}}
+            zeroMinWidth
           >
-            {field['component-parameters'].helperText &&
-            field['component-parameters'].helperText.length > 60 ? (
-              <Typography
-                variant="body2"
-                fontSize={12}
-                fontWeight={400}
-                fontStyle="italic"
-              >
-                {field['component-parameters'].helperText.substring(0, 59)}...
-              </Typography>
-            ) : (
-              <Typography
-                variant="body2"
-                fontSize={12}
-                fontWeight={400}
-                fontStyle="italic"
-              >
-                {field['component-parameters'].helperText}
-              </Typography>
-            )}
+            <Typography
+              variant="body2"
+              fontSize={12}
+              fontWeight={400}
+              fontStyle="italic"
+              noWrap
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                pr: 4,
+              }}
+            >
+              {field['component-parameters'].helperText}
+            </Typography>
           </Grid>
+
           <Grid item xs={12} sm={3}>
             <Stack direction="row" justifyContent={{sm: 'right', xs: 'left'}}>
               <Tooltip title="Delete Field">
@@ -287,14 +282,11 @@ export const FieldEditor = ({
             <BasicAutoIncrementerEditor fieldName={fieldName} viewId={viewId} />
           )) ||
           (fieldComponent === 'TemplatedStringField' && (
-            <>
-              <TemplatedStringFieldEditor
-                fieldName={fieldName}
-                viewId={viewId}
-                viewsetId={viewsetId}
-              />
-              <HiddenFieldEditor fieldName={fieldName} />
-            </>
+            <TemplatedStringFieldEditor
+              fieldName={fieldName}
+              viewId={viewId}
+              viewsetId={viewSetId}
+            />
           )) || <BaseFieldEditor fieldName={fieldName} />}
       </AccordionDetails>
     </Accordion>

--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -139,66 +139,66 @@ export const FieldEditor = ({
         }}
       >
         <Grid container rowGap={1}>
-          <Grid
-            container
-            item
-            xs={12}
-            sm={5}
-            columnGap={1}
-            rowGap={0.5}
-            alignItems="center"
-          >
-            {typeof label === 'string' && label.length > 25 ? (
-              <Typography variant="subtitle2">
-                {label.substring(0, 24)}...
+          <Grid item xs={12} sm={8}>
+            <Stack direction="column" spacing={1} pr={{xs: 0, sm: 2}}>
+              {/* Field Title */}
+              <Typography
+                variant="subtitle2"
+                sx={{
+                  minWidth: 210,
+                  maxWidth: 210,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'normal',
+                }}
+              >
+                {label}
               </Typography>
-            ) : (
-              <Typography variant="subtitle2">{label}</Typography>
-            )}
 
-            <Chip
-              label={fieldComponent}
-              size="small"
-              variant="outlined"
-              sx={{
-                '&.MuiChip-outlined': {
-                  background: '#f9fafb',
-                  color: '#546e7a',
-                  borderColor: '#546e7a',
-                },
-              }}
-            />
-            {field['component-parameters'].required && (
-              <Chip label="Required" size="small" color="primary" />
-            )}
+              {/* Chips Below Title (Tighter Spacing) */}
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                <Chip
+                  label={fieldComponent}
+                  size="small"
+                  variant="outlined"
+                  sx={{
+                    '&.MuiChip-outlined': {
+                      background: '#f9fafb',
+                      color: '#546e7a',
+                      borderColor: '#546e7a',
+                    },
+                  }}
+                />
+
+                {field['component-parameters'].required && (
+                  <Chip label="Required" size="small" color="primary" />
+                )}
+              </Stack>
+
+              {/* Helper Text (More Spacing from Chips) */}
+              <Typography
+                variant="body2"
+                fontSize={12}
+                fontWeight={400}
+                fontStyle="italic"
+                sx={{
+                  mt: 1.5, // Added extra spacing here
+                  display: '-webkit-box',
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {field['component-parameters'].helperText}
+              </Typography>
+            </Stack>
           </Grid>
 
-          <Grid
-            item
-            xs={12}
-            sm={4}
-            sx={{display: 'flex', alignItems: 'center'}}
-            pl={{xs: 0, sm: 1}}
-            zeroMinWidth
-          >
-            <Typography
-              variant="body2"
-              fontSize={12}
-              fontWeight={400}
-              fontStyle="italic"
-              noWrap
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                pr: 4,
-              }}
-            >
-              {field['component-parameters'].helperText}
-            </Typography>
-          </Grid>
-
-          <Grid item xs={12} sm={3}>
+          <Grid item xs={12} sm={4}>
             <Stack direction="row" justifyContent={{sm: 'right', xs: 'left'}}>
               <Tooltip title="Delete Field">
                 <IconButton

--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -18,30 +18,31 @@ import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRound
 import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-    Chip,
-    Grid,
-    IconButton,
-    Stack,
-    Tooltip,
-    Typography,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Chip,
+  Grid,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
 } from '@mui/material';
-import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { AdvancedSelectEditor } from './Fields/AdvancedSelectEditor';
-import { BaseFieldEditor } from './Fields/BaseFieldEditor';
-import { BasicAutoIncrementerEditor } from './Fields/BasicAutoIncrementer';
-import { DateTimeNowEditor } from './Fields/DateTimeNowEditor';
-import { MapFormFieldEditor } from './Fields/MapFormFieldEditor';
-import { MultipleTextFieldEditor } from './Fields/MultipleTextField';
-import { OptionsEditor } from './Fields/OptionsEditor';
-import { RandomStyleEditor } from './Fields/RandomStyleEditor';
-import { RelatedRecordEditor } from './Fields/RelatedRecordEditor';
-import { RichTextEditor } from './Fields/RichTextEditor';
-import { TakePhotoFieldEditor } from './Fields/TakePhotoField';
-import { TemplatedStringFieldEditor } from './Fields/TemplatedStringFieldEditor';
-import { TextFieldEditor } from './Fields/TextFieldEditor';
+import {useAppDispatch, useAppSelector} from '../state/hooks';
+import {AdvancedSelectEditor} from './Fields/AdvancedSelectEditor';
+import {BaseFieldEditor} from './Fields/BaseFieldEditor';
+import {BasicAutoIncrementerEditor} from './Fields/BasicAutoIncrementer';
+import {DateTimeNowEditor} from './Fields/DateTimeNowEditor';
+import HiddenFieldEditor from './Fields/HiddenToggle';
+import {MapFormFieldEditor} from './Fields/MapFormFieldEditor';
+import {MultipleTextFieldEditor} from './Fields/MultipleTextField';
+import {OptionsEditor} from './Fields/OptionsEditor';
+import {RandomStyleEditor} from './Fields/RandomStyleEditor';
+import {RelatedRecordEditor} from './Fields/RelatedRecordEditor';
+import {RichTextEditor} from './Fields/RichTextEditor';
+import {TakePhotoFieldEditor} from './Fields/TakePhotoField';
+import {TemplatedStringFieldEditor} from './Fields/TemplatedStringFieldEditor';
+import {TextFieldEditor} from './Fields/TextFieldEditor';
 
 type FieldEditorProps = {
   fieldName: string;
@@ -138,7 +139,7 @@ export const FieldEditor = ({
           },
         }}
       >
-        <Grid container rowGap={1}>
+        <Grid container rowGap={1} alignItems={'center'}>
           <Grid item xs={12} sm={8}>
             <Stack direction="column" spacing={1} pr={{xs: 0, sm: 2}}>
               {/* Field Title */}
@@ -179,22 +180,24 @@ export const FieldEditor = ({
               </Stack>
 
               {/* Helper Text (More Spacing from Chips) */}
-              <Typography
-                variant="body2"
-                fontSize={12}
-                fontWeight={400}
-                fontStyle="italic"
-                sx={{
-                  mt: 1.5, // Added extra spacing here
-                  display: '-webkit-box',
-                  WebkitLineClamp: 3,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {field['component-parameters'].helperText}
-              </Typography>
+              {field['component-parameters'].helperText && (
+                <Typography
+                  variant="body2"
+                  fontSize={12}
+                  fontWeight={400}
+                  fontStyle="italic"
+                  sx={{
+                    mt: 1.5, // Added extra spacing here
+                    display: '-webkit-box',
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {field['component-parameters'].helperText}
+                </Typography>
+              )}
             </Stack>
           </Grid>
 
@@ -282,11 +285,14 @@ export const FieldEditor = ({
             <BasicAutoIncrementerEditor fieldName={fieldName} viewId={viewId} />
           )) ||
           (fieldComponent === 'TemplatedStringField' && (
-            <TemplatedStringFieldEditor
-              fieldName={fieldName}
-              viewId={viewId}
-              viewsetId={viewSetId}
-            />
+            <>
+              <TemplatedStringFieldEditor
+                fieldName={fieldName}
+                viewId={viewId}
+                viewsetId={viewSetId}
+              />
+              <HiddenFieldEditor fieldName={fieldName} />
+            </>
           )) || <BaseFieldEditor fieldName={fieldName} />}
       </AccordionDetails>
     </Accordion>

--- a/designer/src/components/field-list.tsx
+++ b/designer/src/components/field-list.tsx
@@ -40,8 +40,6 @@ type Props = {
 };
 
 export const FieldList = ({viewSetId, viewId}: Props) => {
-  console.log('FieldList', viewSetId, viewId);
-
   const fView = useAppSelector(
     state => state.notebook['ui-specification'].fviews[viewId]
   );
@@ -65,7 +63,6 @@ export const FieldList = ({viewSetId, viewId}: Props) => {
   };
 
   const addFieldAfterCallback = (fieldName: string) => {
-    console.log('adding a field after', fieldName);
     setAddAfterField(fieldName);
     setDialogOpen(true);
   };

--- a/designer/src/components/field-list.tsx
+++ b/designer/src/components/field-list.tsx
@@ -39,7 +39,9 @@ type Props = {
   viewId: string;
 };
 
-export const FieldList = ({viewSetId: viewsetId, viewId}: Props) => {
+export const FieldList = ({viewSetId, viewId}: Props) => {
+  console.log('FieldList', viewSetId, viewId);
+
   const fView = useAppSelector(
     state => state.notebook['ui-specification'].fviews[viewId]
   );
@@ -63,6 +65,7 @@ export const FieldList = ({viewSetId: viewsetId, viewId}: Props) => {
   };
 
   const addFieldAfterCallback = (fieldName: string) => {
+    console.log('adding a field after', fieldName);
     setAddAfterField(fieldName);
     setDialogOpen(true);
   };
@@ -74,7 +77,7 @@ export const FieldList = ({viewSetId: viewsetId, viewId}: Props) => {
         fieldName: dialogState.name,
         fieldType: dialogState.type,
         viewId: viewId,
-        viewSetId: viewsetId,
+        viewSetId: viewSetId,
         addAfter: addAfterField,
       },
     });
@@ -104,6 +107,23 @@ export const FieldList = ({viewSetId: viewsetId, viewId}: Props) => {
     // section, so reset all fields to be closed
     setIsExpanded(allClosed);
   }, [fView.label]);
+
+  // can't do this with another useEffect because it might fire before
+  // or after the other one, it then opens up random fields
+  //
+  // useEffect(() => {
+  //   // if fViews.fields changes we check if there is a new
+  //   // field (just added) and open it up
+  //   fView.fields.forEach((fieldName: string) => {
+  //     console.log('checking', fieldName, isExpanded[fieldName]);
+  //     if (isExpanded[fieldName] === undefined) {
+  //       setIsExpanded({
+  //         ...isExpanded,
+  //         [fieldName]: true,
+  //       });
+  //     }
+  //   });
+  // }, [fView.fields]);
 
   const handleExpandChange = (fieldName: string) => {
     return (_event: React.SyntheticEvent, expanded: boolean) => {
@@ -158,7 +178,7 @@ export const FieldList = ({viewSetId: viewsetId, viewId}: Props) => {
           <FieldEditor
             key={fieldName}
             fieldName={fieldName}
-            viewsetId={viewsetId}
+            viewSetId={viewSetId}
             viewId={viewId}
             expanded={isExpanded[fieldName] ?? false}
             addFieldCallback={addFieldAfterCallback}


### PR DESCRIPTION
# Fix/designer helper text overflow

## Description

Wasn't assigned this, so feel free not to approve. But:  I wanted to quickly fix the field header UI issues when the window is too narrow or the helper text is too long. This change does increase field header height which may not be ideal over a more adaptive  approach, but for now I think it is a good fix.

## Proposed Changes

UI tweaks in the field header:
- The chips and helper text now appear below the field title, I don't know if this looks _as good_ but I think it looks fine, and gives us a lot more width.
- This resolves overlapping between the action buttons and helper text.

## How to Test

- Load a template in the designer, open design tab.
- Resize the window, ensuring the elements in the field headers do not overlap or generally look bad.
- Modify helper text, making sure that the helper text is not allowed to take uo more than 3 lines.

## Checklist

- [X] I have confirmed all commits have been signed.
- [X] I have added JSDoc style comments to any new functions or classes.
- [X] Relevant documentation such as READMEs, guides, and class comments are updated.
