### PR TITLE
fix: activation of new notebook after refresh

### DIFF
--- a/app/src/sync/process-initialization.ts
+++ b/app/src/sync/process-initialization.ts
@@ -366,7 +366,6 @@ async function get_project_from_directory(
 
   if (listing_id in projects_dbs) {
     const project_db = projects_dbs[listing_id];
-    console.log(await project_db.local.allDocs());
     try {
       const result = await project_db.local.get(project_id);
       return result as ProjectObject;

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
         "dotenv": "^16.3.1",
         "env-cmd": "^10.1.0",
         "jest-fast-check": "1.0.2",
-        "mocha": "^10.2.0",
+        "mocha": "^10.8.2",
         "nano": "^10.1.2",
         "node-fetch": "^3.3.2",
         "nodemon": "^2.0.20",
@@ -38034,9 +38034,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
-      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",


### PR DESCRIPTION
# fix: activation of new notebook after refresh

## JIRA Ticket

[BSS-715](https://jira.csiro.au/browse/BSS-715)

## Description

Fixes bug in which surveys could not be activated when they had arrived from a refresh survey list update. 

This was due to the `projects_dbs[listing_id]` not being updated during this action. 

This change is stupid and should not be necessary - the issue is that there are now two places in which this data is tracked!! The projects_db in the context management, and also in projects_dbs for the listing. They also have different data structures and data models. 

This whole thing needs a rewrite to unify the project/listing management to a single store. And there is literally no reason for it to be a pouch DB. 

## Proposed Changes

Through code surgery/shenanigans pulls out the logic which syncs the projects_dbs code from the process-initialisation file and reuses it in the context management code. 

## How to Test

Have no surveys. Open app, login. Add a survey on conductor. Refresh survey list. Activate the new survey that appears, ensure it works. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
