### PR TITLE
fix: designer photo rich text field BSS

### DIFF
--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -418,11 +418,12 @@ export class FaimsFrontEnd extends Construct {
       domainNames: props.designerDomainNames,
       removalPolicy: RemovalPolicy.DESTROY,
       // Add custom header response overriding CSP to allow unsafe script
-      // execution due to parsing
+      // execution due to parsing - also allow images/blobs for rich text
+      // editing
       securityHeadersBehavior: {
         contentSecurityPolicy: {
           contentSecurityPolicy:
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
+            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:;",
           override: true,
         },
       },


### PR DESCRIPTION
# fix: designer photo rich text field BSS

Fixes missing CSP allowance for image data types on BSS CDK deployment.
