### PR TITLE
feat: refreshed UX for auth routes

### DIFF
--- a/api/src/auth_routes.ts
+++ b/api/src/auth_routes.ts
@@ -123,6 +123,7 @@ export function add_auth_routes(app: Router, handlers: string[]) {
       localAuth: true, // maybe make this configurable?
       messages: req.flash(),
       redirect: redirect,
+      layout: 'auth',
     });
   });
 
@@ -271,6 +272,7 @@ export function add_auth_routes(app: Router, handlers: string[]) {
           redirect: redirect,
           localAuth: true, // maybe make this configurable?
           messages: req.flash(),
+          layout: 'auth',
         });
       }
     }

--- a/api/test/conductor.test.ts
+++ b/api/test/conductor.test.ts
@@ -68,7 +68,7 @@ describe('Auth', () => {
       .get('/auth')
       .expect(200)
       .then(response => {
-        expect(response.text).to.include('Local Login');
+        expect(response.text).to.include('Welcome');
         done();
       });
   });

--- a/api/views/auth.handlebars
+++ b/api/views/auth.handlebars
@@ -11,7 +11,7 @@
 <form method="post" action="/auth/local?redirect={{redirect}}">
     <div class="mb-3">
         <label for="InputIdentifier" class="form-label">Email Address</label>
-        <input name="username" class="form-control" 
+        <input type="text" name="username" class="form-control" 
                id="InputIdentifier" autocomplete="email" required>
     </div>
     <div class="mb-3">

--- a/api/views/auth.handlebars
+++ b/api/views/auth.handlebars
@@ -1,42 +1,38 @@
-
-<div class="form-signin w-100 m-auto">
-    {{#if messages.message}}
-    <div class="alert alert-success">{{messages.message}}</div>
-    {{/if}}
-
-    <div class="form-signin w-100 m-auto text-center">
-     <h3 class="h3 mb-3 fw-normal" style="margin-top:50px">Sign In</h3>
-    <p class="">Please select an authentication provider</p>
-    </div>
-  
-    <form>
-
-    {{#each providers}}
-    <a href="/auth/{{ this.label }}/?redirect={{../redirect}}" class="w-100 btn btn-lg btn-primary"
-            style="background-color:#669911;">{{ this.name }}</a>
-    {{/each}}
- 
-    <div class=" w-100 m-auto text-center">
-    <p>If the provider you chose fails to work, try a different browser, and see
-    any provider-specific advice in the user documentation.
-    </p>
-    </div>
-</form>
-
-{{#if localAuth}}
-<h2>Local Login</h2>
-<form method="post" action="/auth/local?redirect={{redirect}}">
-  <div class="mb-3">
-    <label for="InputIdentifier" class="form-label">Email Address</label>
-    <input type="text" name="username" class="form-control" id="InputIdentifier" autocomplete="email">
-  </div>
-  <div class="mb-3">
-    <label for="InputPassword" class="form-label">Password</label>
-    <input type="password" name="password" class="form-control" id="InputPassword" autocomplete="current-password">
-  </div>
-  <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+{{#if messages.message}}
+<div class="alert alert-warning">{{messages.message}}</div>
 {{/if}}
 
+<div class="auth-header">
+    <h2>Welcome</h2>
+    <p>Sign in to continue</p>
 </div>
 
+{{#if localAuth}}
+<form method="post" action="/auth/local?redirect={{redirect}}">
+    <div class="mb-3">
+        <label for="InputIdentifier" class="form-label">Email Address</label>
+        <input type="email" name="username" class="form-control" 
+               id="InputIdentifier" autocomplete="email" required>
+    </div>
+    <div class="mb-3">
+        <label for="InputPassword" class="form-label">Password</label>
+        <input type="password" name="password" class="form-control" 
+               id="InputPassword" autocomplete="current-password" required>
+    </div>
+    <button type="submit" class="auth-button">Continue</button>
+</form>
+
+<div class="divider">
+    <span>or</span>
+</div>
+{{/if}}
+
+<div class="sso-options">
+    {{#each providers}}
+    <a href="/auth/{{ this.label }}/?redirect={{../redirect}}" 
+       class="auth-button-outline">
+        <i class="bi bi-{{this.name}}" style="margin-right: 8px;"></i>
+        Continue with {{ this.name }}
+    </a>
+    {{/each}}
+</div>

--- a/api/views/auth.handlebars
+++ b/api/views/auth.handlebars
@@ -11,7 +11,7 @@
 <form method="post" action="/auth/local?redirect={{redirect}}">
     <div class="mb-3">
         <label for="InputIdentifier" class="form-label">Email Address</label>
-        <input type="email" name="username" class="form-control" 
+        <input name="username" class="form-control" 
                id="InputIdentifier" autocomplete="email" required>
     </div>
     <div class="mb-3">
@@ -19,7 +19,7 @@
         <input type="password" name="password" class="form-control" 
                id="InputPassword" autocomplete="current-password" required>
     </div>
-    <button type="submit" class="auth-button">Continue</button>
+    <button type="submit" class="auth-button">Sign in</button>
 </form>
 
 <div class="divider">

--- a/api/views/layouts/auth.handlebars
+++ b/api/views/layouts/auth.handlebars
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <title>Conductor - {{pageTitle}}</title>
+    <link rel="icon" type="image/png" href="/images/favicon.png">
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
+    <style>
+        /* Theme Variables */
+        :root {
+            --primary-color: #669911;
+            --primary-hover: #558800;
+            --secondary-color: #FFA000;
+            --background-color: #edeeeb;
+            --text-color: #333333;
+            --card-background: #ffffff;
+            --border-color: #dddddd;
+            --divider-color: #e0e0e0;
+            --button-outline-color: #666666;
+            --error-color: #dc3545;
+            --error-bg: #f8d7da;
+        }
+
+        /* Base Styles */
+        html, body {
+            height: 100%;
+            background-color: var(--background-color);
+            color: var(--text-color);
+        }
+
+        /* Auth Container */
+        .auth-container {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .auth-card {
+            background: var(--card-background);
+            border-radius: 12px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            padding: 1.5rem;
+            width: 100%;
+            max-width: 400px;
+            margin: auto;
+        }
+
+        /* Common Header */
+        .auth-header {
+            text-align: center;
+            margin-bottom: 0.5rem;
+            padding: 0.5rem 0.5rem 0.5rem;
+        }
+
+        .auth-header h2 {
+            font-size: 1.25rem;
+            margin-bottom: 0.25rem;
+        }
+
+        .auth-header p {
+            font-size: 0.875rem;
+            margin-bottom: 0;
+        }
+
+        /* Form Elements */
+        .form-control {
+            border-radius: 6px;
+            padding: 0.5rem 0.75rem;
+            border: 1px solid var(--border-color);
+            margin-bottom: 0.25rem;
+            font-size: 0.9rem;
+        }
+
+        .form-control:focus {
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 0.2rem rgba(102, 153, 17, 0.25);
+        }
+
+        .form-label {
+            font-size: 0.9rem;
+            margin-bottom: 0.25rem;
+        }
+
+        /* Buttons */
+        .auth-button {
+            display: block;
+            width: 100%;
+            padding: 0.6rem;
+            margin: 0.75rem 0;
+            border-radius: 6px;
+            background-color: var(--primary-color);
+            color: white;
+            border: none;
+            transition: all 0.3s ease;
+            font-size: 0.9rem;
+        }
+
+        .auth-button:hover {
+            background-color: var(--primary-hover);
+        }
+
+        .auth-button-outline {
+            display: flex;
+            width: 100%;
+            padding: 0.6rem;
+            margin-bottom: 0.5rem;
+            border-radius: 6px;
+            background-color: transparent;
+            color: var(--button-outline-color);
+            border: 1px solid var(--button-outline-color);
+            transition: all 0.3s ease;
+            text-decoration: none;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.9rem;
+        }
+
+        .auth-button-outline:hover {
+            background-color: rgba(0, 0, 0, 0.05);
+            color: var(--text-color);
+        }
+
+        /* Divider */
+        .divider {
+            display: flex;
+            align-items: center;
+            text-align: center;
+            margin: 0.75rem 0;
+        }
+
+        .divider::before,
+        .divider::after {
+            content: '';
+            flex: 1;
+            border-bottom: 1px solid var(--divider-color);
+        }
+
+        .divider span {
+            padding: 0 0.75rem;
+            color: #666;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        /* Alerts */
+        .alert {
+            border-radius: 6px;
+            margin: 0.25rem 0 0.5rem 0;
+            padding: 0.5rem 0.75rem;
+            font-size: 0.8rem;
+        }
+
+        .alert-danger {
+            background-color: var(--error-bg);
+            color: var(--error-color);
+            border: none;
+        }
+
+        /* Helper Text */
+        .helper-text {
+            font-size: 0.8rem;
+            color: #666;
+            margin-bottom: 0.25rem;
+            font-style: italic;
+        }
+
+        /* Links */
+        .auth-link {
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .auth-link:hover {
+            text-decoration: underline;
+        }
+
+        /* Form Groups */
+        .mb-3 {
+            margin-bottom: 0.5rem !important;
+        }
+    </style>
+    {{{extraStyles}}}
+</head>
+<body>
+    <div class="auth-container">
+        <div class="auth-card">
+            {{{body}}}
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    {{{scripts}}}
+</body>
+</html>

--- a/api/views/layouts/auth.handlebars
+++ b/api/views/layouts/auth.handlebars
@@ -38,6 +38,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            padding: 15px;
         }
 
         .auth-card {

--- a/api/views/layouts/fallback.handlebars
+++ b/api/views/layouts/fallback.handlebars
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
-    <title>Fieldmark Conductor</title>
+    <title>Conductor</title>
     <link rel="icon" type="image/png" href="/images/favicon.png">
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
    <!-- CSS only -->

--- a/api/views/layouts/main.handlebars
+++ b/api/views/layouts/main.handlebars
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
-    <title>Fieldmark Conductor</title>
+    <title>Conductor</title>
     <link rel="icon" type="image/png" href="/images/favicon.png">
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
    <!-- CSS only -->

--- a/api/views/register.handlebars
+++ b/api/views/register.handlebars
@@ -1,5 +1,5 @@
 <div class="auth-header">
-    <h2>Create Account</h2>
+    <h2>Create account</h2>
     <p>Already have an account? <a href="{{loginURL}}" class="auth-link">Sign in</a></p>
 </div>
 
@@ -62,7 +62,7 @@
         {{/if}}
     </div>
 
-    <button type="submit" class="auth-button">Create Account</button>
+    <button type="submit" class="auth-button">Create account</button>
 </form>
 
 <div class="divider">
@@ -75,7 +75,7 @@
     <a href="/register/{{../invite}}/{{ this.label }}/?redirect={{ ../redirect }}" 
        class="auth-button-outline">
         <i class="bi bi-{{this.name}}" style="margin-right: 8px;"></i>
-        Register with {{ this.name }}
+        Continue with {{ this.name }}
     </a>
     {{/each}}
 </div>

--- a/api/views/register.handlebars
+++ b/api/views/register.handlebars
@@ -75,7 +75,7 @@
     <a href="/register/{{../invite}}/{{ this.label }}/?redirect={{ ../redirect }}" 
        class="auth-button-outline">
         <i class="bi bi-{{this.name}}" style="margin-right: 8px;"></i>
-        Continue with {{ this.name }}
+        Register with {{ this.name }}
     </a>
     {{/each}}
 </div>

--- a/api/views/register.handlebars
+++ b/api/views/register.handlebars
@@ -1,57 +1,81 @@
-
-<div class="form-signin w-100 m-auto">
-  <div class="form-signin w-100 m-auto text-center">
-    <h3 class="h3 mb-3 fw-normal" style="margin-top:50px">Register</h3>
-
-    <p>If you already have an account <a href="{{loginURL}}">Login here</a>.</p>
-
-    <p class="">You can either register a local account (below) or 
-      use an authentication provide.</p>
-  </div>
-
-  {{#each providers}}
-  <p><a href="/register/{{../invite}}/{{ this.label }}/?redirect={{ ../redirect }}" class="w-100 btn btn-lg btn-primary"
-          style="background-color:#669911;">{{ this.name }}</a></p>
-  {{/each}}
-
-  {{#if localAuth}}
-  {{#if messages.error.registration}}
-  <div class="alert alert-danger">{{messages.error.registration}}</div>
-  {{/if}}
-  <form method="post" action="/register/local">
-  <input type="hidden" name="redirect" value="{{redirect}}">
-  <fieldset>
-    <legend>Register Local Account</legend>
-    <div class="mb-3">
-      <label for="EmailInput" class="form-label">Email</label>
-      <input type="text" autocomplete="email" name="email" class="form-control" id="EmailInput" value="{{messages.email}}">
-      {{#if messages.error.email}}
-      <div class="alert alert-danger">{{messages.error.email.msg}}</div>
-      {{/if}}
-    </div>
-    <div class="mb-3">
-      <label for="NameInput" class="form-label">Full Name</label>
-      <input type="text" autocomplete="name" name="name" class="form-control" id="NameInput" value="{{messages.name}}">
-    </div>
-    <div class="mb-3">
-      <label for="InputPassword" class="form-label">Password</label>
-      <p style="font-style: italic;">Choose a password with at least 10 characters.</p>
-      <input type="password" autocomplete="new-password" name="password" class="form-control" id="InputPassword">
-      {{#if messages.error.password}}
-      <div class="alert alert-danger">{{messages.error.password.msg}}</div>
-      {{/if}}
-    </div>
-    <div class="mb-3">
-      <label for="RepeatPassword" class="form-label">Repeat Password</label>
-      <input type="password" autocomplete="new-password" name="repeat" class="form-control" id="RepeatPassword">
-      {{#if messages.error.repeat}}
-      <div class="alert alert-danger">{{messages.error.repeat.msg}}</div>
-      {{/if}}
-    </div>
-    <button type="submit" class="btn btn-primary">Submit</button>
-    </fieldset>
-  </form>
-  {{/if}}
-
+<div class="auth-header">
+    <h2>Create Account</h2>
+    <p>Already have an account? <a href="{{loginURL}}" class="auth-link">Sign in</a></p>
 </div>
 
+{{#if localAuth}}
+<form method="post" action="/register/local">
+    <input type="hidden" name="redirect" value="{{redirect}}">
+    {{#if messages.error.registration}}
+    <div class="alert alert-danger">{{messages.error.registration}}</div>
+    {{/if}}
+
+    <div class="mb-3">
+        <label for="EmailInput" class="form-label">Email</label>
+        <input type="email" 
+               autocomplete="email" 
+               name="email" 
+               class="form-control" 
+               id="EmailInput" 
+               value="{{messages.email}}"
+               required>
+        {{#if messages.error.email}}
+        <div class="alert alert-danger">{{messages.error.email.msg}}</div>
+        {{/if}}
+    </div>
+
+    <div class="mb-3">
+        <label for="NameInput" class="form-label">Full Name</label>
+        <input type="text" 
+               autocomplete="name" 
+               name="name" 
+               class="form-control" 
+               id="NameInput" 
+               value="{{messages.name}}"
+               required>
+    </div>
+
+    <div class="mb-3">
+        <label for="InputPassword" class="form-label">Password</label>
+        <p class="helper-text">Choose a password with at least 10 characters</p>
+        <input type="password" 
+               autocomplete="new-password" 
+               name="password" 
+               class="form-control" 
+               id="InputPassword"
+               required>
+        {{#if messages.error.password}}
+        <div class="alert alert-danger">{{messages.error.password.msg}}</div>
+        {{/if}}
+    </div>
+
+    <div class="mb-3">
+        <label for="RepeatPassword" class="form-label">Confirm Password</label>
+        <input type="password" 
+               autocomplete="new-password" 
+               name="repeat" 
+               class="form-control" 
+               id="RepeatPassword"
+               required>
+        {{#if messages.error.repeat}}
+        <div class="alert alert-danger">{{messages.error.repeat.msg}}</div>
+        {{/if}}
+    </div>
+
+    <button type="submit" class="auth-button">Create Account</button>
+</form>
+
+<div class="divider">
+    <span>or</span>
+</div>
+{{/if}}
+
+<div class="sso-options">
+    {{#each providers}}
+    <a href="/register/{{../invite}}/{{ this.label }}/?redirect={{ ../redirect }}" 
+       class="auth-button-outline">
+        <i class="bi bi-{{this.name}}" style="margin-right: 8px;"></i>
+        Continue with {{ this.name }}
+    </a>
+    {{/each}}
+</div>

--- a/designer/src/components/section-editor.tsx
+++ b/designer/src/components/section-editor.tsx
@@ -119,7 +119,7 @@ export const SectionEditor = ({
       handleSectionMoveCallback(targetViewSetId);
     } else {
       // manually setting the error message
-      setAddAlertMessage(`Failed to move the section to this form.`);
+      setAddAlertMessage('Failed to move the section to this form.');
     }
 
     handleCloseMoveDialog();

--- a/designer/src/state/uiSpec-reducer.ts
+++ b/designer/src/state/uiSpec-reducer.ts
@@ -273,7 +273,8 @@ export const uiSpecificationReducer = createSlice({
         );
         state.viewsets[viewSetID].views = newViewSetViews;
       }
-    },sectionMovedToForm: (
+    },
+    sectionMovedToForm: (
       state,
       action: PayloadAction<{
         sourceViewSetId: string;
@@ -287,7 +288,7 @@ export const uiSpecificationReducer = createSlice({
       const newSourceViews = sourceViews.filter(view => view !== viewId);
       state.viewsets[sourceViewSetId].views = newSourceViews;
       // add the section to the target form
-      state.viewsets[targetViewSetId].views.push(viewId);    
+      state.viewsets[targetViewSetId].views.push(viewId);
     },
     sectionMoved: (
       state,


### PR DESCRIPTION
# feat: refreshed UX for auth routes

## JIRA Ticket

[BSS-709](https://jira.csiro.au/browse/BSS-709)

## Description

Refreshes the appearance of the login/register routes. 

Eventually the other handlebars views will be deprecated (see #1257)

Notably

- more modern/minimalist appearance
- reusing CSS styling classes
- adding an auth layout which has common CSS (a pathway towards theming but not implementing here)
- removing the redundant nav bar, log out button etc

## How to Test

View and functionally test the login and register conductor pages.

## Additional Information

Theming not implemented here - so went with consistency with Fieldmark colours but tried to keep it minimalist so it doesn't stand out for BSS use case. Can override the root CSS colours (since these are variables) in another PR.

## Screenshots (desktop)

Login

![image](https://github.com/user-attachments/assets/7345bf19-febf-4cba-a967-b03d9d73e388)

Register

![image](https://github.com/user-attachments/assets/bf73400f-6bd8-4589-887c-c7715fec415b)

## Screenshots (mobile size Iphone SE)

Register

![image](https://github.com/user-attachments/assets/b6c90b24-5ad3-4a7e-84ca-3a0592ed3214)

Login

![image](https://github.com/user-attachments/assets/0a70a445-a56e-4d2d-8729-89a2960e2995)


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
