### PR TITLE
fix: templated string field character escaping

### DIFF
--- a/app/src/utils/formUtilities.ts
+++ b/app/src/utils/formUtilities.ts
@@ -7,6 +7,26 @@ import {
 import Mustache from 'mustache';
 import {RecordContext} from '../gui/components/record/form';
 
+/*
+Patch mustache to not escape values.
+
+This addresses JIRA BSS-714 where Observation/Point of Interest was being
+rendered as "Observation&#x2F;Point of Interest"
+
+This is generally a risky approach but safe enough in our use case provided the
+output is never:
+
+- Inserted into the DOM using .innerHTML
+- Used as an HTML attribute value
+- Evaluated as JavaScript
+- Used in a <script> tag
+- Used in a CSS value
+- Used in a URL
+*/
+Mustache.escape = function (text: string) {
+  return text;
+};
+
 /**
  * Converts a record (real or draft) into record context used in the form
  * @param record

--- a/designer/src/components/TemplateBuilder.tsx
+++ b/designer/src/components/TemplateBuilder.tsx
@@ -34,6 +34,26 @@ import {
 import Mustache from 'mustache';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+/*
+Patch mustache to not escape values.
+
+This addresses JIRA BSS-714 where Observation/Point of Interest was being
+rendered as "Observation&#x2F;Point of Interest"
+
+This is generally a risky approach but safe enough in our use case provided the
+output is never:
+
+- Inserted into the DOM using .innerHTML
+- Used as an HTML attribute value
+- Evaluated as JavaScript
+- Used in a <script> tag
+- Used in a CSS value
+- Used in a URL
+*/
+Mustache.escape = function (text: string) {
+  return text;
+};
+
 /**
  * Maintains a counter for generating unique block IDs within a session
  */


### PR DESCRIPTION
# fix: templated string field character escaping

## JIRA Ticket

[BSS-714](https://jira.csiro.au/browse/BSS-714)

## Description

For our use case, just disabling the escape function is sufficient. 

See code comment explaining risks assoc.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
