### PR TITLE
build: source map inline config for debuggability

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
   base: '/',
   build: {
     outDir: 'build',
+    sourcemap: 'inline'
   },
   server: {
     port: 3000,


### PR DESCRIPTION
# build: source map inline config for debuggability

Given our code is open source, the improvement in debugging vs security risk is probably skewed in favour of source map being included. In BSS this source-map configuration was deployed and helped debug the latest prod error.