### PR TITLE
back button , hide breadcrumb in mobile view, display back to respons…

### DIFF
--- a/app/src/gui/components/ui/breadcrumbs.tsx
+++ b/app/src/gui/components/ui/breadcrumbs.tsx
@@ -4,20 +4,25 @@ import {
   Typography,
   Breadcrumbs as MuiBreadcrumbs,
   IconButton,
+  Button,
 } from '@mui/material';
-import {Link as RouterLink} from 'react-router-dom';
+import {Link as RouterLink, useNavigate} from 'react-router-dom';
 import HomeIcon from '@mui/icons-material/Home';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 type BreadcrumbProps = {
   data: Array<{title: string; link?: string}>;
+  backLink?: string;
 };
 
 export default function Breadcrumbs(props: BreadcrumbProps) {
-  const {data} = props;
+  const {data, backLink} = props;
   const theme = useTheme();
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
+  const navigate = useNavigate();
+  const isMobile = !useMediaQuery(theme.breakpoints.up('sm'));
 
   // Function to abbreviate long titles on small screens
   const abbreviateTitle = (title: string) => {
@@ -29,37 +34,59 @@ export default function Breadcrumbs(props: BreadcrumbProps) {
 
   return (
     <Box display="flex" flexDirection="row-reverse" sx={{p: 1, m: 1}}>
-      <MuiBreadcrumbs
-        aria-label="breadcrumb"
-        maxItems={not_xs ? 4 : 2}
-        itemsAfterCollapse={not_xs ? 2 : 1}
-        itemsBeforeCollapse={not_xs ? 0 : 1}
-      >
-        {data.map((item, index) => {
-          // If it's the root item, use an icon
-          if (index === 0 && item.link) {
-            return (
+      {/* Show "Back to Responses" button only on mobile */}
+      {isMobile && backLink && (
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate(backLink)}
+          variant="text"
+          sx={{
+            fontSize: '0.875rem',
+            textTransform: 'none',
+            color: theme.palette.primary.main,
+          }}
+        >
+          Back to Responses
+        </Button>
+      )}
+
+      {/* Hide breadcrumbs in mobile view */}
+      {!isMobile && (
+        <MuiBreadcrumbs
+          aria-label="breadcrumb"
+          maxItems={not_xs ? 4 : 2}
+          itemsAfterCollapse={not_xs ? 2 : 1}
+          itemsBeforeCollapse={not_xs ? 0 : 1}
+        >
+          {data.map((item, index) => {
+            // If it's the root item, use an icon
+            if (index === 0 && item.link) {
+              return (
+                <RouterLink
+                  to={item.link}
+                  key={'breadcrumb-item-' + item.title}
+                >
+                  <IconButton size="small">
+                    <HomeIcon fontSize="inherit" />
+                  </IconButton>
+                </RouterLink>
+              );
+            }
+            return item.link !== undefined ? (
               <RouterLink to={item.link} key={'breadcrumb-item-' + item.title}>
-                <IconButton size="small">
-                  <HomeIcon fontSize="inherit" />
-                </IconButton>
+                {abbreviateTitle(item.title)}
               </RouterLink>
+            ) : (
+              <Typography
+                color="textPrimary"
+                key={'breadcrumb-item-' + item.title}
+              >
+                {abbreviateTitle(item.title)}
+              </Typography>
             );
-          }
-          return item.link !== undefined ? (
-            <RouterLink to={item.link} key={'breadcrumb-item-' + item.title}>
-              {abbreviateTitle(item.title)}
-            </RouterLink>
-          ) : (
-            <Typography
-              color="textPrimary"
-              key={'breadcrumb-item-' + item.title}
-            >
-              {abbreviateTitle(item.title)}
-            </Typography>
-          );
-        })}
-      </MuiBreadcrumbs>
+          })}
+        </MuiBreadcrumbs>
+      )}
     </Box>
   );
 }

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -411,10 +411,17 @@ export default function RecordCreate() {
       {title: 'Draft'},
     ];
   }
+
+  // fethc survey link for the records
+  let surveyLink = ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + project_id;
+  if (location.state && location.state.parent_record_id !== record_id) {
+    surveyLink = ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + location.state.parent_link;
+  }
+
   return (
     <React.Fragment>
       <Box>
-        <Breadcrumbs data={breadcrumbs} />
+        <Breadcrumbs data={breadcrumbs} backLink={surveyLink} />
         {draft_id === undefined || record_id === undefined ? (
           <DraftCreate
             project_id={project_id!}


### PR DESCRIPTION
To be tested: 


## JIRA Ticket

BSS-718

-As discussed with Elana:
- Added a back button that will take user back to the survey (where records are dispalyed that user has created)
- Breadcrumbs in moible view to be hidden to avoid confusion.

## Checklist

- [y ] I have confirmed all commits have been signed.
- [ y] I have added JSDoc style comments to any new functions or classes.
- [y ] Relevant documentation such as READMEs, guides, and class comments are updated.
