### PR TITLE
feat: bold in right hand column

### DIFF
--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -637,7 +637,6 @@ const KeyValueTable = ({data}: {data: {[key: string]: string | ReactNode}}) => {
                   width: '40%',
                   borderBottom: 'none',
                   padding: '4px 8px',
-                  fontWeight: 'bold',
                 }}
               >
                 {key}
@@ -647,6 +646,7 @@ const KeyValueTable = ({data}: {data: {[key: string]: string | ReactNode}}) => {
                   width: '60%',
                   borderBottom: 'none',
                   padding: '4px 8px',
+                  fontWeight: 'bold',
                 }}
               >
                 {val}


### PR DESCRIPTION
# feat: bold in right hand column

Elana prefers right hand (changing content) to be bolded for UX legibility reasons. 

Minor code change.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
