### PR TITLE
feat: configurable rate limiting with reasonable defaults

### DIFF
--- a/api/.env.dist
+++ b/api/.env.dist
@@ -52,3 +52,12 @@ REFRESH_TOKEN_EXPIRY_MINUTES=2880
 # Access expires in 5 minutes
 ACCESS_TOKEN_EXPIRY_MINUTES=5
 
+# Rate Limiter Configuration
+# Window duration in milliseconds (default: 600000 - 10 minutes)
+RATE_LIMITER_WINDOW_MS=600000
+
+# Maximum number of requests per window (default: 1000)
+RATE_LIMITER_PER_WINDOW=1000
+
+# Enable/disable rate limiting (default: true)
+RATE_LIMITER_ENABLED=true

--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -323,6 +323,62 @@ function refreshTokenExpiryMinutes(): number {
   }
 }
 
+const DEFAULT_RATE_LIMITER_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_RATE_LIMITER_PER_WINDOW = 1000; // 1000 requests per window
+const DEFAULT_RATE_LIMITER_ENABLED = true;
+
+/**
+ * Gets the rate limiter window duration in milliseconds from environment variables
+ * @returns The window duration in milliseconds
+ */
+function rateLimiterWindowMs(): number {
+  const rateLimiterWindowMs = process.env.RATE_LIMITER_WINDOW_MS;
+  if (rateLimiterWindowMs === '' || rateLimiterWindowMs === undefined) {
+    return DEFAULT_RATE_LIMITER_WINDOW_MS;
+  }
+  try {
+    return parseInt(rateLimiterWindowMs);
+  } catch (err) {
+    console.error(
+      'RATE_LIMITER_WINDOW_MS unparseable, defaulting to ' +
+        DEFAULT_RATE_LIMITER_WINDOW_MS
+    );
+    return DEFAULT_RATE_LIMITER_WINDOW_MS;
+  }
+}
+
+/**
+ * Gets the number of requests allowed per window from environment variables
+ * @returns The number of requests allowed per window
+ */
+function rateLimiterPerWindow(): number {
+  const rateLimiterPerWindow = process.env.RATE_LIMITER_PER_WINDOW;
+  if (rateLimiterPerWindow === '' || rateLimiterPerWindow === undefined) {
+    return DEFAULT_RATE_LIMITER_PER_WINDOW;
+  }
+  try {
+    return parseInt(rateLimiterPerWindow);
+  } catch (err) {
+    console.error(
+      'RATE_LIMITER_PER_WINDOW unparseable, defaulting to ' +
+        DEFAULT_RATE_LIMITER_PER_WINDOW
+    );
+    return DEFAULT_RATE_LIMITER_PER_WINDOW;
+  }
+}
+
+/**
+ * Checks if rate limiting is enabled from environment variables
+ * @returns Boolean indicating if rate limiting is enabled
+ */
+function rateLimiterEnabled(): boolean {
+  const rateLimiterEnabled = process.env.RATE_LIMITER_ENABLED;
+  if (rateLimiterEnabled === undefined) {
+    return DEFAULT_RATE_LIMITER_ENABLED;
+  }
+  return rateLimiterEnabled.toLowerCase() === 'true';
+}
+
 export const DEVELOPER_MODE = developer_mode();
 export const COUCHDB_INTERNAL_URL = couchdb_internal_url();
 export const COUCHDB_PUBLIC_URL = couchdb_public_url();
@@ -344,6 +400,9 @@ export const IOS_APP_URL = ios_url();
 export const ACCESS_TOKEN_EXPIRY_MINUTES = accessTokenExpiryMinutes();
 export const REFRESH_TOKEN_EXPIRY_MINUTES = refreshTokenExpiryMinutes();
 export const DESIGNER_URL = designer_url();
+export const RATE_LIMITER_WINDOW_MS = rateLimiterWindowMs();
+export const RATE_LIMITER_PER_WINDOW = rateLimiterPerWindow();
+export const RATE_LIMITER_ENABLED = rateLimiterEnabled();
 
 /**
  * Checks the KEY_SOURCE env variable to ensure its a KEY_SOURCE or defaults to

--- a/api/src/core.ts
+++ b/api/src/core.ts
@@ -56,7 +56,12 @@ import {api as notebookApi} from './api/notebooks';
 import {api as templatesApi} from './api/templates';
 import {api as usersApi} from './api/users';
 import {api as utilityApi} from './api/utilities';
-import {COOKIE_SECRET} from './buildconfig';
+import {
+  COOKIE_SECRET,
+  RATE_LIMITER_ENABLED,
+  RATE_LIMITER_PER_WINDOW,
+  RATE_LIMITER_WINDOW_MS,
+} from './buildconfig';
 import patch from './utils/patchExpressAsync';
 
 // This must occur before express app is used
@@ -65,15 +70,30 @@ patch();
 export const app = express();
 app.use(morgan('combined'));
 
-if (process.env.NODE_ENV !== 'test') {
-  // set up rate limiter: maximum of 60 requests per minute
-  const limiter = RateLimit({
-    windowMs: 1 * 60 * 1000, // 1 minute
-    max: 60,
-    validate: true,
-  });
-  app.use(limiter);
-  console.log('Rate limiter enabled');
+const IS_TEST = process.env.NODE_ENV === 'test';
+
+// Setup rate limiter
+export const RATE_LIMITER = RateLimit({
+  windowMs: RATE_LIMITER_WINDOW_MS,
+  max: RATE_LIMITER_PER_WINDOW,
+  message: 'Too many requests from this IP, please try again after 10 minutes',
+  // Return rate limit info in the `RateLimit-*` headers
+  standardHeaders: true,
+  // Disable the `X-RateLimit-*` headers
+  legacyHeaders: true,
+});
+
+if (!IS_TEST && RATE_LIMITER_ENABLED) {
+  console.log('Activating rate limiter');
+  app.use(RATE_LIMITER);
+} else {
+  if (IS_TEST) {
+    console.log('Not enabling rate limiting due to being in test mode.');
+  } else {
+    console.log(
+      'Not enabling rate limiting due to it being explicitly disabled.'
+    );
+  }
 }
 
 // Only parse query parameters into strings, not objects


### PR DESCRIPTION
# feat: configurable rate limiting with reasonable defaults

## JIRA Ticket

https://jira.csiro.au/browse/BSS-744

## Description

Adds configuration in the typical style for rate limit window, events and enable/disable. 

Sets much more generous defaults which evaluate over a longer period. Rate limiting 60 req/minute was excessive - this meant that a request rate of 1/second was too much. This sets it to 1000 requests per 10 minutes which allows for bursty loads while still protecting the API. We would need a more advanced configuration or possibly limiter to catch very high burst loads over shorter durations without punishing normal usage.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
