### PR TITLE
feat: back button display and intercept to safely alert draft creation

### DIFF
--- a/app/src/gui/components/ui/BackButton.tsx
+++ b/app/src/gui/components/ui/BackButton.tsx
@@ -4,27 +4,31 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 const BackButton = ({
   label = 'Back',
   onClick,
+  singleLine = false, // control layout for new record / draft record vieww
 }: {
   label: string;
   onClick: () => void;
+  singleLine?: boolean;
 }) => {
   return (
     <Box
       sx={{
         display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        maxWidth: 60,
-        '&:hover': {
-          cursor: 'pointer',
-        },
+        alignItems: singleLine ? 'center' : 'flex-start',
+        flexDirection: singleLine ? 'row' : 'column',
+        gap: singleLine ? 2 : 0,
+        cursor: 'pointer',
       }}
       onClick={onClick}
     >
-      <IconButton color="primary" aria-label={label}>
-        <ArrowBackIcon />
+      <IconButton color="primary" aria-label={label} sx={{p: 0}}>
+        <ArrowBackIcon sx={{fontSize: 28}} />
       </IconButton>
-      <Typography variant="caption" sx={{mt: 0.5}}>
+      <Typography
+        variant="h5"
+        fontWeight="bold"
+        sx={{color: 'primary.main', textAlign: singleLine ? 'left' : 'center'}}
+      >
         {label}
       </Typography>
     </Box>

--- a/app/src/gui/pages/notebook.tsx
+++ b/app/src/gui/pages/notebook.tsx
@@ -52,9 +52,9 @@ export default function Notebook() {
 
   return (
     <Stack spacing={2}>
-      <Stack direction="row" alignItems={'center'}>
+      <Stack direction="row" alignItems={'center'} spacing={2}>
         <BackButton
-          //label={`Back to ${NOTEBOOK_NAME_CAPITALIZED}s`}
+        label="Back"
           onClick={() => history(ROUTES.INDEX)}
         ></BackButton>
 

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -155,6 +155,7 @@ interface DraftRecordEditProps {
   record_id: RecordID;
   state?: any;
   location?: Location;
+  onBack: () => void;
 }
 
 function DraftRecordEdit(props: DraftRecordEditProps) {
@@ -226,6 +227,9 @@ function DraftRecordEdit(props: DraftRecordEditProps) {
   return (
     <React.Fragment>
       <Grid container justifyContent={'space-between'} spacing={2}>
+        <Grid item>
+          <BackButton label="Back" onClick={props.onBack} />
+        </Grid>
         <Grid item xs>
           <ProgressBar percentage={progress} />
         </Grid>
@@ -368,21 +372,6 @@ export default function RecordCreate() {
   return (
     <React.Fragment>
       <Box>
-        <Grid
-          container
-          wrap="nowrap"
-          spacing={2}
-          padding={1}
-          alignItems="center"
-        >
-          <Grid item>
-            <BackButton
-              label="Back to records"
-              onClick={() => setOpenDialog(true)}
-              singleLine
-            />
-          </Grid>
-        </Grid>
         {
           // only show breadcrumbs if we have parent record
         }
@@ -397,6 +386,7 @@ export default function RecordCreate() {
           />
         ) : (
           <DraftRecordEdit
+            onBack={() => setOpenDialog(true)}
             project_info={projectInfo}
             project_id={project_id!}
             type_name={type_name!}

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -351,7 +351,7 @@ export default function RecordCreate() {
 
   // detect when user click's android back buttn
   useEffect(() => {
-    const handleAndroidBackPress = (event: Event) => {
+    const handleBackEvent = (event: Event) => {
       event.preventDefault();
       setAndroidBackPressed(true);
       setOpenDialog(true);
@@ -361,11 +361,11 @@ export default function RecordCreate() {
       setOpenDialog(true);
     };
     window.addEventListener('popstate', handlePopState);
-    window.addEventListener('beforeunload', handleAndroidBackPress);
+    window.addEventListener('beforeunload', handleBackEvent);
 
     return () => {
       window.removeEventListener('popstate', handlePopState);
-      window.removeEventListener('beforeunload', handleAndroidBackPress);
+      window.removeEventListener('beforeunload', handleBackEvent);
     };
   }, []);
 

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -455,7 +455,7 @@ export default function Record() {
       >
         <Grid item>
           <BackButton
-            label="Back to records"
+            label="Back"
             onClick={() => {
               // Go back to the records list
               history({

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
         "dotenv": "^16.3.1",
         "env-cmd": "^10.1.0",
         "jest-fast-check": "1.0.2",
-        "mocha": "^10.2.0",
+        "mocha": "^10.8.2",
         "nano": "^10.1.2",
         "node-fetch": "^3.3.2",
         "nodemon": "^2.0.20",
@@ -37896,10 +37896,11 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
-      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",


### PR DESCRIPTION
# feat: back button display and intercept to safely alert draft creation

## JIRA Ticket

BSS-718

-As discussed with Elana:
- Added a back button that will take user back to the survey (where records are dispalyed that user has created)


New updates: 
- Used BackButton component to display a back to records button from the record creation phases.
- Improved styling for back button to be displayed  like "back to surveys" button to maintain consistency
      - Back button will be displayed like before in record draft view - in wrapped state as previosuly.
- Added android back button effect to detect when user click back button from device, if yes then popup is shown to alert user that there's a draft being saved.
- Back button from record creation also introduces a popup for user to know that there's draft being saved for that record.
![image](https://github.com/user-attachments/assets/f5013af3-ce8d-4ea5-8096-2fa34372d0c7)
![image](https://github.com/user-attachments/assets/f5e5c54b-3436-4bc7-a077-28fde5950ace)
![image](https://github.com/user-attachments/assets/151b73ec-4d2b-4c70-bcb4-9211e98c8bc8)


## Checklist

- [y ] I have confirmed all commits have been signed.
- [ y] I have added JSDoc style comments to any new functions or classes.
- [y ] Relevant documentation such as READMEs, guides, and class comments are updated.