### PR TITLE
feat: upgraded small screen scaling and various UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,16 @@ Further build/install instructions can be found at
 
 ## Live reload Android studio workflow (WSL)
 
-On WSL, the following setup and procedure allows live reloading of the app on an Android emulator (or physical device through adb [though I haven't gotten this working due to adb config issues])
+On WSL, the following setup and procedure allows live reloading of the app on an Android emulator (or physical device through adb [though I haven't gotten this working due to adb config issues]).
 
-- install Android studio on your WSL instance
+### Prereqs
+
+- install Android studio on your WSL instance with suitable JDK (this usually comes bundled)
+
+### Setup
+
+First run `npm i` to install all dependencies, and move into `/app`. Then `npm i` to be certain local deps are installed, then
+
 - open android studio in one tab i.e. `./<studio path>/studio.sh`
 - in the open studio window, configure/start the emulator you want to run it on
 - in another tab, build the app i.e. `npm run build && npx cap sync android`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This spins up three services
 
 - conductor API (/api) live reloading on http://localhost:8080
 - FAIMS3 app (/app) live reloading on http://localhost:3000
-- couchDB on http://localhost:5984/_utils
+- couchDB on http://localhost:5984/\_utils
 
 ## Initial step-by step setup
 
@@ -193,6 +193,19 @@ Further build/install instructions can be found at
 1. [Optional] Resolve `xcode-select` error
    - `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
 1. Build the apk from the build/build bundle/build apk section
+
+## Live reload Android studio workflow (WSL)
+
+On WSL, the following setup and procedure allows live reloading of the app on an Android emulator (or physical device through adb [though I haven't gotten this working due to adb config issues])
+
+- install Android studio on your WSL instance
+- open android studio in one tab i.e. `./<studio path>/studio.sh`
+- in the open studio window, configure/start the emulator you want to run it on
+- in another tab, build the app i.e. `npm run build && npx cap sync android`
+- run the server `npx vite --force`
+- in another tab, start live reload `npx cap run android -l --external` and select the desired running emulator (it's important you use the existing running emulator rather than starting another which is unstable with WSL)
+
+This then live reloads on the emulator device from the running server.
 
 ## API Development
 

--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -38,12 +38,12 @@ import {
 import express, {Response} from 'express';
 import {z} from 'zod';
 import {processRequest} from 'zod-express-middleware';
-import {CONDUCTOR_INSTANCE_NAME, DEVELOPER_MODE} from '../buildconfig';
+import {DEVELOPER_MODE} from '../buildconfig';
 import {createManyRandomRecords} from '../couchdb/devtools';
 import {
   createNotebook,
   deleteNotebook,
-  generateFilenameForAttachment as generateFilenameForAttachment,
+  generateFilenameForAttachment,
   getNotebookMetadata,
   getNotebooks,
   getNotebookUISpec,
@@ -66,9 +66,8 @@ import {
 import * as Exceptions from '../exceptions';
 import {requireAuthenticationAPI} from '../middleware';
 
+import {generateTokenContentsForUser} from '../utils';
 import patch from '../utils/patchExpressAsync';
-import {generateTokenContentsForUser, slugify} from '../utils';
-import {generateUserToken} from '../authkeys/create';
 
 // This must occur before express api is used
 patch();

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -27,7 +27,7 @@ import {
   notebookRecordIterator,
   ProjectID,
   ProjectObject,
-  resolve_project_id
+  resolve_project_id,
 } from '@faims3/data-model';
 import archiver from 'archiver';
 import PouchDB from 'pouchdb';
@@ -582,7 +582,12 @@ const csvFormatValue = (
       }
       const valueList = value.map((v: any) => {
         if (v instanceof File) {
-          const filename = generateFilenameForAttachment(v, fieldName, hrid, filenames);
+          const filename = generateFilenameForAttachment(
+            v,
+            fieldName,
+            hrid,
+            filenames
+          );
           filenames.push(filename);
           return filename;
         } else {
@@ -882,7 +887,12 @@ export const streamNotebookFilesAsZip = async (
                 chunks.push(value);
               }
               const stream = Stream.Readable.from(chunks);
-              const filename = generateFilenameForAttachment(file, key, hrid, fileNames);
+              const filename = generateFilenameForAttachment(
+                file,
+                key,
+                hrid,
+                fileNames
+              );
               fileNames.push(filename);
               await archive.append(stream, {
                 name: filename,

--- a/api/test/utils.ts
+++ b/api/test/utils.ts
@@ -17,13 +17,13 @@
  *   Setup helper functions for the api tests
  */
 
-import request from 'supertest';
 import {NOTEBOOK_CREATOR_GROUP_NAME} from '@faims3/data-model';
 import {expect} from 'chai';
 import PouchDB from 'pouchdb';
+import request from 'supertest';
 import {addLocalPasswordForUser} from '../src/auth_providers/local';
 import {createAuthKey} from '../src/authkeys/create';
-import {CONDUCTOR_INSTANCE_NAME, KEY_SERVICE} from '../src/buildconfig';
+import {KEY_SERVICE} from '../src/buildconfig';
 import {
   addOtherRoleToUser,
   createUser,
@@ -31,7 +31,6 @@ import {
   saveUser,
 } from '../src/couchdb/users';
 import {cleanDataDBS, resetDatabases} from './mocks';
-import {slugify} from '../src/utils';
 PouchDB.plugin(require('pouchdb-adapter-memory')); // enable memory adapter for testing
 PouchDB.plugin(require('pouchdb-find'));
 

--- a/app/.env.dist
+++ b/app/.env.dist
@@ -20,8 +20,6 @@ VITE_THEME='default'
 VITE_NOTEBOOK_LIST_TYPE=tabs
 # Configure the name used for Notebooks in the app, lowercase, singular (eg. notebook, survey)
 VITE_NOTEBOOK_NAME=survey
-# Should the record view show a summary count total <>, my <>
-VITE_SHOW_RECORD_SUMMARY_COUNTS=false
 # What is the name of the app - used for App store and also as default heading
 VITE_APP_NAME=Fieldmark
 # Override for title heading (defaults to VITE_APP_NAME)

--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -267,23 +267,6 @@ function get_notebook_list_type(): 'tabs' | 'headings' {
 }
 
 /**
- * Is the VITE_SHOW_RECORD_SUMMARY_COUNTS env variable present and not falsey
- * @returns The notebook list type, which can be either "tabs" or "headings".
- */
-function showRecordCounts(): boolean {
-  const val = import.meta.env.VITE_SHOW_RECORD_SUMMARY_COUNTS as
-    | string
-    | undefined;
-  if (!val) {
-    return false;
-  }
-  if (['false', 'f'].includes(val.toLowerCase())) {
-    return false;
-  }
-  return true;
-}
-
-/**
  * Retrieves the name of notebooks from the environment variables.
  * If the environment variable is not set, it returns a default value 'notebook'.
  *
@@ -412,7 +395,6 @@ export const NOTEBOOK_NAME_CAPITALIZED = get_notebook_name_capitalized();
 export const APP_NAME = get_app_name();
 export const HEADING_APP_NAME = get_heading_app_name();
 export const APP_ID = get_app_id();
-export const SHOW_RECORD_SUMMARY_COUNTS = showRecordCounts();
 export const TOKEN_REFRESH_INTERVAL_MS = tokenRefreshIntervalMs();
 export const TOKEN_REFRESH_WINDOW_MS = tokenRefreshWindowMs();
 export const IGNORE_TOKEN_EXP = ignoreTokenExp();

--- a/app/src/gui/components/app-bar/app-bar-heading.tsx
+++ b/app/src/gui/components/app-bar/app-bar-heading.tsx
@@ -24,9 +24,9 @@ export const AppBarHeading = ({link}: AppBarHeadingProps) => (
       color: 'black',
     }}
   >
-    <Box sx={{paddingRight: 1}}>
+    <Box sx={{}}>
       <img src="/assets/icons/icon-48.webp" />
     </Box>
-    <h1>{HEADING_APP_NAME}</h1>
+    <h2>{HEADING_APP_NAME}</h2>
   </NavLink>
 );

--- a/app/src/gui/components/notebook/MetadataDisplay.tsx
+++ b/app/src/gui/components/notebook/MetadataDisplay.tsx
@@ -1,0 +1,187 @@
+import {
+  Box,
+  Typography,
+  Grid,
+  Paper,
+  TableContainer,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '@mui/material';
+import MetadataRenderer from '../metadataRenderer';
+import RangeHeader from './range_header';
+import {ProjectExtended} from '../../../types/project';
+
+interface MetadataDisplayComponentProps {
+  project: ProjectExtended;
+  templateId?: string | null | undefined;
+  handleTabChange: (index: number) => void;
+}
+export const MetadataDisplayComponent = (props: MetadataDisplayComponentProps) => {
+  /**
+    Component: MetadataDisplayComponent
+    
+    */
+  // TODO Destub
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+          px: 2,
+        }}
+      >
+        <Typography
+          variant="body1"
+          sx={{
+            textAlign: 'center',
+            fontSize: '18px',
+            fontWeight: 'bold',
+            flexGrow: 1,
+          }}
+        >
+          Survey Details
+        </Typography>
+      </Box>
+
+      <Box sx={{p: 2}}>
+        <Typography variant="body1" gutterBottom sx={{marginBottom: '16px'}}>
+          <strong>Name:</strong>{' '}
+          <MetadataRenderer
+            project_id={props.project.project_id}
+            metadata_key={'name'}
+            chips={false}
+          />
+        </Typography>
+        {props.templateId && (
+          <Typography variant="body1" gutterBottom sx={{marginBottom: '16px'}}>
+            <strong>Template Used: </strong>
+            <span>{props.templateId}</span>
+          </Typography>
+        )}
+        <Typography
+          variant="body1"
+          gutterBottom
+          component="div"
+          sx={{marginBottom: '16px'}}
+        >
+          <strong>Description:</strong>{' '}
+          <MetadataRenderer
+            project_id={props.project.project_id}
+            metadata_key={'pre_description'}
+            chips={false}
+          />
+        </Typography>
+
+        <Typography variant="body1" gutterBottom sx={{marginBottom: '16px'}}>
+          <strong>Lead Institution:</strong>{' '}
+          <MetadataRenderer
+            project_id={props.project.project_id}
+            metadata_key={'lead_institution'}
+            chips={false}
+          />
+        </Typography>
+        <Typography
+          variant="body1"
+          gutterBottom
+          sx={{marginBottom: '16px', textAlign: 'left'}}
+        >
+          <strong>Project Lead:</strong>{' '}
+          <MetadataRenderer
+            project_id={props.project.project_id}
+            metadata_key={'project_lead'}
+            chips={false}
+          />
+        </Typography>
+      </Box>
+
+      <Grid container spacing={{xs: 1, sm: 2, md: 3}}>
+        <Grid item xs={12} sm={6} md={6} lg={4}>
+          <Box component={Paper} elevation={0} variant={'outlined'} p={2}>
+            <Typography variant={'h6'} sx={{mb: 2}}>
+              Description
+            </Typography>
+            <Typography variant="body2" color="textPrimary" gutterBottom>
+              <MetadataRenderer
+                project_id={props.project.project_id}
+                metadata_key={'pre_description'}
+                chips={false}
+              />
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid item xs={12} sm={6} md={4}>
+          <TableContainer component={Paper} elevation={0} variant={'outlined'}>
+            <Typography variant={'h6'} sx={{m: 2}} gutterBottom>
+              About
+            </Typography>
+            <Table size={'small'}>
+              <TableBody>
+                <TableRow>
+                  <TableCell>
+                    <Typography variant={'overline'}>Status</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <MetadataRenderer
+                      project_id={props.project.project_id}
+                      metadata_key={'project_status'}
+                      chips={false}
+                    />
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    <Typography variant={'overline'}>
+                      Lead Institution
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <MetadataRenderer
+                      project_id={props.project.project_id}
+                      metadata_key={'lead_institution'}
+                      chips={false}
+                    />
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    <Typography variant={'overline'}>Project Lead</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <MetadataRenderer
+                      project_id={props.project.project_id}
+                      metadata_key={'project_lead'}
+                      chips={false}
+                    />
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    <Typography variant={'overline'}>Last Updated</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <MetadataRenderer
+                      project_id={props.project.project_id}
+                      metadata_key={'last_updated'}
+                      chips={false}
+                    />
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+        <Grid item xs={12} sm={12} md={12} lg={4}>
+          <RangeHeader
+            project={props.project}
+            handleAIEdit={props.handleTabChange}
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+};

--- a/app/src/gui/components/notebook/MetadataDisplay.tsx
+++ b/app/src/gui/components/notebook/MetadataDisplay.tsx
@@ -18,10 +18,12 @@ interface MetadataDisplayComponentProps {
   templateId?: string | null | undefined;
   handleTabChange: (index: number) => void;
 }
-export const MetadataDisplayComponent = (props: MetadataDisplayComponentProps) => {
+export const MetadataDisplayComponent = (
+  props: MetadataDisplayComponentProps
+) => {
   /**
     Component: MetadataDisplayComponent
-    
+
     */
   // TODO Destub
   return (

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -34,7 +34,6 @@ import {MetadataDisplayComponent} from './MetadataDisplay';
 import {OverviewMap} from './overview_map';
 import {RecordsTable} from './record_table';
 import NotebookSettings from './settings';
-import {recomputeDerivedFields} from '../../../utils/formUtilities';
 
 // Define how tabs appear in the query string arguments, providing a two way map
 type TabIndexLabel =
@@ -303,14 +302,14 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                   value={0}
                   {...a11yProps(0, `${NOTEBOOK_NAME}-myrecords`)}
                 />
-                {(tabIndex == 1 || records.otherRecords.length > 0) && (
+                {(tabIndex === 1 || records.otherRecords.length > 0) && (
                   <Tab
                     value={1}
                     label={`Other ${recordLabel}s (${records.otherRecords.length})`}
                     {...a11yProps(1, `${NOTEBOOK_NAME}-otherrecords`)}
                   />
                 )}
-                {(tabIndex == 2 || (drafts.data?.length ?? 0) > 0) && (
+                {(tabIndex === 2 || (drafts.data?.length ?? 0) > 0) && (
                   <Tab
                     value={2}
                     label={`Drafts (${drafts.data?.length ?? 0})`}

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -300,23 +300,34 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
               >
                 <Tab
                   label={`My ${recordLabel}s (${records.myRecords.length})`}
+                  value={0}
                   {...a11yProps(0, `${NOTEBOOK_NAME}-myrecords`)}
                 />
                 {(tabIndex == 1 || records.otherRecords.length > 0) && (
                   <Tab
+                    value={1}
                     label={`Other ${recordLabel}s (${records.otherRecords.length})`}
                     {...a11yProps(1, `${NOTEBOOK_NAME}-otherrecords`)}
                   />
                 )}
                 {(tabIndex == 2 || (drafts.data?.length ?? 0) > 0) && (
                   <Tab
+                    value={2}
                     label={`Drafts (${drafts.data?.length ?? 0})`}
                     {...a11yProps(2, `${NOTEBOOK_NAME}-drafts`)}
                   />
                 )}
-                <Tab label="Details" {...a11yProps(3, NOTEBOOK_NAME)} />
-                <Tab label="Settings" {...a11yProps(4, NOTEBOOK_NAME)} />
-                <Tab label="Map" {...a11yProps(5, NOTEBOOK_NAME)} />
+                <Tab
+                  value={3}
+                  label="Details"
+                  {...a11yProps(3, NOTEBOOK_NAME)}
+                />
+                <Tab
+                  value={4}
+                  label="Settings"
+                  {...a11yProps(4, NOTEBOOK_NAME)}
+                />
+                <Tab value={5} label="Map" {...a11yProps(5, NOTEBOOK_NAME)} />
               </Tabs>
             </AppBar>
           </Box>

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1404,7 +1404,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
 
                         return (
                           <div key={`form-${view}`}>
-                            <h2>{ui_specification.views[view].label}</h2>
+                            <h1>{ui_specification.views[view].label}</h1>
                             <Form>
                               {description !== '' && (
                                 <Typography>{description}</Typography>

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -41,10 +41,7 @@ import {
   NotificationContext,
   NotificationContextType,
 } from '../../../context/popup';
-import {
-  listAllConnections,
-  selectActiveUser,
-} from '../../../context/slices/authSlice';
+import {selectActiveUser} from '../../../context/slices/authSlice';
 import {store} from '../../../context/store';
 import {
   currentlyVisibleFields,
@@ -780,7 +777,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
 
   onChangeStepper(view_name: string, activeStepIndex: number) {
     this.setState(prevState => {
-      const {visitedSteps, activeStep} = prevState;
+      const {activeStep} = prevState;
 
       const wasVisitedBefore = prevState.visitedSteps.has(view_name);
 

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1523,82 +1523,88 @@ class RecordForm extends React.Component<any, RecordFormState> {
 
                 return (
                   <Form>
-                    {views.length > 1 && (
-                      <RecordStepper
-                        view_index={view_index}
+                    <div
+                      style={{
+                        padding: this.props.mq_above_md ? '1rem' : '0.2rem',
+                      }}
+                    >
+                      {views.length > 1 && (
+                        <RecordStepper
+                          view_index={view_index}
+                          ui_specification={ui_specification}
+                          onChangeStepper={this.onChangeStepper}
+                          views={views}
+                          formErrors={formProps.errors}
+                          visitedSteps={this.state.visitedSteps}
+                          isRecordSubmitted={isRecordSubmitted}
+                        />
+                      )}
+
+                      {description !== '' && (
+                        <Box
+                          bgcolor={'#fafafa'}
+                          p={3}
+                          style={{border: '1px #eeeeee dashed'}}
+                        >
+                          <Typography>{description}</Typography>
+                        </Box>
+                      )}
+                      <ViewComponent
+                        viewName={viewName}
                         ui_specification={ui_specification}
+                        formProps={formProps}
+                        draftState={this.draftState}
+                        annotation={this.state.annotation}
+                        handleAnnotation={this.updateannotation}
+                        isSyncing={this.props.isSyncing}
+                        conflictfields={this.props.conflictfields}
+                        handleChangeTab={this.props.handleChangeTab}
+                        fieldNames={fieldNames}
+                        disabled={this.props.disabled}
+                        visitedSteps={this.state.visitedSteps}
+                        currentStepId={this.state.view_cached ?? ''}
+                        isRevisiting={this.state.isRevisiting}
+                        handleSectionClick={this.handleSectionClick}
+                      />
+                      <FormButtonGroup
+                        record_type={this.state.type_cached}
+                        is_final_view={is_final_view}
+                        disabled={this.props.disabled}
                         onChangeStepper={this.onChangeStepper}
-                        views={views}
-                        formErrors={formProps.errors}
                         visitedSteps={this.state.visitedSteps}
                         isRecordSubmitted={isRecordSubmitted}
-                      />
-                    )}
-
-                    {description !== '' && (
-                      <Box
-                        bgcolor={'#fafafa'}
-                        p={3}
-                        style={{border: '1px #eeeeee dashed'}}
-                      >
-                        <Typography>{description}</Typography>
-                      </Box>
-                    )}
-                    <ViewComponent
-                      viewName={viewName}
-                      ui_specification={ui_specification}
-                      formProps={formProps}
-                      draftState={this.draftState}
-                      annotation={this.state.annotation}
-                      handleAnnotation={this.updateannotation}
-                      isSyncing={this.props.isSyncing}
-                      conflictfields={this.props.conflictfields}
-                      handleChangeTab={this.props.handleChangeTab}
-                      fieldNames={fieldNames}
-                      disabled={this.props.disabled}
-                      visitedSteps={this.state.visitedSteps}
-                      currentStepId={this.state.view_cached ?? ''}
-                      isRevisiting={this.state.isRevisiting}
-                      handleSectionClick={this.handleSectionClick}
-                    />
-                    <FormButtonGroup
-                      record_type={this.state.type_cached}
-                      is_final_view={is_final_view}
-                      disabled={this.props.disabled}
-                      onChangeStepper={this.onChangeStepper}
-                      visitedSteps={this.state.visitedSteps}
-                      isRecordSubmitted={isRecordSubmitted}
-                      view_index={view_index}
-                      formProps={formProps}
-                      ui_specification={ui_specification}
-                      views={views}
-                      handleFormSubmit={(is_close: string) => {
-                        formProps.setSubmitting(true);
-                        this.setTimeout(() => {
-                          this.save(
-                            formProps.values,
-                            is_close,
-                            formProps.setSubmitting
-                          );
-                        }, 500);
-                      }}
-                      layout={layout}
-                    />
-                    {this.state.revision_cached !== undefined && (
-                      <Box mt={3}>
-                        <Divider />
-                        <UGCReport
-                          handleUGCReport={(value: string) => {
-                            this.setState({ugc_comment: value});
+                        view_index={view_index}
+                        formProps={formProps}
+                        ui_specification={ui_specification}
+                        views={views}
+                        handleFormSubmit={(is_close: string) => {
+                          formProps.setSubmitting(true);
+                          this.setTimeout(() => {
                             this.save(
                               formProps.values,
-                              'continue',
+                              is_close,
                               formProps.setSubmitting
                             );
-                          }}
-                        />
-                      </Box>
-                    )}
+                          }, 500);
+                        }}
+                        layout={layout}
+                      />
+                      {this.state.revision_cached !== undefined && (
+                        <Box mt={3}>
+                          <Divider />
+                          <UGCReport
+                            handleUGCReport={(value: string) => {
+                              this.setState({ugc_comment: value});
+                              this.save(
+                                formProps.values,
+                                'continue',
+                                formProps.setSubmitting
+                              );
+                            }}
+                          />
+                        </Box>
+                      )}
+                    </div>
                   </Form>
                 );
               }}

--- a/app/src/gui/components/record/recordStepper.tsx
+++ b/app/src/gui/components/record/recordStepper.tsx
@@ -31,7 +31,7 @@ import {
   Typography,
   keyframes,
   styled,
-  useTheme
+  useTheme,
 } from '@mui/material';
 import {useState} from 'react';
 import {createUseStyles} from 'react-jss';
@@ -117,7 +117,7 @@ export default function RecordStepper(props: RecordStepperProps) {
     formErrors,
     isRecordSubmitted,
   } = props;
-  const [shakeStepper, setShakeStepper] = useState(false);
+  const [shakeStepper, _setShakeStepper] = useState(false);
   const theme = useTheme();
 
   // function to check if stepper has erros
@@ -215,7 +215,11 @@ export default function RecordStepper(props: RecordStepperProps) {
             visitedSteps={visitedSteps}
             isRecordSubmitted={isRecordSubmitted}
           />
-          <Typography variant="h4" align="center" style={{marginTop: theme.spacing(2)}}>
+          <Typography
+            variant="h4"
+            align="center"
+            style={{marginTop: theme.spacing(2)}}
+          >
             {ui_specification.views[views[view_index]]?.label}
           </Typography>
         </Box>

--- a/app/src/gui/components/record/recordStepper.tsx
+++ b/app/src/gui/components/record/recordStepper.tsx
@@ -31,11 +31,11 @@ import {
   Typography,
   keyframes,
   styled,
+  useTheme
 } from '@mui/material';
 import {useState} from 'react';
 import {createUseStyles} from 'react-jss';
 import {getStepColor} from '../../../utils/generateStepperColors';
-import {theme} from '../../themes';
 
 type RecordStepperProps = {
   view_index: number;
@@ -118,6 +118,7 @@ export default function RecordStepper(props: RecordStepperProps) {
     isRecordSubmitted,
   } = props;
   const [shakeStepper, setShakeStepper] = useState(false);
+  const theme = useTheme();
 
   // function to check if stepper has erros
   const hasErrors = (sectionId: string | undefined) => {
@@ -136,7 +137,6 @@ export default function RecordStepper(props: RecordStepperProps) {
     <>
       <Box display={{xs: 'none', sm: 'block'}} py={1}>
         <div style={{overflowX: 'visible', position: 'relative', zIndex: 1}}>
-          {' '}
           <Stepper
             nonLinear
             activeStep={view_index}
@@ -215,7 +215,7 @@ export default function RecordStepper(props: RecordStepperProps) {
             visitedSteps={visitedSteps}
             isRecordSubmitted={isRecordSubmitted}
           />
-          <Typography variant="h5" align="center">
+          <Typography variant="h4" align="center" style={{marginTop: theme.spacing(2)}}>
             {ui_specification.views[views[view_index]]?.label}
           </Typography>
         </Box>

--- a/app/src/gui/components/record/view.tsx
+++ b/app/src/gui/components/record/view.tsx
@@ -19,29 +19,29 @@
  *   20220620 BBS Adjusted sm to 11 from 8 to get rid of the awful margin reported in FAIMS3-328
  */
 
-import React, {useState} from 'react';
-import {FormikProps} from 'formik';
 import {ProjectUIModel} from '@faims3/data-model';
-import RecordDraftState from '../../../sync/draft-state';
-import {getComponentFromFieldConfig} from './fields';
-import {AnnotationField} from './Annotation';
+import NoteIcon from '@mui/icons-material/Note';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import {
-  Box,
-  Grid,
-  Paper,
   Alert,
-  IconButton,
+  Box,
   Collapse,
-  Link,
-  Typography,
   Divider,
+  Grid,
+  IconButton,
+  Link,
+  Paper,
+  Typography,
   useMediaQuery,
 } from '@mui/material';
-import {EditConflictDialog} from './conflict/conflictDialog';
-import NoteIcon from '@mui/icons-material/Note';
 import {grey} from '@mui/material/colors';
+import {FormikProps} from 'formik';
+import React from 'react';
+import RecordDraftState from '../../../sync/draft-state';
 import {theme} from '../../themes';
-import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import {AnnotationField} from './Annotation';
+import {EditConflictDialog} from './conflict/conflictDialog';
+import {getComponentFromFieldConfig} from './fields';
 
 type ViewProps = {
   viewName: string;
@@ -112,9 +112,6 @@ function SingleComponent(props: SingleComponentProps) {
   const fieldConfig = fields[fieldName];
   const label = fieldConfig['component-parameters'].label;
   const [expanded, setExpanded] = React.useState(false);
-  const hasError = Boolean(
-    props.formProps.errors[fieldName] && props.formProps.touched[fieldName]
-  );
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -263,14 +260,8 @@ function SingleComponent(props: SingleComponentProps) {
  */
 
 export function ViewComponent(props: ViewProps) {
-  const {
-    visitedSteps,
-    viewName,
-    formProps,
-    ui_specification,
-    isRevisiting,
-    handleSectionClick,
-  } = props;
+  const {visitedSteps, viewName, formProps, ui_specification, isRevisiting} =
+    props;
   const fieldNames: string[] = props.fieldNames;
   const fields = ui_specification.fields;
 
@@ -365,7 +356,7 @@ export function ViewComponent(props: ViewProps) {
                 Other sections have errors. Click to navigate:
               </Typography>
 
-              {otherSectionsWithErrors.map((section, index) => (
+              {otherSectionsWithErrors.map((section, _index) => (
                 <Link
                   key={section}
                   component="button"
@@ -413,7 +404,7 @@ function displayErrors(
   thisView: string,
   ui_specification: ProjectUIModel,
   currentFields: string[],
-  otherSections?: string[]
+  _otherSections?: string[]
 ) {
   if (!errors) return <p>No errors to display</p>;
 

--- a/app/src/gui/components/ui/BackButton.tsx
+++ b/app/src/gui/components/ui/BackButton.tsx
@@ -2,10 +2,10 @@ import {IconButton, Typography, Box} from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 const BackButton = ({
-  label = 'Back',
+  label,
   onClick,
 }: {
-  label: string;
+  label?: string;
   onClick: () => void;
 }) => {
   return (
@@ -24,9 +24,11 @@ const BackButton = ({
       <IconButton color="primary" aria-label={label}>
         <ArrowBackIcon />
       </IconButton>
-      <Typography variant="caption" sx={{mt: 0.5}}>
-        {label}
-      </Typography>
+      {label && (
+        <Typography variant="caption" sx={{mt: 0.5}}>
+          {label}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/app/src/gui/components/ui/heading-grid.tsx
+++ b/app/src/gui/components/ui/heading-grid.tsx
@@ -24,11 +24,11 @@ import {ACTIVATED_LABEL, NOT_ACTIVATED_LABEL} from '../workspace/notebooks';
 export default function HeadingProjectGrid({
   projects,
   activatedColumns,
-  notActivatedColumns
+  notActivatedColumns,
 }: {
   projects: ProjectExtended[];
-  activatedColumns : GridColDef<ProjectExtended>[];
-  notActivatedColumns : GridColDef<ProjectExtended>[];
+  activatedColumns: GridColDef<ProjectExtended>[];
+  notActivatedColumns: GridColDef<ProjectExtended>[];
 }) {
   // pull out active/inactive surveys
   const activatedProjects = projects.filter(({activated}) => activated);

--- a/app/src/gui/components/ui/heading-grid.tsx
+++ b/app/src/gui/components/ui/heading-grid.tsx
@@ -1,6 +1,7 @@
 import {Stack} from '@mui/material';
 import {
   DataGrid,
+  GridColDef,
   GridEventListener,
   GridPaginationModel,
 } from '@mui/x-data-grid';
@@ -22,10 +23,12 @@ import {ACTIVATED_LABEL, NOT_ACTIVATED_LABEL} from '../workspace/notebooks';
  */
 export default function HeadingProjectGrid({
   projects,
-  columns,
+  activatedColumns,
+  notActivatedColumns
 }: {
   projects: ProjectExtended[];
-  columns: any;
+  activatedColumns : GridColDef<ProjectExtended>[];
+  notActivatedColumns : GridColDef<ProjectExtended>[];
 }) {
   // pull out active/inactive surveys
   const activatedProjects = projects.filter(({activated}) => activated);
@@ -60,7 +63,7 @@ export default function HeadingProjectGrid({
       <DataGrid
         key={'notebook_list_datagrid_activated'}
         rows={activatedProjects}
-        columns={columns}
+        columns={activatedColumns}
         onRowClick={handleRowClick}
         autoHeight
         sx={{
@@ -102,7 +105,7 @@ export default function HeadingProjectGrid({
       <DataGrid
         key={'notebook_list_datagrid_not_activated'}
         rows={availableProjects}
-        columns={columns}
+        columns={notActivatedColumns}
         autoHeight
         sx={{
           cursor: 'pointer',

--- a/app/src/gui/components/ui/tab-grid.tsx
+++ b/app/src/gui/components/ui/tab-grid.tsx
@@ -4,6 +4,7 @@ import TabPanel from '@mui/lab/TabPanel';
 import {Box, Tab} from '@mui/material';
 import {
   DataGrid,
+  GridColDef,
   GridEventListener,
   GridPaginationModel,
 } from '@mui/x-data-grid';
@@ -27,12 +28,14 @@ export default function TabProjectGrid({
   projects,
   tabID,
   handleChange,
-  columns,
+  activatedColumns,
+  notActivatedColumns,
 }: {
   projects: ProjectExtended[];
   tabID: string;
   handleChange: React.Dispatch<React.SetStateAction<string>>;
-  columns: any;
+  activatedColumns: GridColDef<ProjectExtended>[];
+  notActivatedColumns: GridColDef<ProjectExtended>[];
 }) {
   const activatedProjects = projects.filter(({activated}) => activated);
   const availableProjects = projects.filter(({activated}) => !activated);
@@ -90,7 +93,7 @@ export default function TabProjectGrid({
             <DataGrid
               key={`notebook_list_datagrid_${tab}`}
               rows={tab === '1' ? activatedProjects : availableProjects}
-              columns={columns}
+              columns={tab === '1' ? activatedColumns : notActivatedColumns}
               sx={{cursor: tab === '1' ? 'pointer' : 'default'}}
               onRowClick={handleRowClick}
               getRowId={({_id}) => _id}

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -20,7 +20,6 @@
 
 import {RefreshOutlined} from '@mui/icons-material';
 import AddCircleSharpIcon from '@mui/icons-material/AddCircleSharp';
-import FolderIcon from '@mui/icons-material/Folder';
 import {Alert, AlertTitle, Box, Button, Paper, Typography} from '@mui/material';
 import {grey} from '@mui/material/colors';
 import {useTheme} from '@mui/material/styles';

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -99,137 +99,46 @@ export default function NoteBooks() {
   const history = useNavigate();
 
   const theme = useTheme();
-  const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
+  const is_xs = !useMediaQuery(theme.breakpoints.up('sm'));
 
-  const columns: GridColDef<ProjectExtended>[] = not_xs
-    ? [
-        {
-          field: 'name',
-          headerName: 'Name',
-          type: 'string',
-          flex: 0.4,
-          minWidth: 200,
-          renderCell: ({row: {activated, name, description}}) => (
-            <Box my={3}>
-              <span
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  flexWrap: 'nowrap',
-                  padding: '12px 0',
-                }}
-              >
-                <FolderIcon
-                  fontSize={'small'}
-                  color={activated ? 'primary' : 'disabled'}
-                  sx={{mr: '8px'}}
-                />
-                <Typography
-                  variant={'body1'}
-                  fontWeight={activated ? 'bold' : 'normal'}
-                  color={activated ? 'black' : grey[800]}
-                  sx={{
-                    padding: '4px 0',
-                    lineHeight: 1,
-                  }}
-                >
-                  {name}
-                </Typography>
-              </span>
-              <Typography variant={'caption'}>{description}</Typography>
-            </Box>
-          ),
-        },
-        // commenting this untill the functionality is fixed for this column.
-        // {
-        //   field: 'last_updated',
-        //   headerName: 'Last Updated',
-        //   type: 'dateTime',
-        //   minWidth: 160,
-        //   flex: 0.2,
-        //   valueGetter: ({value}) => value && new Date(value),
-        // },
-        {
-          field: 'actions',
-          type: 'actions',
-          flex: 0.2,
-          minWidth: 160,
-          headerName: 'Sync',
-          description: `Toggle syncing this ${NOTEBOOK_NAME} to the server`,
-          renderCell: ({row}) => (
-            <NotebookSyncSwitch
-              project={row}
-              showHelperText={false}
-              setTabID={setTabID}
-            />
-          ),
-        },
-      ]
-    : [
-        {
-          field: 'name',
-          headerName: 'Name',
-          type: 'string',
-          flex: 0.4,
-          minWidth: 160,
-          renderCell: ({row: {activated, name, description}}) => (
-            <div>
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'flex-start',
-                  padding: '12px 0',
-                }}
-              >
-                <FolderIcon
-                  fontSize={'small'}
-                  color={activated ? 'secondary' : 'disabled'}
-                  sx={{mr: '4px'}}
-                />
-                <Typography
-                  variant={'body2'}
-                  fontWeight={activated ? 'bold' : 'normal'}
-                  color={activated ? 'black' : grey[800]}
-                  sx={{
-                    padding: '4px 0',
-                  }}
-                >
-                  {name}
-                </Typography>
-              </div>
-              <Typography variant={'caption'} sx={{paddingTop: '4px'}}>
-                {description}
-              </Typography>
-            </div>
-          ),
-        },
-        // commenting this until the functionality is fixed for this column.
-
-        // {
-        //   field: 'last_updated',
-        //   headerName: 'Last Updated',
-        //   type: 'dateTime',
-        //   minWidth: 100,
-        //   flex: 0.3,
-        //   valueGetter: ({value}) => value && new Date(value),
-        // },
-        {
-          field: 'actions',
-          type: 'actions',
-          flex: 0.3,
-          minWidth: 80,
-          headerName: 'Sync',
-          description: `Toggle syncing this ${NOTEBOOK_NAME} to the server`,
-          renderCell: ({row}) => (
-            <NotebookSyncSwitch
-              project={row}
-              showHelperText={false}
-              setTabID={setTabID}
-            />
-          ),
-        },
-      ];
-
+  const baseColumns: GridColDef<ProjectExtended>[] = [
+    {
+      field: 'name',
+      headerName: 'Name',
+      type: 'string',
+      flex: 0.4,
+      renderCell: ({row: {activated, name, description}}) => (
+        <Box>
+          <Typography
+            variant={is_xs ? 'body2' : 'body1'}
+            fontWeight={activated ? 'bold' : 'normal'}
+            color={activated ? 'black' : grey[800]}
+            sx={{
+              padding: '4px 0',
+            }}
+          >
+            {name} {description}
+          </Typography>
+          <Typography variant="caption">{description}</Typography>
+        </Box>
+      ),
+    },
+  ];
+  const activatedColumns = baseColumns;
+  const notActivatedColumns = baseColumns.concat([
+    {
+      field: 'actions',
+      type: 'actions',
+      width: 100,
+      renderCell: ({row}) => (
+        <NotebookSyncSwitch
+          project={row}
+          showHelperText={false}
+          setTabID={setTabID}
+        />
+      ),
+    },
+  ]);
   const showCreateNewNotebookButton = false; // activeUserToken && userCanCreateNotebooks(activeUserToken);
 
   // What type of layout are we using?
@@ -320,10 +229,15 @@ export default function NoteBooks() {
             projects={projects}
             tabID={tabID}
             handleChange={setTabID}
-            columns={columns}
+            activatedColumns={activatedColumns}
+            notActivatedColumns={notActivatedColumns}
           />
         ) : (
-          <HeadingProjectGrid projects={projects} columns={columns} />
+          <HeadingProjectGrid
+            projects={projects}
+            activatedColumns={activatedColumns}
+            notActivatedColumns={notActivatedColumns}
+          />
         )}
         <Alert severity="info">
           <AlertTitle>

--- a/app/src/gui/fields/RandomStyle.tsx
+++ b/app/src/gui/fields/RandomStyle.tsx
@@ -20,7 +20,7 @@
 
 import React from 'react';
 import {Box, Typography} from '@mui/material';
-import { contentToSanitizedHtml } from '../../utils/DomPurifier';
+import {contentToSanitizedHtml} from '../../utils/DomPurifier';
 
 interface Props {
   helperText?: string;
@@ -37,7 +37,11 @@ export class RandomStyle extends React.Component<Props> {
           {this.props.label}
         </Typography>
         <Typography variant="caption">{this.props.helperText}</Typography>
-        <div dangerouslySetInnerHTML={{__html: contentToSanitizedHtml(this.props.html_tag)}} />
+        <div
+          dangerouslySetInnerHTML={{
+            __html: contentToSanitizedHtml(this.props.html_tag),
+          }}
+        />
         <Typography
           paragraph
           sx={{fontWeight: 'fontWeightLight', fontSize: 11}}

--- a/app/src/gui/fields/RichText.tsx
+++ b/app/src/gui/fields/RichText.tsx
@@ -16,7 +16,7 @@
 
 /**
  * RichTextField Component
- * 
+ *
  * Safely injects markdown content directly into HTML - see DomPurifier.ts
  */
 

--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -170,8 +170,8 @@ const ImageGallery = ({
           gap: theme.spacing(1),
           padding: theme.spacing(1),
           gridTemplateColumns: {
-            // Show 3 images per row on mobile
-            xs: 'repeat(3, 1fr)',
+            // Show 2 images per row on mobile
+            xs: 'repeat(2, 1fr)',
             // Show 4 images per row on tablet
             sm: 'repeat(4, 1fr)',
             // Show 6 images per row on small desktop

--- a/app/src/gui/layout/appBar.tsx
+++ b/app/src/gui/layout/appBar.tsx
@@ -181,9 +181,9 @@ export default function MainAppBar() {
         <CssBaseline />
         <MuiAppBar
           position="relative"
-          sx={theme => ({
+          sx={{
             boxShadow: 'none',
-          })}
+          }}
         >
           <Toolbar>
             <IconButton
@@ -193,7 +193,7 @@ export default function MainAppBar() {
               edge="start"
               sx={{
                 mr: 0,
-                paddingLeft:1,
+                paddingLeft: 1,
                 paddingRight: 0,
                 display: isOpen ? 'hidden' : 'flex',
               }}

--- a/app/src/gui/layout/appBar.tsx
+++ b/app/src/gui/layout/appBar.tsx
@@ -18,7 +18,6 @@
  *   This contains the navbar React component, which allows users to navigate
  *   throughout the app.
  */
-
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import AccountTree from '@mui/icons-material/AccountTree';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -29,12 +28,12 @@ import ExpandMore from '@mui/icons-material/ExpandMore';
 import MenuIcon from '@mui/icons-material/Menu';
 import SettingsIcon from '@mui/icons-material/Settings';
 import {
+  Box,
   CircularProgress,
   IconButton,
   ListItemButton,
   AppBar as MuiAppBar,
   Toolbar,
-  createTheme,
 } from '@mui/material';
 import Collapse from '@mui/material/Collapse';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -43,9 +42,7 @@ import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import clsx from 'clsx';
 import React, {useContext, useState} from 'react';
-import {createUseStyles as makeStyles} from 'react-jss';
 import {Link as RouterLink} from 'react-router-dom';
 import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
 import * as ROUTES from '../../constants/routes';
@@ -61,15 +58,11 @@ import {AppBarHeading} from '../components/app-bar/app-bar-heading';
 import AppBarAuth from '../components/authentication/appbarAuth';
 import SyncStatus from '../components/sync';
 
+const drawerWidth = 240;
+
 /**
  * Represents the properties for a menu list item.
- * @typedef {Object} ProjectListItemProps
- * @property {string} title - The title of the menuitem.
- * @property {React.ReactElement} icon - The icon associated with the menuitem.
- * @property {string} to - The path to navigate to for this menuitem.
- * @property {boolean} disabled - Whether the menuitem is disabled in the list.
  */
-
 type ProjectListItemProps = {
   title: string;
   icon: any;
@@ -79,8 +72,8 @@ type ProjectListItemProps = {
 
 /**
  * Represents the type of icon used in the navigation menu.
- * @typedef {React.ReactElement | string | number | undefined} IconType
- */ type IconType =
+ */
+type IconType =
   | undefined
   | string
   | number
@@ -94,106 +87,9 @@ type MenuItemProps = {
   icon: IconType;
 };
 
-const drawerWidth = 240;
-const theme = createTheme();
-
-const useStyles = makeStyles({
-  root: {
-    display: 'flex',
-    boxShadow: 'none',
-  },
-  appBar: {
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    boxShadow: 'none',
-  },
-  appBarShift: {
-    width: `calc(100% - ${drawerWidth}px)`,
-    marginLeft: drawerWidth,
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  menuButton: {
-    marginRight: theme.spacing(2),
-  },
-  hide: {
-    display: 'none',
-  },
-  drawer: {
-    width: drawerWidth,
-    flexShrink: 0,
-    zIndex: 1500,
-  },
-  drawerPaper: {
-    width: drawerWidth,
-    height: '100vh',
-    boxShadow: '2px 0 10px rgba(0, 0, 0, 0.3)',
-    borderRight: '1px solid rgba(0, 0, 0, 0.1)',
-  },
-  drawerHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    padding: theme.spacing(0, 1),
-    minHeight: '64px',
-    justifyContent: 'flex-end',
-  },
-  content: {
-    flexGrow: 1,
-    padding: theme.spacing(3),
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginLeft: -drawerWidth,
-  },
-  contentShift: {
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginLeft: 0,
-  },
-  nested: {
-    paddingLeft: theme.spacing(4),
-  },
-  /**
-   * Styles for the ListItemText component in the navigation items.
-   * @type {Object}
-   */
-  listItemText: {
-    fontSize: '1.1rem',
-    fontWeight: 'bold',
-    color: 'rgba(0, 0, 0, 0.54)', // Use the same gray color as the icons (this is a common MUI icon color)
-  },
-  /**
-   * Styles for the bottom section options in the drawer.
-   * Includes padding and a border at the top.
-   * @type {Object}
-   */
-  bottomOptions: {
-    borderTop: `1px solid ${theme.palette.divider}`,
-    padding: theme.spacing(2, 0),
-  },
-  /**
-   * Ensures that the bottom section of the drawer is positioned at the bottom of the viewport.
-   * @type {Object}
-   */
-  bottomSection: {
-    marginTop: 'auto',
-  },
-});
-
 /**
  * Retrieves a list of nested menu items to be displayed in the navigation menu.
- * @function
- * @param {ProjectInformation[]} pouchProjectList - List of project information.
- * @returns {MenuItemProps} - The item for nested menu.
  */
-
 function getNestedProjects(pouchProjectList: ProjectExtended[]) {
   const projectListItems: ProjectListItemProps[] = [];
   pouchProjectList.map(project_info => {
@@ -216,16 +112,12 @@ function getNestedProjects(pouchProjectList: ProjectExtended[]) {
 /**
  * MainAppBar component handles the display of the navigation drawer and the app bar.
  * It includes top menu items, bottom menu items, and conditional rendering based on authentication status.
- *
- * @component
- * @returns {JSX.Element} - The rendered MainAppBar component.
+ * This version uses inline sx props for styling.
  */
 export default function MainAppBar() {
-  const classes = useStyles();
   const isAuthenticated = useAppSelector(selectIsAuthenticated);
   const activeServerId = useAppSelector(selectActiveServerId);
 
-  // get the list of activated projects
   const projectList = useContext(ProjectsContext).projects.filter(
     p => p.activated && p.listing === activeServerId
   );
@@ -264,7 +156,6 @@ export default function MainAppBar() {
       to: ROUTES.ABOUT_BUILD,
       disabled: false,
     },
-
     isAuthenticated
       ? {
           title: 'Sign out',
@@ -286,12 +177,12 @@ export default function MainAppBar() {
 
   return (
     <React.Fragment>
-      <div className={classes.root}>
+      <div style={{display: 'flex', boxShadow: 'none'}}>
         <CssBaseline />
         <MuiAppBar
           position="relative"
-          className={clsx(classes.appBar, {
-            [classes.appBarShift]: isOpen,
+          sx={theme => ({
+            boxShadow: 'none',
           })}
         >
           <Toolbar>
@@ -300,7 +191,12 @@ export default function MainAppBar() {
               aria-label="open drawer"
               onClick={toggle}
               edge="start"
-              className={clsx(classes.menuButton, isOpen && classes.hide)}
+              sx={{
+                mr: 0,
+                paddingLeft:1,
+                paddingRight: 0,
+                display: isOpen ? 'hidden' : 'flex',
+              }}
             >
               <MenuIcon />
             </IconButton>
@@ -319,20 +215,37 @@ export default function MainAppBar() {
           </Toolbar>
         </MuiAppBar>
         <Drawer
-          className={classes.drawer}
+          sx={{
+            width: drawerWidth,
+            flexShrink: 0,
+            zIndex: 1500,
+          }}
           variant="temporary"
           anchor="left"
           open={isOpen}
           ModalProps={{onBackdropClick: toggle}}
-          classes={{
-            paper: classes.drawerPaper,
+          PaperProps={{
+            sx: {
+              width: drawerWidth,
+              height: '100vh',
+              boxShadow: '2px 0 10px rgba(0, 0, 0, 0.3)',
+              borderRight: '1px solid rgba(0, 0, 0, 0.1)',
+            },
           }}
         >
-          <div className={classes.drawerHeader}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              px: 1,
+              minHeight: '64px',
+              justifyContent: 'flex-end',
+            }}
+          >
             <IconButton onClick={toggle} size="large">
               <ChevronLeftIcon />
             </IconButton>
-          </div>
+          </Box>
           <Divider />
 
           <List>
@@ -349,7 +262,15 @@ export default function MainAppBar() {
                     disabled={item.disabled}
                   >
                     <ListItemIcon>{item.icon}</ListItemIcon>
-                    <ListItemText classes={{primary: classes.listItemText}}>
+                    <ListItemText
+                      sx={{
+                        '& .MuiListItemText-primary': {
+                          fontSize: '1.1rem',
+                          fontWeight: 'bold',
+                          color: 'rgba(0, 0, 0, 0.54)',
+                        },
+                      }}
+                    >
                       {item.title}{' '}
                     </ListItemText>
                     {item.nested.length === 0 ? (
@@ -374,7 +295,7 @@ export default function MainAppBar() {
                           to: string;
                         }) => (
                           <ListItemButton
-                            className={classes.nested}
+                            sx={{pl: 4}}
                             key={
                               'nestedMenuItem' + item.title + nestedItem.title
                             }
@@ -385,8 +306,14 @@ export default function MainAppBar() {
                           >
                             <ListItemIcon>{nestedItem.icon}</ListItemIcon>
                             <ListItemText
+                              sx={{
+                                '& .MuiListItemText-primary': {
+                                  fontSize: '1.1rem',
+                                  fontWeight: 'bold',
+                                  color: 'rgba(0, 0, 0, 0.54)',
+                                },
+                              }}
                               primary={nestedItem.title}
-                              classes={{primary: classes.listItemText}}
                             />
                           </ListItemButton>
                         )
@@ -404,16 +331,27 @@ export default function MainAppBar() {
                 >
                   <ListItemIcon>{item.icon}</ListItemIcon>
                   <ListItemText
+                    sx={{
+                      '& .MuiListItemText-primary': {
+                        fontSize: '1.1rem',
+                        fontWeight: 'bold',
+                        color: 'rgba(0, 0, 0, 0.54)',
+                      },
+                    }}
                     primary={item.title}
-                    classes={{primary: classes.listItemText}}
                   />
                 </ListItemButton>
               );
             })}
           </List>
-          <div className={classes.bottomSection}>
+          <Box sx={{mt: 'auto'}}>
             <Divider />
-            <List className={classes.bottomOptions}>
+            <List
+              sx={theme => ({
+                borderTop: `1px solid ${theme.palette.divider}`,
+                py: 2,
+              })}
+            >
               {bottomMenuItems.map(
                 (item: {
                   title: string;
@@ -430,14 +368,20 @@ export default function MainAppBar() {
                   >
                     <ListItemIcon>{item.icon}</ListItemIcon>
                     <ListItemText
+                      sx={{
+                        '& .MuiListItemText-primary': {
+                          fontSize: '1.1rem',
+                          fontWeight: 'bold',
+                          color: 'rgba(0, 0, 0, 0.54)',
+                        },
+                      }}
                       primary={item.title}
-                      classes={{primary: classes.listItemText}}
                     />
                   </ListItemButton>
                 )
               )}
             </List>
-          </div>
+          </Box>
         </Drawer>
       </div>
       <SystemAlert />

--- a/app/src/gui/pages/notebook.tsx
+++ b/app/src/gui/pages/notebook.tsx
@@ -27,25 +27,15 @@
  * - React Router: useParams, useNavigate
  * - Material UI: Box, Typography, Chip, IconButton, CircularProgress
  */
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import ErrorIcon from '@mui/icons-material/Error';
-import MenuBookIcon from '@mui/icons-material/MenuBook';
-import {
-  Box,
-  Chip,
-  CircularProgress,
-  IconButton,
-  Typography,
-} from '@mui/material';
+import {CircularProgress, Stack, Typography} from '@mui/material';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {useContext} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
-import {NOTEBOOK_NAME_CAPITALIZED} from '../../buildconfig';
 import * as ROUTES from '../../constants/routes';
 import {ProjectsContext} from '../../context/projects-context';
 import NotebookComponent from '../components/notebook';
+import BackButton from '../components/ui/BackButton';
 
 export default function Notebook() {
   const theme = useTheme();
@@ -56,131 +46,32 @@ export default function Notebook() {
   const project = useContext(ProjectsContext).projects.find(
     project => project_id === project.project_id
   );
-  const mq_above_md = useMediaQuery(theme.breakpoints.up('md'));
-  const isActive = project?.activated;
+  const largerThanMedium = useMediaQuery(theme.breakpoints.up('md'));
 
   if (!project) return <CircularProgress data-testid="progressbar" />;
 
   return (
-    <Box>
-      {/* Back Button Section */}
-      <Box sx={{display: 'flex', alignItems: 'center', padding: '8px'}}>
-        <IconButton
+    <Stack spacing={2}>
+      <Stack direction="row" alignItems={'center'}>
+        <BackButton
+          //label={`Back to ${NOTEBOOK_NAME_CAPITALIZED}s`}
           onClick={() => history(ROUTES.INDEX)}
-          aria-label="back"
-          size="small"
-          sx={{color: 'black'}}
-        >
-          <ArrowBackIcon />
-        </IconButton>
+        ></BackButton>
+
         <Typography
-          variant="body1"
-          sx={{marginLeft: '8px', fontWeight: 'bold'}}
-        >
-          Back to {NOTEBOOK_NAME_CAPITALIZED}s
-        </Typography>
-      </Box>
-
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '8px 16px',
-        }}
-      >
-        <Box
-          sx={{display: 'flex', alignItems: 'center', flexGrow: 1, minWidth: 0}}
-        >
-          <MenuBookIcon
-            fontSize={mq_above_md ? 'large' : 'medium'}
-            sx={{marginRight: '8px', color: theme.palette.secondary.main}}
-          />
-          <Typography
-            variant={mq_above_md ? 'h4' : 'h5'}
-            component="div"
-            sx={{
-              fontWeight: 'bold',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              fontSize: '1.6rem',
-            }}
-          >
-            {project.name}
-          </Typography>
-        </Box>
-
-        <Box
+          variant={largerThanMedium ? 'h3' : 'h4'}
+          component="div"
           sx={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            textAlign: 'center',
-            marginLeft: {xs: '32px', sm: '24px', md: '20px'},
+            fontWeight: 'bold',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
           }}
         >
-          {isActive ? (
-            <Chip
-              label="Active"
-              icon={<CheckCircleIcon />}
-              sx={{
-                backgroundColor: 'green',
-                color: 'white',
-                fontSize: '15px',
-                fontWeight: 'bold',
-                borderRadius: '8px',
-                '& .MuiChip-icon': {
-                  color: 'white',
-                },
-              }}
-            />
-          ) : (
-            <Chip
-              label="Not Active"
-              icon={<ErrorIcon sx={{color: 'white'}} />}
-              sx={{
-                backgroundColor: '#b62b2b',
-                color: 'white',
-                fontSize: '15px',
-                fontWeight: 'bold',
-                borderRadius: '8px',
-                '& .MuiChip-icon': {
-                  color: 'white',
-                },
-              }}
-            />
-          )}
-        </Box>
-      </Box>
-      {/* <Grid
-        container
-        direction="row"
-        justifyContent="flex-start"
-        alignItems="center"
-        spacing={2}
-      >
-        <Grid item xs={'auto'}>
-          <Typography variant={mq_above_md ? 'h3' : 'h4'} component={'div'}>
-            <Grid
-              container
-              direction="row"
-              justifyContent="flex-start"
-              alignItems="center"
-              spacing={1}
-            >
-              <Grid item>
-                <FolderIcon
-                  sx={{color: theme.palette.secondary.main}}
-                  fontSize={mq_above_md ? 'large' : 'medium'}
-                  style={{verticalAlign: 'middle'}}
-                />
-              </Grid>
-              <Grid item>{project.name}</Grid>
-            </Grid>
-          </Typography>
-        </Grid>
-      </Grid> */}
+          {project.name}
+        </Typography>
+      </Stack>
+
       <NotebookComponent project={project} />
-    </Box>
+    </Stack>
   );
 }

--- a/app/src/gui/pages/workspace.tsx
+++ b/app/src/gui/pages/workspace.tsx
@@ -38,7 +38,7 @@ export default function Workspace() {
       <Grid container spacing={3}>
         <Grid item xs={12} md={12} lg={8}>
           <Typography
-            variant="h1"
+            variant="h2"
             color="textSecondary"
             style={{marginBottom: theme.spacing(2)}}
           >

--- a/app/src/gui/themes/default/index.tsx
+++ b/app/src/gui/themes/default/index.tsx
@@ -18,9 +18,8 @@
  *   TODO
  */
 
-import {createTheme, colors} from '@mui/material';
+import {colors, createTheme} from '@mui/material';
 import typography from './typography';
-import {generateStepperColors} from '../../../utils/generateStepperColors';
 
 const theme = createTheme({
   stepperColors: {


### PR DESCRIPTION
# feat: upgraded small screen scaling and various UI improvements

Various UI tweaks in critical views to simplify layouts and fix various bugs. 

Summary of changes: 

- live reload android emulator procedure documented, enabling rapid testing on more realistic device scaling
- rework the survey landing page to unify tabs into single set of tabs, intelligently display required tabs, show arrow icons to enable scrolling with dynamic transitioned width to not waste vertical space when at extremes of tab range, improve component structure/layout, remove truncation of title, remove status icon and remove text from back button
- add dynamic form padding depending on screen size
- increase mobile stepper view section header size and spacing
- remove sync toggle from activated surveys landing page, simplify styling, remove icons, separate into activated and not activated column definitions
- fix issue on small device scaling where delete button obscures image by decreasing grid count to 2 on xs displays
- refactored appBar to use inline sx styling for consistency with remaining code base, simplified styling by removing unnecessary/complex x layout shift on drawer open, decreased heading sizing and various padding to make this fit on small device sizes without cutting off the profile icon 

## To test 

I'd recommend trying out on large and small display sizes - I have tested on the emulator with the smallest device I could find and these changes significantly improve display.