### PR TITLE
Fix: use template_id rather than project_id for template download

### DIFF
--- a/api/views/template-landing.handlebars
+++ b/api/views/template-landing.handlebars
@@ -13,7 +13,7 @@
           <dt>Description</dt><dd>{{markdown template.metadata.pre_description }}</dd>
       </dl>
 
-      <p><a download href="/api/templates/{{template.metadata.project_id}}">Download this template's JSON definition file.</a></p>
+      <p><a download href="/api/templates/{{template.metadata.template_id}}">Download this template's JSON definition file.</a></p>
 
     </div>
 


### PR DESCRIPTION
# Fix: use template_id rather than project_id for template download

## JIRA Ticket

None

## Description

The link to download a template from Conductor was not working. 

## How to Test

Go to the page for a template in Conductor, click on "Download this template..." and you should get a valid template file.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
