### PR TITLE
fix: my vs other record listing, pouch, sync, drafts

### DIFF
--- a/api/.env.dist
+++ b/api/.env.dist
@@ -46,3 +46,9 @@ GOOGLE_CLIENT_SECRET=replace-me
 # You will need to generate these
 FAIMS_COOKIE_SECRET=output of `uuidgen` or similar
 
+# Refresh expires in (2 days)
+REFRESH_TOKEN_EXPIRY_MINUTES=2880
+
+# Access expires in 5 minutes
+ACCESS_TOKEN_EXPIRY_MINUTES=5
+

--- a/app/src/context/slices/authSlice.ts
+++ b/app/src/context/slices/authSlice.ts
@@ -153,9 +153,7 @@ const authSlice = createSlice({
         state.activeUser.parsedToken = parsedToken;
       }
 
-      console.log('Checking is authenticated');
       state.isAuthenticated = checkAuthenticationStatus(state);
-      console.log('True/false, ', state.isAuthenticated);
     },
 
     setActiveUser: (state, action: PayloadAction<ServerUserIdentity>) => {
@@ -418,7 +416,6 @@ export const refreshToken = createAsyncThunk<
         refreshToken: connection.refreshToken,
       })
     );
-    console.log('Token refresh request successful');
   } catch (error) {
     console.warn('Token refresh failed:', error);
   }
@@ -432,8 +429,6 @@ export const refreshActiveUser = createAsyncThunk<void, void>(
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async (_, {dispatch, getState}) => {
-    console.log('Initiating active user token refresh.');
-
     // cast and get state
     const state = getState() as RootState;
     const appDispatch = dispatch as AppDispatch;
@@ -465,8 +460,6 @@ export const refreshAllUsers = createAsyncThunk<void, void>(
   'auth/refreshAll',
   // eslint-disable-next-line no-unused-vars
   async (_, {dispatch, getState}) => {
-    console.log('Initiating all user token refresh.');
-
     // cast and get state
     const state = getState() as RootState;
     const appDispatch = dispatch as AppDispatch;

--- a/app/src/drafts.ts
+++ b/app/src/drafts.ts
@@ -19,38 +19,7 @@
  */
 
 import {ProjectID, RecordID} from '@faims3/data-model';
-import {draft_db, listDraftMetadata} from './sync/draft-storage';
-import {DraftMetadataList} from '@faims3/data-model';
-import {logError} from './logging';
-
-export function listenDrafts(
-  project_id: ProjectID,
-  filter: 'updates' | 'created' | 'all',
-  callback: (draftList: DraftMetadataList) => unknown
-): () => void {
-  const runCallback = () =>
-    listDraftMetadata(project_id, filter)
-      .then(callback)
-      .catch(err => logError(err)); // 'Uncaught draft list error'
-
-  const changes = draft_db
-    .changes({
-      since: 'now',
-      include_docs: true,
-      live: true,
-    })
-    .on('change', info => {
-      console.log('change in drafts database', info);
-      if (info.doc!.project_id === project_id) {
-        runCallback();
-      }
-    })
-    .on('error', err => logError(err)); // 'Uncaught draft list error'
-
-  runCallback();
-
-  return changes.cancel.bind(changes);
-}
+import {draft_db} from './sync/draft-storage';
 
 export async function deleteDraftsForRecord(
   project_id: ProjectID,

--- a/app/src/gui/components/notebook/datagrid_toolbar.tsx
+++ b/app/src/gui/components/notebook/datagrid_toolbar.tsx
@@ -80,6 +80,12 @@ export function GridToolbarSearchRecordDataButton(props: ToolbarProps) {
     }
   }, [value]);
 
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      handleSubmit();
+    }
+  };
+
   return (
     <Box
       component={Paper}
@@ -97,6 +103,7 @@ export function GridToolbarSearchRecordDataButton(props: ToolbarProps) {
             placeholder="Search record data (case sensitive)"
             value={value}
             onChange={handleChange}
+            onKeyDown={handleKeyPress}
             variant="outlined"
             size="small"
             fullWidth

--- a/app/src/gui/components/notebook/draft_tab_badge.tsx
+++ b/app/src/gui/components/notebook/draft_tab_badge.tsx
@@ -1,39 +1,19 @@
-import React, {useEffect} from 'react';
 import {Badge, CircularProgress} from '@mui/material';
-import {listenDrafts} from '../../../drafts';
-import _ from 'lodash';
-import {ProjectID} from '@faims3/data-model';
 
-export default function DraftTabBadge(props: {project_id: ProjectID}) {
-  const {project_id} = props;
-  const [draftCount, setDraftCount] = React.useState(0);
-  const [isLoading, setLoading] = React.useState(true);
-
-  useEffect(() => {
-    //  Dependency is only the project_id, ie., register one callback for this component
-    // on load - if the record list is updated, the callback should be fired
-    if (project_id === undefined) return; //dummy project
-    const destroyListener = listenDrafts(
-      project_id,
-      'all',
-      newPouchRecordList => {
-        setLoading(false);
-        if (!_.isEqual(Object.values(newPouchRecordList).length, draftCount)) {
-          setDraftCount(Object.values(newPouchRecordList).length);
-        }
-      }
-    );
-
-    return destroyListener; // destroyListener called when this component unmounts.
-  }, [project_id, draftCount]);
-
+export default function DraftTabBadge({
+  count,
+  loading,
+}: {
+  count: number;
+  loading: boolean;
+}) {
   return (
     <Badge
       badgeContent={
-        isLoading ? (
+        loading ? (
           <CircularProgress size={10} sx={{color: 'white'}} thickness={6} />
         ) : (
-          draftCount
+          count
         )
       }
       color="primary"

--- a/app/src/gui/components/notebook/draft_table.tsx
+++ b/app/src/gui/components/notebook/draft_table.tsx
@@ -18,6 +18,7 @@
  *   TODO need to check created draft route
  */
 
+import {DraftMetadata, ProjectID, ProjectUIViewsets} from '@faims3/data-model';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import {Box, Grid, Link, Paper, Typography} from '@mui/material';
 import {useTheme} from '@mui/material/styles';
@@ -25,20 +26,9 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import {DataGrid, GridCellParams, GridEventListener} from '@mui/x-data-grid';
 import React from 'react';
 import {useNavigate} from 'react-router-dom';
-
-import {DraftMetadata, ProjectID, ProjectUIViewsets} from '@faims3/data-model';
 import * as ROUTES from '../../../constants/routes';
 import {NotebookDraftDataGridToolbar} from './datagrid_toolbar';
 import RecordDelete from './delete';
-
-type DraftsTableProps = {
-  project_id: ProjectID;
-  maxRows: number | null;
-  viewsets?: ProjectUIViewsets | null;
-  handleRefresh: () => void;
-  drafts: DraftMetadata[];
-  loading: boolean;
-};
 
 type DraftsRecordProps = {
   project_id: ProjectID;

--- a/app/src/gui/components/notebook/draft_table.tsx
+++ b/app/src/gui/components/notebook/draft_table.tsx
@@ -49,9 +49,8 @@ type DraftsRecordProps = {
   handleRefresh: () => void;
 };
 
-function DraftRecord(props: DraftsRecordProps) {
+export function DraftsTable(props: DraftsRecordProps) {
   const {project_id, maxRows, rows, loading} = props;
-  console.log('DraftRecord rows', rows);
   const theme = useTheme();
   const history = useNavigate();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
@@ -275,19 +274,3 @@ function DraftRecord(props: DraftsRecordProps) {
     </React.Fragment>
   );
 }
-export default function DraftsTable(props: DraftsTableProps) {
-  const {project_id, maxRows} = props;
-  return (
-    <DraftRecord
-      project_id={project_id}
-      maxRows={maxRows}
-      rows={props.drafts}
-      loading={props.loading}
-      viewsets={props.viewsets}
-      handleRefresh={props.handleRefresh}
-    />
-  );
-}
-DraftsTable.defaultProps = {
-  maxRows: null,
-};

--- a/app/src/gui/components/notebook/draft_table.tsx
+++ b/app/src/gui/components/notebook/draft_table.tsx
@@ -18,19 +18,16 @@
  *   TODO need to check created draft route
  */
 
-import React, {useEffect, useState} from 'react';
-import _ from 'lodash';
-import {DataGrid, GridCellParams, GridEventListener} from '@mui/x-data-grid';
-import {Typography, Box, Paper, Grid, Link} from '@mui/material';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
-import {useNavigate} from 'react-router-dom';
+import {Box, Grid, Link, Paper, Typography} from '@mui/material';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import {DataGrid, GridCellParams, GridEventListener} from '@mui/x-data-grid';
+import React from 'react';
+import {useNavigate} from 'react-router-dom';
 
-import {ProjectID, DraftMetadata} from '@faims3/data-model';
+import {DraftMetadata, ProjectID, ProjectUIViewsets} from '@faims3/data-model';
 import * as ROUTES from '../../../constants/routes';
-import {listenDrafts} from '../../../drafts';
-import {ProjectUIViewsets} from '@faims3/data-model';
 import {NotebookDraftDataGridToolbar} from './datagrid_toolbar';
 import RecordDelete from './delete';
 
@@ -39,6 +36,8 @@ type DraftsTableProps = {
   maxRows: number | null;
   viewsets?: ProjectUIViewsets | null;
   handleRefresh: () => void;
+  drafts: DraftMetadata[];
+  loading: boolean;
 };
 
 type DraftsRecordProps = {
@@ -52,6 +51,7 @@ type DraftsRecordProps = {
 
 function DraftRecord(props: DraftsRecordProps) {
   const {project_id, maxRows, rows, loading} = props;
+  console.log('DraftRecord rows', rows);
   const theme = useTheme();
   const history = useNavigate();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
@@ -277,34 +277,12 @@ function DraftRecord(props: DraftsRecordProps) {
 }
 export default function DraftsTable(props: DraftsTableProps) {
   const {project_id, maxRows} = props;
-  const [loading, setLoading] = useState(true);
-
-  const [rows, setRows] = useState<Array<DraftMetadata>>([]);
-
-  useEffect(() => {
-    //  Dependency is only the project_id, ie., register one callback for this component
-    // on load - if the record list is updated, the callback should be fired
-    if (project_id === undefined) return; //dummy project
-    const destroyListener = listenDrafts(
-      project_id,
-      'all',
-      newPouchRecordList => {
-        setLoading(false);
-        if (!_.isEqual(Object.values(newPouchRecordList), rows)) {
-          setRows(Object.values(newPouchRecordList));
-        }
-      }
-    );
-
-    return destroyListener; // destroyListener called when this component unmounts.
-  }, [project_id, rows]);
-
   return (
     <DraftRecord
       project_id={project_id}
       maxRows={maxRows}
-      rows={rows}
-      loading={loading}
+      rows={props.drafts}
+      loading={props.loading}
       viewsets={props.viewsets}
       handleRefresh={props.handleRefresh}
     />

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -40,7 +40,7 @@ import MetadataRenderer from '../metadataRenderer';
 import CircularLoading from '../ui/circular_loading';
 import AddRecordButtons from './add_record_by_type';
 import DraftTabBadge from './draft_tab_badge';
-import DraftsTable from './draft_table';
+import {DraftsTable} from './draft_table';
 import {OverviewMap} from './overview_map';
 import RangeHeader from './range_header';
 import {RecordsTable} from './record_table';
@@ -152,6 +152,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
     projectId: project.project_id,
     filter: 'all',
   });
+  const forceDraftRefresh = drafts.refetch;
 
   /**
    * Handles the change event when the user switches between the Records and Drafts tabs.
@@ -406,10 +407,10 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                 <DraftsTable
                   project_id={project.project_id}
                   maxRows={25}
-                  drafts={drafts.data ?? []}
+                  rows={drafts.data ?? []}
                   loading={drafts.isLoading}
                   viewsets={viewsets}
-                  handleRefresh={handleRefresh}
+                  handleRefresh={forceDraftRefresh}
                 />
               </TabPanel>
             </Box>

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -131,7 +131,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
     setParam('tab', INDEX_TO_TAB.get(val) ?? 'records');
   };
 
-  const [recordDraftTabValue, setRecordDraftTabValue] = React.useState(0);
+  const [tabIndex, setTabIndex] = React.useState<0 | 1 | 2>(0);
   const [totalRecords, setTotalRecords] = useState(0);
   const [myRecords, setMyRecords] = useState(0);
   /**
@@ -140,11 +140,11 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
    * @param {React.SyntheticEvent} event - The event triggered by the tab change.
    * @param {number} newValue - The index of the selected tab.
    */
-  const handleRecordDraftTabChange = (
-    event: React.SyntheticEvent,
-    newValue: number
+  const handleTabChange = (
+    _event: React.SyntheticEvent,
+    newValue: 0 | 1 | 2
   ) => {
-    setRecordDraftTabValue(newValue);
+    setTabIndex(newValue);
   };
 
   /**
@@ -338,19 +338,19 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
             <Box mt={2}>
               <Box mb={1}>
                 <Tabs
-                  value={recordDraftTabValue}
-                  onChange={handleRecordDraftTabChange}
+                  value={tabIndex}
+                  onChange={handleTabChange}
                   aria-label={`${NOTEBOOK_NAME}-records`}
                   sx={{
                     backgroundColor: theme.palette.background.tabsBackground,
                   }}
                 >
                   <Tab
-                    label={`My ${recordLabel}s`}
+                    label={`My ${recordLabel}s (${myRecords})`}
                     {...a11yProps(0, `${NOTEBOOK_NAME}-records`)}
                   />
                   <Tab
-                    label={`All ${recordLabel}s`}
+                    label={`All ${recordLabel}s (${totalRecords})`}
                     {...a11yProps(1, `${NOTEBOOK_NAME}-records`)}
                   />
                   <Tab
@@ -359,12 +359,9 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                   />
                 </Tabs>
               </Box>
-              <TabPanel
-                value={recordDraftTabValue}
-                index={0}
-                id={'records-drafts-'}
-              >
+              <TabPanel value={tabIndex} index={0} id={'records-mine'}>
                 <RecordsBrowseTable
+                  key={'myrecordstable'}
                   project_id={project.project_id}
                   maxRows={25}
                   viewsets={viewsets}
@@ -372,14 +369,13 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                   handleRefresh={handleRefresh}
                   onRecordsCountChange={handleCountChange}
                   recordLabel={recordLabel}
+                  // Just my records
+                  myRecordsOnly={true}
                 />
               </TabPanel>
-              <TabPanel
-                value={recordDraftTabValue}
-                index={1}
-                id={'records-drafts-'}
-              >
+              <TabPanel value={tabIndex} index={1} id={'records-all'}>
                 <RecordsBrowseTable
+                  key={'allrecordstable'}
                   project_id={project.project_id}
                   maxRows={25}
                   viewsets={viewsets}
@@ -387,13 +383,11 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                   handleRefresh={handleRefresh}
                   onRecordsCountChange={handleCountChange}
                   recordLabel={recordLabel}
+                  // Everyone's records
+                  myRecordsOnly={false}
                 />
               </TabPanel>
-              <TabPanel
-                value={recordDraftTabValue}
-                index={2}
-                id={'records-drafts-'}
-              >
+              <TabPanel value={tabIndex} index={2} id={'record-drafts'}>
                 <DraftsTable
                   project_id={project.project_id}
                   maxRows={25}

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -31,7 +31,11 @@ import * as ROUTES from '../../../constants/routes';
 import {getMetadataValue} from '../../../sync/metadata';
 import {ProjectExtended} from '../../../types/project';
 import {getUiSpecForProject} from '../../../uiSpecification';
-import {useQueryParams} from '../../../utils/customHooks';
+import {
+  useDraftsList,
+  useQueryParams,
+  useRecordList,
+} from '../../../utils/customHooks';
 import MetadataRenderer from '../metadataRenderer';
 import CircularLoading from '../ui/circular_loading';
 import AddRecordButtons from './add_record_by_type';
@@ -39,7 +43,7 @@ import DraftTabBadge from './draft_tab_badge';
 import DraftsTable from './draft_table';
 import {OverviewMap} from './overview_map';
 import RangeHeader from './range_header';
-import {RecordsBrowseTable} from './record_table';
+import {RecordsTable} from './record_table';
 import NotebookSettings from './settings';
 
 // Define how tabs appear in the query string arguments, providing a two way map
@@ -132,8 +136,23 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
   };
 
   const [tabIndex, setTabIndex] = React.useState<0 | 1 | 2>(0);
-  const [totalRecords, setTotalRecords] = useState(0);
-  const [myRecords, setMyRecords] = useState(0);
+
+  // Fetch records from the (local) DB with 10 second auto refetch
+  const [query, setQuery] = useState<string>('');
+  const records = useRecordList({
+    query: query,
+    projectId: project.project_id,
+    filterDeleted: true,
+    // refetch every 10 seconds (local only fetch - no network traffic here)
+    refreshIntervalMs: 10000,
+  });
+
+  // Fetch drafts
+  const drafts = useDraftsList({
+    projectId: project.project_id,
+    filter: 'all',
+  });
+
   /**
    * Handles the change event when the user switches between the Records and Drafts tabs.
    *
@@ -223,12 +242,6 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
   // record or draft was deleted)
   const handleRefresh = () => {
     pageLoader();
-  };
-
-  // Callback to handle counts from RecordsTable
-  const handleCountChange = (counts: {total: number; myRecords: number}) => {
-    setTotalRecords(counts.total);
-    setMyRecords(counts.myRecords);
   };
 
   return (
@@ -321,11 +334,12 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
               }}
             >
               <Typography variant="body2" sx={{fontSize: '1.1rem'}}>
-                <strong>My {recordLabel}s:</strong> {myRecords}
+                <strong>My {recordLabel}s:</strong> {records.myRecords.length}
               </Typography>
 
               <Typography variant="body2" sx={{fontSize: '1.1rem'}}>
-                <strong>Total {recordLabel}s:</strong> {totalRecords}
+                <strong>Other {recordLabel}s:</strong>{' '}
+                {records.otherRecords.length}
               </Typography>
             </Box>
           )}
@@ -346,51 +360,54 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                   }}
                 >
                   <Tab
-                    label={`My ${recordLabel}s (${myRecords})`}
-                    {...a11yProps(0, `${NOTEBOOK_NAME}-records`)}
+                    label={`My ${recordLabel}s (${records.myRecords.length})`}
+                    {...a11yProps(0, `${NOTEBOOK_NAME}-myrecords`)}
                   />
                   <Tab
-                    label={`All ${recordLabel}s (${totalRecords})`}
-                    {...a11yProps(1, `${NOTEBOOK_NAME}-records`)}
+                    label={`Other ${recordLabel}s (${records.otherRecords.length})`}
+                    {...a11yProps(1, `${NOTEBOOK_NAME}-otherrecords`)}
                   />
                   <Tab
-                    label={<DraftTabBadge project_id={project.project_id} />}
-                    {...a11yProps(1, `${NOTEBOOK_NAME}-records`)}
+                    label={
+                      <DraftTabBadge
+                        loading={drafts.isLoading}
+                        count={drafts.data?.length ?? 0}
+                      />
+                    }
+                    {...a11yProps(2, `${NOTEBOOK_NAME}-drafts`)}
                   />
                 </Tabs>
               </Box>
               <TabPanel value={tabIndex} index={0} id={'records-mine'}>
-                <RecordsBrowseTable
-                  key={'myrecordstable'}
+                <RecordsTable
                   project_id={project.project_id}
                   maxRows={25}
+                  rows={records.myRecords}
+                  loading={records.query.isLoading}
                   viewsets={viewsets}
-                  filter_deleted={true}
+                  handleQueryFunction={setQuery}
                   handleRefresh={handleRefresh}
-                  onRecordsCountChange={handleCountChange}
                   recordLabel={recordLabel}
-                  // Just my records
-                  myRecordsOnly={true}
                 />
               </TabPanel>
               <TabPanel value={tabIndex} index={1} id={'records-all'}>
-                <RecordsBrowseTable
-                  key={'allrecordstable'}
+                <RecordsTable
                   project_id={project.project_id}
                   maxRows={25}
+                  rows={records.otherRecords}
+                  loading={records.query.isLoading}
                   viewsets={viewsets}
-                  filter_deleted={true}
+                  handleQueryFunction={setQuery}
                   handleRefresh={handleRefresh}
-                  onRecordsCountChange={handleCountChange}
                   recordLabel={recordLabel}
-                  // Everyone's records
-                  myRecordsOnly={false}
                 />
               </TabPanel>
               <TabPanel value={tabIndex} index={2} id={'record-drafts'}>
                 <DraftsTable
                   project_id={project.project_id}
                   maxRows={25}
+                  drafts={drafts.data ?? []}
+                  loading={drafts.isLoading}
                   viewsets={viewsets}
                   handleRefresh={handleRefresh}
                 />

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -19,27 +19,27 @@
  */
 
 import {
-    ProjectID,
-    ProjectUIModel,
-    ProjectUIViewsets,
-    RecordMetadata,
+  ProjectID,
+  ProjectUIModel,
+  ProjectUIViewsets,
+  RecordMetadata,
 } from '@faims3/data-model';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import { Alert, Box, Grid, Link, Paper, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import {Alert, Box, Grid, Link, Paper, Typography} from '@mui/material';
+import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { DataGrid, GridCellParams, GridEventListener } from '@mui/x-data-grid';
-import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import {DataGrid, GridCellParams, GridEventListener} from '@mui/x-data-grid';
+import React, {useEffect, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
 import {
-    getFieldLabel,
-    getSummaryFields,
-    getUiSpecForProject,
-    getVisibleTypes,
+  getFieldLabel,
+  getSummaryFields,
+  getUiSpecForProject,
+  getVisibleTypes,
 } from '../../../uiSpecification';
 import getLocalDate from '../../fields/LocalDate';
-import { NotebookDataGridToolbar } from './datagrid_toolbar';
+import {NotebookDataGridToolbar} from './datagrid_toolbar';
 import RecordDelete from './delete';
 
 /**
@@ -64,7 +64,6 @@ type RecordsTableProps = {
   handleRefresh: () => void;
   recordLabel: string;
 };
-
 
 /**
  * Component to render the records in a DataGrid table.

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -19,30 +19,27 @@
  */
 
 import {
-  ProjectID,
-  ProjectUIModel,
-  ProjectUIViewsets,
-  RecordMetadata,
+    ProjectID,
+    ProjectUIModel,
+    ProjectUIViewsets,
+    RecordMetadata,
 } from '@faims3/data-model';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import {Alert, Box, Grid, Link, Paper, Typography} from '@mui/material';
-import {useTheme} from '@mui/material/styles';
+import { Alert, Box, Grid, Link, Paper, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import {DataGrid, GridCellParams, GridEventListener} from '@mui/x-data-grid';
-import React, {useEffect, useState} from 'react';
-import {useNavigate} from 'react-router-dom';
+import { DataGrid, GridCellParams, GridEventListener } from '@mui/x-data-grid';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
-import {selectActiveUser} from '../../../context/slices/authSlice';
-import {useAppSelector} from '../../../context/store';
 import {
-  getFieldLabel,
-  getSummaryFields,
-  getUiSpecForProject,
-  getVisibleTypes,
+    getFieldLabel,
+    getSummaryFields,
+    getUiSpecForProject,
+    getVisibleTypes,
 } from '../../../uiSpecification';
-import {useRecordList} from '../../../utils/customHooks';
 import getLocalDate from '../../fields/LocalDate';
-import {NotebookDataGridToolbar} from './datagrid_toolbar';
+import { NotebookDataGridToolbar } from './datagrid_toolbar';
 import RecordDelete from './delete';
 
 /**
@@ -68,18 +65,6 @@ type RecordsTableProps = {
   recordLabel: string;
 };
 
-type RecordsBrowseTableProps = {
-  project_id: ProjectID;
-  maxRows: number | null;
-  viewsets?: ProjectUIViewsets | null;
-  filter_deleted: boolean;
-  handleRefresh: () => void;
-  onRecordsCountChange?: (counts: {total: number; myRecords: number}) => void;
-  recordLabel: string;
-  // If true, then only show active user records, else, show all that the user
-  // has permission to see
-  myRecordsOnly: boolean;
-};
 
 /**
  * Component to render the records in a DataGrid table.
@@ -87,10 +72,8 @@ type RecordsBrowseTableProps = {
  * @param {RecordsTableProps} props - The properties passed to the RecordsTable.
  * @returns {JSX.Element} The rendered DataGrid with record metadata.
  */
-function RecordsTable(props: RecordsTableProps) {
+export function RecordsTable(props: RecordsTableProps) {
   const {project_id, maxRows, rows, loading} = props;
-  const activeUser = useAppSelector(selectActiveUser);
-
   const theme = useTheme();
   const history = useNavigate();
 
@@ -513,48 +496,3 @@ function RecordsTable(props: RecordsTableProps) {
     </React.Fragment>
   );
 }
-
-/**
- * Component to handle browsing records and querying with search.
- *
- * @param {RecordsBrowseTableProps} props - The properties passed to RecordsBrowseTable.
- * @returns {JSX.Element} The rendered table for browsing records.
- */
-export function RecordsBrowseTable(props: RecordsBrowseTableProps) {
-  const {recordLabel} = props;
-  const [query, setQuery] = React.useState('');
-
-  // Fetch records from the (local) DB with 10 second auto refetch
-  const records = useRecordList({
-    query: query,
-    projectId: props.project_id,
-    filterDeleted: props.filter_deleted,
-    // refetch every 10 seconds (local only fetch - no network traffic here)
-    refreshIntervalMs: 10000,
-  });
-
-  // Update counts when the unfiltered or filtered list is updated
-  useEffect(() => {
-    props.onRecordsCountChange?.({
-      total: records.allRecords.length,
-      myRecords: records.myRecords.length,
-    });
-  }, [records.allRecords.length, records.myRecords.length]);
-
-  return (
-    <RecordsTable
-      project_id={props.project_id}
-      maxRows={props.maxRows}
-      // Show the appropriate list depending on filter
-      rows={props.myRecordsOnly ? records.myRecords : records.allRecords}
-      loading={records.query.isLoading}
-      viewsets={props.viewsets}
-      handleQueryFunction={setQuery}
-      handleRefresh={props.handleRefresh}
-      recordLabel={recordLabel}
-    />
-  );
-}
-RecordsBrowseTable.defaultProps = {
-  maxRows: null,
-};

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -23,9 +23,6 @@ import {
   ProjectUIModel,
   ProjectUIViewsets,
   RecordMetadata,
-  TokenContents,
-  getMetadataForAllRecords,
-  getRecordsWithRegex,
 } from '@faims3/data-model';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {Alert, Box, Grid, Link, Paper, Typography} from '@mui/material';
@@ -35,18 +32,18 @@ import {DataGrid, GridCellParams, GridEventListener} from '@mui/x-data-grid';
 import React, {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
-import {NotebookDataGridToolbar} from './datagrid_toolbar';
-import RecordDelete from './delete';
-import getLocalDate from '../../fields/LocalDate';
-import {useQuery} from '@tanstack/react-query';
+import {selectActiveUser} from '../../../context/slices/authSlice';
+import {useAppSelector} from '../../../context/store';
 import {
   getFieldLabel,
   getSummaryFields,
   getUiSpecForProject,
   getVisibleTypes,
 } from '../../../uiSpecification';
-import {useAppSelector} from '../../../context/store';
-import {selectActiveUser} from '../../../context/slices/authSlice';
+import {useRecordList} from '../../../utils/customHooks';
+import getLocalDate from '../../fields/LocalDate';
+import {NotebookDataGridToolbar} from './datagrid_toolbar';
+import RecordDelete from './delete';
 
 /**
  * Props for the RecordsTable component
@@ -68,7 +65,6 @@ type RecordsTableProps = {
   viewsets?: ProjectUIViewsets | null;
   handleQueryFunction: Function;
   handleRefresh: () => void;
-  onRecordsCountChange?: (counts: {total: number; myRecords: number}) => void;
   recordLabel: string;
 };
 
@@ -80,6 +76,9 @@ type RecordsBrowseTableProps = {
   handleRefresh: () => void;
   onRecordsCountChange?: (counts: {total: number; myRecords: number}) => void;
   recordLabel: string;
+  // If true, then only show active user records, else, show all that the user
+  // has permission to see
+  myRecordsOnly: boolean;
 };
 
 /**
@@ -89,7 +88,7 @@ type RecordsBrowseTableProps = {
  * @returns {JSX.Element} The rendered DataGrid with record metadata.
  */
 function RecordsTable(props: RecordsTableProps) {
-  const {project_id, maxRows, rows, loading, onRecordsCountChange} = props;
+  const {project_id, maxRows, rows, loading} = props;
   const activeUser = useAppSelector(selectActiveUser);
 
   const theme = useTheme();
@@ -155,16 +154,6 @@ function RecordsTable(props: RecordsTableProps) {
       ? (props.viewsets[params.row.type.toString()].label ?? params.row.type)
       : params.row.type;
   }
-
-  /**
-   * Counts the records filtering by current user
-   * @param records The list of records
-   * @returns Count filtered by  current user
-   */
-  const getUserRecordCount = (records: RecordMetadata[]) => {
-    return records.filter(record => record.created_by === activeUser?.username)
-      .length;
-  };
 
   const rowTypeColumn = {
     field: 'type',
@@ -382,21 +371,6 @@ function RecordsTable(props: RecordsTableProps) {
 
   columns.push(deleteColumn);
 
-  useEffect(() => {
-    if (!visible_rows || visible_rows.length === 0) {
-      if (onRecordsCountChange) onRecordsCountChange({total: 0, myRecords: 0});
-      return;
-    }
-
-    const totalRecords = visible_rows.length;
-    const myRecords = activeUser ? getUserRecordCount(visible_rows) : 0;
-
-    // Send count to parent with callback  - onRecordsCountChangee
-    if (onRecordsCountChange) {
-      onRecordsCountChange({total: totalRecords, myRecords});
-    }
-  }, [rows, activeUser, onRecordsCountChange]);
-
   return (
     <React.Fragment>
       <Box
@@ -541,25 +515,6 @@ function RecordsTable(props: RecordsTableProps) {
 }
 
 /**
- * Filters out draft records from the dataset.
- *
- * Draft records are identified by the prefix `drf-` in their `record_id`.
- */
-const filterOutDrafts = (rows: RecordMetadata[]) => {
-  return rows.filter(record => !record.record_id.startsWith('drf-'));
-};
-
-/**
- * Filters records to include only thosse created by the active user.
- *
- * @param rows - The dataset of records.
- * @param username - The active user's username.
- */
-const filterByActiveUser = (rows: RecordMetadata[], username: string) => {
-  return rows.filter(record => record.created_by === username);
-};
-
-/**
  * Component to handle browsing records and querying with search.
  *
  * @param {RecordsBrowseTableProps} props - The properties passed to RecordsBrowseTable.
@@ -567,55 +522,35 @@ const filterByActiveUser = (rows: RecordMetadata[], username: string) => {
  */
 export function RecordsBrowseTable(props: RecordsBrowseTableProps) {
   const {recordLabel} = props;
-  // TODO validate this is always defined
-  const activeUser = useAppSelector(selectActiveUser);
-  const activeToken = activeUser?.parsedToken as TokenContents;
-
   const [query, setQuery] = React.useState('');
 
-  const {data: records, isLoading: recordsLoading} = useQuery({
-    queryKey: ['allrecords', query, props.project_id, activeUser?.username],
-    networkMode: 'always',
-    gcTime: 0,
-    queryFn: async () => {
-      let rows;
-
-      if (query.length === 0) {
-        rows = await getMetadataForAllRecords(
-          activeToken,
-          props.project_id,
-          props.filter_deleted
-        );
-      } else {
-        rows = await getRecordsWithRegex(
-          activeToken,
-          props.project_id,
-          query,
-          props.filter_deleted
-        );
-      }
-
-      // filterr drafts based on `drf-` prefix
-      const filteredRows = filterOutDrafts(rows);
-
-      // filterrecords created by the active user
-      if (activeUser) {
-        return filterByActiveUser(filteredRows, activeUser.username);
-      }
-
-      return filteredRows;
-    },
+  // Fetch records from the (local) DB with 10 second auto refetch
+  const records = useRecordList({
+    query: query,
+    projectId: props.project_id,
+    filterDeleted: props.filter_deleted,
+    // refetch every 10 seconds (local only fetch - no network traffic here)
+    refreshIntervalMs: 10000,
   });
+
+  // Update counts when the unfiltered or filtered list is updated
+  useEffect(() => {
+    props.onRecordsCountChange?.({
+      total: records.allRecords.length,
+      myRecords: records.myRecords.length,
+    });
+  }, [records.allRecords.length, records.myRecords.length]);
+
   return (
     <RecordsTable
       project_id={props.project_id}
       maxRows={props.maxRows}
-      rows={records}
-      loading={recordsLoading}
+      // Show the appropriate list depending on filter
+      rows={props.myRecordsOnly ? records.myRecords : records.allRecords}
+      loading={records.query.isLoading}
       viewsets={props.viewsets}
       handleQueryFunction={setQuery}
       handleRefresh={props.handleRefresh}
-      onRecordsCountChange={props.onRecordsCountChange}
       recordLabel={recordLabel}
     />
   );

--- a/app/src/sync/connection.ts
+++ b/app/src/sync/connection.ts
@@ -112,34 +112,34 @@ export function ping_sync_denied() {
 
 /**
  * Creates a local PouchDB.Database used to access a remote Couch/Pouch instance
- * @param connection_info Network address/database info to use to initialize the connection
+ * @param connectionInfo Network address/database info to use to initialize the connection
  * @returns A new PouchDB.Database, interfacing to the remote Couch/Pouch instance
  */
-export function ConnectionInfo_create_pouch<Content extends {}>(
-  connection_info: ConnectionInfo
+export function createPouchDbFromConnectionInfo<Content extends {}>(
+  connectionInfo: ConnectionInfo
 ): PouchDB.Database<Content> {
   const pouch_options: PouchDB.Configuration.RemoteDatabaseConfiguration = {
     skip_setup: true,
   };
 
   // Username & password auth is optional
-  if ('auth' in connection_info && connection_info.auth !== undefined) {
+  if ('auth' in connectionInfo && connectionInfo.auth !== undefined) {
     pouch_options.auth = {
-      username: connection_info.auth.username,
-      password: connection_info.auth.password,
+      username: connectionInfo.auth.username,
+      password: connectionInfo.auth.password,
     };
   }
   // TODO: Use a new enough pouchdb such that we don't need the fetch hook, see
   // https://github.com/pouchdb/pouchdb/issues/8387
   pouch_options.fetch = function (url: any, opts: any) {
     if (
-      'jwt_token' in connection_info &&
-      connection_info.jwt_token !== undefined
+      'jwt_token' in connectionInfo &&
+      connectionInfo.jwt_token !== undefined
     ) {
       // if (DEBUG_APP) {
       //   console.debug('Using JWT for connection', connection_info);
       // }
-      opts.headers.set('Authorization', `Bearer ${connection_info.jwt_token}`);
+      opts.headers.set('Authorization', `Bearer ${connectionInfo.jwt_token}`);
     }
     throttled_ping_sync_up();
     throttled_ping_sync_down();
@@ -150,19 +150,19 @@ export function ConnectionInfo_create_pouch<Content extends {}>(
   };
   let db_url: string;
   // if we have a base_url configured, make the connection url from that
-  if (connection_info.base_url) {
-    if (connection_info.base_url.endsWith('/'))
-      db_url = connection_info.base_url + connection_info.db_name;
-    else db_url = connection_info.base_url + '/' + connection_info.db_name;
+  if (connectionInfo.base_url) {
+    if (connectionInfo.base_url.endsWith('/'))
+      db_url = connectionInfo.base_url + connectionInfo.db_name;
+    else db_url = connectionInfo.base_url + '/' + connectionInfo.db_name;
   } else {
     db_url =
-      encodeURIComponent(connection_info.proto || 'http') +
+      encodeURIComponent(connectionInfo.proto || 'http') +
       '://' +
-      encodeURIComponent(connection_info.host || 'localhost') +
+      encodeURIComponent(connectionInfo.host || 'localhost') +
       ':' +
-      encodeURIComponent(connection_info.port || '5984') +
+      encodeURIComponent(connectionInfo.port || '5984') +
       '/' +
-      encodeURIComponent(connection_info.db_name);
+      encodeURIComponent(connectionInfo.db_name);
   }
 
   return new PouchDB(db_url, pouch_options);

--- a/app/src/sync/databases.ts
+++ b/app/src/sync/databases.ts
@@ -311,7 +311,7 @@ function hasMatchingConnection<Content extends {}>(
  * Creates a new synchronisation (PouchDB.sync) between the specified local and
  * remote DB. This uses the preferred sync options to avoid misconfiguration in
  * caller functions. Two way sync is always enabled, with live and retry. If
- * attachment filter is supplied, the pull sync options are overrided with a
+ * attachment filter is supplied, the pull sync options are overridden with a
  * filter.
  *
  * @param attachmentDownload Download attachments iff true

--- a/app/src/sync/databases.ts
+++ b/app/src/sync/databases.ts
@@ -341,7 +341,16 @@ export function createPouchDbSync<Content extends {}>({
     // Retry on fail
     retry: true,
     // Back off reasonably slowly
-    back_off_function: (delay: number) => delay * 1.5,
+    back_off_function: (delay: number) => {
+      // initial delay is zero
+      if (delay === 0) {
+        // initially 1500ms
+        return 1500;
+      } else {
+        // then 1.5x after that
+        return delay * 1.5;
+      }
+    },
     // Timeout after 15 seconds
     timeout: 15000,
     // Sync batch sizing options

--- a/app/src/sync/databases.ts
+++ b/app/src/sync/databases.ts
@@ -32,7 +32,7 @@ import {db as projects_db} from '../dbs/projects-db';
 import {logError} from '../logging';
 import {
   ConnectionInfo,
-  ConnectionInfo_create_pouch,
+  createPouchDbFromConnectionInfo,
   local_pouch_options,
 } from './connection';
 import {draft_db} from './draft-storage';
@@ -157,32 +157,38 @@ export const metadata_dbs: LocalDBList<ProjectMetaObject> = {};
 
 /**
  * @param prefix Name to use to run new PouchDB(prefix + POUCH_SEPARATOR + id), objects of the same type have the same prefix
- * @param local_db_id id is per-object of type, to discriminate between them. i.e. a project ID
- * @param global_dbs projects_db
+ * @param localDbId id is per-object of type, to discriminate between them. i.e. a project ID
+ * @param globalDbs projects_db
  * @returns Flag if newly created =true, already existing=false & The local DB
  */
-export function ensure_local_db<Content extends {}>(
-  prefix: string,
-  local_db_id: string,
-  start_sync: boolean,
-  global_dbs: LocalDBList<Content>,
-  start_sync_attachments: boolean
-): [boolean, LocalDB<Content>] {
-  if (global_dbs[local_db_id]) {
-    global_dbs[local_db_id].is_sync = start_sync;
-    return [false, global_dbs[local_db_id]];
+export function ensureLocalDb<Content extends {}>({
+  prefix,
+  localDbId,
+  initiateSync,
+  globalDbs,
+  startSyncAttachments,
+}: {
+  prefix: string;
+  localDbId: string;
+  initiateSync: boolean;
+  globalDbs: LocalDBList<Content>;
+  startSyncAttachments: boolean;
+}): [boolean, LocalDB<Content>] {
+  if (globalDbs[localDbId]) {
+    globalDbs[localDbId].is_sync = initiateSync;
+    return [false, globalDbs[localDbId]];
   } else {
     const db = new PouchDB<Content>(
-      prefix + POUCH_SEPARATOR + local_db_id,
+      prefix + POUCH_SEPARATOR + localDbId,
       local_pouch_options
     );
     return [
       true,
-      (global_dbs[local_db_id] = {
+      (globalDbs[localDbId] = {
         local: db,
         changes: db.changes(default_changes_opts),
-        is_sync: start_sync,
-        is_sync_attachments: start_sync_attachments,
+        is_sync: initiateSync,
+        is_sync_attachments: startSyncAttachments,
         remote: null,
       }),
     ];
@@ -190,144 +196,183 @@ export function ensure_local_db<Content extends {}>(
 }
 
 /**
- * @param local_db_id id is per-object of type, to discriminate between them. i.e. a project ID
- * @param global_dbs projects_db
- * @param connection_info Info to use to connect to remote
- * @param options PouchDB options. Defaults to live: true, retry: true.
- *                if options.sync is defined, then this turns into ensuring the DB
- *                is pushing to the remote as well as pulling.
- * @returns Flag if newly created =true, already existing=false & The local DB & remote
+ * Manages synchronization between local and remote PouchDB databases.
+ *
+ * This function ensures proper synchronization between a local database and its
+ * remote counterpart by:
+ *
+ * 1. Validating the local database exists
+ * 2. Maintaining existing sync if configuration hasn't changed
+ * 3. Creating new sync connections when needed
+ * 4. Cleaning up old resources (sync and pouch DBs)
+ *
+ * NOTE: this method will write the updates to the global DB
+ *
+ * @param localDbId - Identifier for the local database
+ * @param connectionInfo - Remote connection configuration (null for local-only DBs)
+ * @param globalDbs - Registry of all local databases
+ * @returns [boolean, LocalDB<Content>] - [true if new sync created, updated database info]
+ * @throws Error if local database is not initialized
  */
-export function ensure_synced_db<Content extends {}>(
-  local_db_id: string,
-  connection_info: ConnectionInfo | null,
-  global_dbs: LocalDBList<Content>,
-  options: DBReplicateOptions = {}
-): [boolean, LocalDB<Content>] {
-  if (global_dbs[local_db_id] === undefined) {
-    throw 'Logic error: ensure_local_db must be called before this code';
+export function createUpdateAndSavePouchSync<Content extends {}>({
+  localDbId,
+  connectionInfo,
+  globalDbs,
+}: {
+  localDbId: string;
+  connectionInfo: ConnectionInfo | null;
+  globalDbs: LocalDBList<Content>;
+}): [boolean, LocalDB<Content>] {
+  // Verify local database exists
+  const localDb = globalDbs[localDbId];
+  if (!localDb) {
+    throw new Error(
+      'Local database must be initialized before creating sync connection'
+    );
   }
 
-  // Already connected/connecting, or local-only database
-
-  // This checks for a diff so as to not unnecessarily recreate synced
-  // connections without any changes
-  if (
-    global_dbs[local_db_id].remote !== null &&
-    JSON.stringify(global_dbs[local_db_id].remote!.info) ===
-      JSON.stringify(connection_info) &&
-    JSON.stringify(global_dbs[local_db_id].remote!.options) ===
-      JSON.stringify(options)
-  ) {
-    return [
-      false,
-      {
-        ...global_dbs[local_db_id],
-        remote: global_dbs[local_db_id].remote!,
-      },
-    ];
+  // Handle local-only databases (no remote connection needed)
+  if (connectionInfo === null) {
+    return [false, localDb];
   }
 
-  // Special case for local-only projects
-  if (connection_info === null) {
-    return [false, global_dbs[local_db_id]];
+  // Check if existing remote connection matches new configuration
+  if (hasMatchingConnection(localDb.remote, connectionInfo)) {
+    return [false, localDb];
   }
 
-  const db_info = (global_dbs[local_db_id] = {
-    ...global_dbs[local_db_id],
-    remote: {
-      db: ConnectionInfo_create_pouch(connection_info),
-      connection: null, //Connection initialized in setLocalConnection
-      info: connection_info,
-      options: options,
-    },
+  // Helper function to stop existing connection
+  const cleanupPouchState = (db: LocalDB<Content>) => {
+    // First remove any sync
+    if (db.remote?.connection) {
+      console.log('Closing existing sync connection');
+      // Remove all listeners
+      db.remote.connection.removeAllListeners();
+      // Cancel the connection
+      db.remote.connection.cancel();
+      // Set it to null
+      db.remote.connection = null;
+    }
+
+    // And if the db itself is still there, clean it up too
+    if (db.remote?.db) {
+      console.log('Closing existing remote DB');
+      db.remote.db.close();
+    }
+  };
+
+  // cleanup the old PouchDB object and the related sync
+  cleanupPouchState(localDb);
+
+  // Create updated database configuration with new remote connection and new
+  // PouchDB object
+  const newDb = createPouchDbFromConnectionInfo<Content>(connectionInfo);
+  const {sync: newSync, options} = createPouchDbSync({
+    attachmentDownload: localDb.is_sync,
+    localDb: localDb.local,
+    remoteDb: newDb,
   });
 
-  setLocalConnection(db_info);
-  return [true, db_info];
+  const updatedDb = {
+    ...localDb,
+    remote: {
+      db: newDb,
+      connection: newSync,
+      info: connectionInfo,
+      options,
+    },
+  };
+
+  // Update the global DB as specified
+  globalDbs[localDbId] = updatedDb;
+
+  // Return those details
+  return [true, updatedDb];
 }
 
 /**
- * If the given remote DB is not synced, starts syncing, and visa versa.
- * db_info.remote.{connection, handler} are modified based on what's in
- * db_info.is_sync, db_info.remote.info, db_info.remote.create_handler.
- *
- * This does NOT ensure that the existing connection info (URL, port, proto)
- * matches anything. that's left to ensure_synced_db
- *
- * @param db_info info to use to create a DB connection:
- *                Remote connection info, is_sync, the local DB to sync with,
+ * Determines if an existing remote connection matches new connection parameters
+ * by comparing their serialized configurations.
  */
-export function setLocalConnection<Content extends {}>(
-  db_info: LocalDB<Content> & {remote: LocalDBRemote<Content>}
-) {
-  const options = db_info.remote.options;
-
-  if (db_info.is_sync) {
-    if (db_info.remote.connection !== null) {
-      // Stop an existing connection
-      db_info.remote.connection.cancel();
-      db_info.remote.connection = null;
-      console.debug('Removed sync for', db_info);
-    }
-    // Start a new connection
-    const push_too = (options as {push?: unknown}).push !== undefined;
-    let connection:
-      | PouchDB.Replication.Replication<Content>
-      | PouchDB.Replication.Sync<Content>;
-
-    const pull_filter = db_info.is_sync_attachments
-      ? {}
-      : {filter: '_view', view: 'attachment_filter/attachment_filter'};
-
-    if (push_too) {
-      const options_sync = options as PouchDB.Replication.SyncOptions;
-      console.debug(
-        'Pushing and pulling from',
-        db_info,
-        options_sync.push,
-        options_sync.pull,
-        pull_filter
-      );
-      connection = PouchDB.sync(db_info.local, db_info.remote.db, {
-        push: {
-          live: true,
-          retry: true,
-          checkpoint: 'source',
-          batch_size: POUCH_BATCH_SIZE,
-          batches_limit: POUCH_BATCHES_LIMIT,
-          ...options_sync.push,
-        },
-        pull: {
-          live: true,
-          retry: true,
-          checkpoint: 'target',
-          batch_size: POUCH_BATCH_SIZE,
-          batches_limit: POUCH_BATCHES_LIMIT,
-          ...pull_filter,
-          ...(options_sync.pull || {}),
-        },
-      });
-    } else {
-      console.debug('Pulling only from', db_info, options);
-      connection = PouchDB.replicate(db_info.remote.db, db_info.local, {
-        live: true,
-        retry: true,
-        checkpoint: 'target',
-        ...options,
-      });
-    }
-
-    db_info.remote.connection = connection;
-    console.debug('Added sync for', db_info);
-  } else if (!db_info.is_sync && db_info.remote.connection !== null) {
-    // Stop an existing connection
-    db_info.remote.connection.cancel();
-    db_info.remote.connection = null;
-    console.debug('Removed sync for', db_info);
-  } else {
-    logError(`Sync is still off ${db_info}`);
+function hasMatchingConnection<Content extends {}>(
+  existingRemote: LocalDBRemote<Content> | null,
+  newConnectionInfo: ConnectionInfo
+): boolean {
+  if (!existingRemote) {
+    return false;
   }
+
+  return (
+    JSON.stringify(existingRemote.info) === JSON.stringify(newConnectionInfo)
+  );
+}
+
+/**
+ * Creates a new synchronisation (PouchDB.sync) between the specified local and
+ * remote DB. This uses the preferred sync options to avoid misconfiguration in
+ * caller functions. Two way sync is always enabled, with live and retry. If
+ * attachment filter is supplied, the pull sync options are overrided with a
+ * filter.
+ *
+ * @param attachmentDownload Download attachments iff true
+ * @param localDb The local DB to sync
+ * @param remoteDb The remote DB to sync
+ *
+ * @returns sync The new sync object
+ * @returns options The sync options used (since parent caller likes to know)
+ */
+export function createPouchDbSync<Content extends {}>({
+  attachmentDownload,
+  localDb,
+  remoteDb,
+}: {
+  attachmentDownload: boolean;
+  localDb: PouchDB.Database<Content>;
+  remoteDb: PouchDB.Database<Content>;
+}) {
+  // Configure attachment filtering if needed
+  const pullFilter = attachmentDownload
+    ? {}
+    : {filter: '_view', view: 'attachment_filter/attachment_filter'};
+
+  const options: DBReplicateOptions = {
+    // Live sync mode (i.e. poll)
+    live: true,
+    // Retry on fail
+    retry: true,
+    // Back off reasonably slowly
+    back_off_function: (delay: number) => delay * 1.5,
+    // Timeout after 15 seconds
+    timeout: 15000,
+    // Sync batch sizing options
+    batch_size: POUCH_BATCH_SIZE,
+    batches_limit: POUCH_BATCHES_LIMIT,
+    // Push and pull specific options
+    push: {
+      checkpoint: 'source',
+    },
+    pull: {
+      checkpoint: 'target',
+      ...pullFilter,
+    },
+  };
+
+  return {
+    options,
+    sync: PouchDB.sync(localDb, remoteDb, options)
+      .on('error', err => {
+        console.warn('❌ Sync error occurred:', {
+          error: err,
+          dbName: localDb.name,
+        });
+      })
+      .on('denied', err => {
+        console.warn('🚫 Sync access denied:', {
+          error: err,
+          dbName: localDb.name,
+        });
+      }),
+  };
 }
 
 async function delete_synced_db(name: string, db: LocalDB<any>) {
@@ -404,16 +449,24 @@ export async function refreshDataDbTokens({
     // This is server/project combinations
     const {listing_id} = record;
 
+    // Only consider this server's DBs
     if (listing_id !== serverId) {
       continue;
     }
 
+    // This is the database ID
     const dbKey = record._id;
 
     // Get the associated data DB for this active db
     const db = data_dbs[dbKey];
 
     if (!db.remote) {
+      console.error(
+        "Couldn't get remote for db with key ",
+        dbKey,
+        'More details about the DB that was found',
+        db
+      );
       continue;
     }
 
@@ -423,7 +476,11 @@ export async function refreshDataDbTokens({
       jwt_token: newToken,
     };
 
-    // run the synced db operation which will update the
-    ensure_synced_db(dbKey, newConnectionInfo, data_dbs);
+    // run the synced db operation which will update the token
+    createUpdateAndSavePouchSync({
+      localDbId: dbKey,
+      connectionInfo: newConnectionInfo,
+      globalDbs: data_dbs,
+    });
   }
 }

--- a/app/src/sync/databases.ts
+++ b/app/src/sync/databases.ts
@@ -340,7 +340,8 @@ export function createPouchDbSync<Content extends {}>({
     live: true,
     // Retry on fail
     retry: true,
-    // Back off reasonably slowly
+    // Back off reasonably slowly (okay with default for now)
+    /*
     back_off_function: (delay: number) => {
       // initial delay is zero
       if (delay === 0) {
@@ -351,6 +352,7 @@ export function createPouchDbSync<Content extends {}>({
         return delay * 1.5;
       }
     },
+    */
     // Timeout after 15 seconds
     timeout: 15000,
     // Sync batch sizing options

--- a/app/src/sync/index.ts
+++ b/app/src/sync/index.ts
@@ -99,7 +99,7 @@ export async function getDataDB(
   if (active_id in data_dbs) {
     return data_dbs[active_id].local;
   } else {
-    throw `Data DB of project ${active_id} is not known`;
+    throw `Data DB of project ${active_id} is not known. Current DBs available = ${Object.keys(data_dbs)}`;
   }
 }
 

--- a/app/src/sync/process-initialization.ts
+++ b/app/src/sync/process-initialization.ts
@@ -33,7 +33,7 @@ import {
   ExistingActiveDoc,
   active_db,
   directory_db,
-  ensure_local_db,
+  ensureLocalDb,
   projects_dbs,
 } from './databases';
 import {events} from './events';
@@ -177,13 +177,13 @@ async function get_projects_from_conductor(listing: ListingsObject) {
 
   // make sure there is a local projects database
   // projects_did_change is true if this made a new database
-  const [projects_did_change, projects_local] = ensure_local_db(
-    'projects',
-    listing.id,
-    true,
-    projects_dbs,
-    true
-  );
+  const [projects_did_change, projects_local] = ensureLocalDb({
+    prefix: 'projects',
+    localDbId: listing.id,
+    initiateSync: true,
+    globalDbs: projects_dbs,
+    startSyncAttachments: true,
+  });
 
   const previous_listing = getListing(listing.id);
   addOrUpdateListing(listing.id, listing, projects_local);

--- a/app/src/sync/projects.ts
+++ b/app/src/sync/projects.ts
@@ -385,7 +385,6 @@ export async function ensure_project_databases(
     connectionInfo: data_connection_info,
     globalDbs: data_dbs,
   });
-  console.log('Global state after update', data_dbs[active_id]);
 
   if (data_remote.remote !== null && data_remote.remote.connection !== null) {
     data_remote.remote.connection!.once('paused', data_pause());

--- a/app/src/sync/sync-toggle.ts
+++ b/app/src/sync/sync-toggle.ts
@@ -21,103 +21,15 @@
  */
 
 import {ProjectID} from '@faims3/data-model';
-import {ProjectDataObject} from '@faims3/data-model';
 import {logError} from '../logging';
 import {
   active_db,
+  createUpdateAndSavePouchSync,
   data_dbs,
   ExistingActiveDoc,
-  LocalDB,
-  LocalDBRemote,
-  setLocalConnection,
 } from './databases';
 import {events} from './events';
 import {getProject} from './projects';
-import {NOTEBOOK_NAME} from '../buildconfig';
-
-export function listenSyncingProject(
-  active_id: ProjectID,
-  callback: (syncing: boolean) => unknown
-): () => void {
-  const project_update_cb = (
-    _type: unknown,
-    _mc: unknown,
-    _dc: unknown,
-    active: ExistingActiveDoc
-  ) => {
-    if (active._id === active_id) {
-      callback(active.is_sync);
-    }
-  };
-  events.on('project_update', project_update_cb);
-  return events.removeListener.bind(
-    events,
-    'project_update',
-    project_update_cb
-  );
-}
-
-export function isSyncingProject(active_id: ProjectID): boolean {
-  return data_dbs[active_id]!.is_sync;
-}
-
-export async function setSyncingProject(
-  active_id: ProjectID,
-  syncing: boolean
-) {
-  if (syncing === isSyncingProject(active_id)) {
-    logError(`Did not change sync for project ${active_id}`);
-    return; //Nothing to do, already same value
-  }
-  console.info('Change sync for project', active_id, syncing);
-  const data_db = data_dbs[active_id];
-  data_db.is_sync = syncing;
-
-  const has_remote = (
-    db: typeof data_db
-  ): db is LocalDB<ProjectDataObject> & {
-    remote: LocalDBRemote<ProjectDataObject>;
-  } => {
-    return db.remote !== null;
-  };
-
-  if (has_remote(data_db)) {
-    setLocalConnection(data_db);
-  } else {
-    console.log('project is local only');
-  }
-
-  try {
-    const active_doc = await active_db.get(active_id);
-    active_doc.is_sync = syncing;
-    await active_db.put(active_doc);
-  } catch (err) {
-    logError(err);
-    throw Error(
-      `Could not change sync for this ${NOTEBOOK_NAME} (${active_id}). Contact Support.`
-    );
-  }
-
-  const created = await getProject(active_id);
-
-  events.emit(
-    'project_update',
-    [
-      'update',
-      {
-        ...created,
-        active: {
-          ...created.active,
-          is_sync: !syncing,
-        },
-      },
-    ],
-    false,
-    false,
-    created.active,
-    created.project
-  );
-}
 
 export function listenSyncingProjectAttachments(
   active_id: ProjectID,
@@ -153,22 +65,20 @@ export async function setSyncingProjectAttachments(
     logError(`Did not change attachment sync for project ${active_id}`);
     return; //Nothing to do, already same value
   }
+
+  // Get the current database
   const data_db = data_dbs[active_id];
+
+  // update the sync property
   data_db.is_sync_attachments = syncing;
 
-  const has_remote = (
-    db: typeof data_db
-  ): db is LocalDB<ProjectDataObject> & {
-    remote: LocalDBRemote<ProjectDataObject>;
-  } => {
-    return db.remote !== null;
-  };
-
-  if (has_remote(data_db)) {
-    setLocalConnection(data_db);
-  } else {
-    console.log('project is local only');
-  }
+  // This creates and updates the
+  createUpdateAndSavePouchSync({
+    // If local only - this method will handle it
+    connectionInfo: data_db.remote?.info ?? null,
+    globalDbs: data_dbs,
+    localDbId: active_id,
+  });
 
   try {
     const active_doc = await active_db.get(active_id);

--- a/app/src/sync/sync-toggle.ts
+++ b/app/src/sync/sync-toggle.ts
@@ -72,7 +72,8 @@ export async function setSyncingProjectAttachments(
   // update the sync property
   data_db.is_sync_attachments = syncing;
 
-  // This creates and updates the
+  // This creates and updates the sync connection so that it streams the
+  // attachments appropriately
   createUpdateAndSavePouchSync({
     // If local only - this method will handle it
     connectionInfo: data_db.remote?.info ?? null,

--- a/app/src/users.ts
+++ b/app/src/users.ts
@@ -173,22 +173,30 @@ export async function shouldDisplayRecord(
   // TODO - consider the context in which this is being run - should only be
   // active user notebooks!
   // TODO understand why this is coming through as a full project instead of just project id
+
+  // TODO this should not be on a per row basis - it's the same for all of them
+  // (facepalm)
   const split_id = split_full_project_id(full_proj_id);
   const user_id = contents.username;
+
+  // Always display your own records
   if (record_metadata.created_by === user_id) {
     return true;
   }
-  const is_admin = await isClusterAdmin(contents);
-  if (is_admin) {
+
+  // If you are admin (of cluster) then you can see all responses
+  const isAdmin = isClusterAdmin(contents);
+
+  if (isAdmin) {
     return true;
   }
+
+  // Get roles
   const roles = getUserProjectRolesForCluster(contents);
-  // TODO this doesn't really work
   for (const projectId of Object.keys(roles)) {
     if (
       projectId === split_id.project_id &&
       // TODO BSS-453 consider how we handle this
-
       // This currently hard-codes admin as a special role which allows visibility of all records but
       // a) why is this necessary on client side?
       // b) isn't this configurable in the notebook designer?

--- a/app/src/utils/apiOperations/client.tsx
+++ b/app/src/utils/apiOperations/client.tsx
@@ -205,7 +205,6 @@ export class ListingFetchManager {
     let server = this.serverMap.get(serverId);
     if (!server) {
       const ids = getAllListingIDs();
-      console.log(ids);
       ids.forEach(id => {
         const listingObj = getListing(id);
         this.serverMap.set(id, listingObj.listing);

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -358,7 +358,6 @@ export const useRecordList = ({
     gcTime: 0,
     refetchInterval: refreshIntervalMs,
     queryFn: async () => {
-      console.log('Running query');
       if (!token) {
         // Trying to run without token!
         console.warn('Trying to fetch record list without user token.');

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -321,7 +321,10 @@ const filterByActiveUser = (rows: RecordMetadata[], username: string) => {
 };
 
 /**
- * Returns a list of all records, and active user records.
+ * Returns a list of all records, and active user records. This applies the
+ * built in getMetadataForAllRecords filtering (which does client side
+ * permission filtering) and also provides my records vs all records list(s).
+ * 
  * @param query The search string, if any - regex match
  * @param projectId Project ID to get records for
  * @param filterDeleted Whether to filter out deleted records

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -12,7 +12,7 @@ import * as ROUTES from '../constants/routes';
 import {selectActiveUser} from '../context/slices/authSlice';
 import {useAppSelector} from '../context/store';
 import {OfflineFallbackComponent} from '../gui/components/ui/OfflineFallback';
-import {data_dbs, directory_db} from '../sync/databases';
+import {directory_db} from '../sync/databases';
 import {DraftFilters, listDraftMetadata} from '../sync/draft-storage';
 
 export const usePrevious = <T extends {}>(value: T): T | undefined => {

--- a/library/data-model/src/data_storage/index.ts
+++ b/library/data-model/src/data_storage/index.ts
@@ -469,16 +469,10 @@ async function filterRecordMetadata(
   record_list: RecordMetadata[],
   filter_deleted: boolean
 ): Promise<RecordMetadata[]> {
-  const new_record_list: RecordMetadata[] = [];
-  for (const metadata of record_list) {
-    if (
-      !(metadata.deleted && filter_deleted) &&
-      (await shouldDisplayRecord(tokenContents, project_id, metadata))
-    ) {
-      new_record_list.push(metadata);
-    }
-  }
-  return new_record_list;
+  return record_list.filter(async metadata => {
+    !(metadata.deleted && filter_deleted) &&
+      (await shouldDisplayRecord(tokenContents, project_id, metadata));
+  });
 }
 
 function sortByLastUpdated(record_list: RecordMetadata[]): RecordMetadata[] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faims3",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faims3",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -38,7 +38,7 @@
     },
     "api": {
       "name": "@faims3/api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@faims3/data-model": "*",
         "archiver": "^6.0.1",
@@ -134,7 +134,7 @@
     },
     "app": {
       "name": "@faims3/app",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@bugsnag/js": "^7.20.2",
         "@bugsnag/plugin-react": "^7.19.0",


### PR DESCRIPTION
# fix: listing bug, my vs other, pouch synchronisation and management issues

## JIRA Ticket

[BSS-708](https://jira.csiro.au/browse/BSS-708)
[BSS-712](https://jira.csiro.au/browse/BSS-712)

## Description

Fixes logical issue with record filtering for my vs other responses. 

Moved record listing logic into reusable custom hook which is smarter about caching, memoisation etc. 

Makes draft and normal record management more sensible with custom hooks for both.

Moves the record fetching to the top level so it can be done once and memoised.

Fixes the issue which was that at no point was the record table actually being configured to properly filter based on mine vs others. 

Added auto refresh every 10 seconds for the list to ensure it stays fresh.

Fixes or at least mitigates this bug https://jira.csiro.au/browse/BSS-712 

This was principally two main bugs

1. the options {push:{}, pull:{}} were used as a trigger to indicate two way sync - this was missing in token refresh, meaning new sync connections were one way
2. the pouch sync and db objects were not being cleaned up well (causing listener leaks) and also unstable behaviour with multiple syncs on the same local DB

And also propose this improvement for future work. 

https://jira.csiro.au/browse/BSS-713

Also fixes a bug with drafts - I'm not even sure what the bug was, but the implementation was so unnecessarily complicated I unified with record approach, removing some subscription logic while there.

## How to Test

User 1: create records
User 2: make sure you can see them 

Then for the above, try this under many conditions i.e. let tokens refresh, let the tab go to sleep, try refreshing the app, or leaving it un refreshed for a long time, you should continue to observe reliable syncing for both users, two way.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
