### PR TITLE
feat: field duplication function in designer

### DIFF
--- a/designer/src/components/field-editor.tsx
+++ b/designer/src/components/field-editor.tsx
@@ -18,6 +18,7 @@ import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRound
 import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import MoveRoundedIcon from '@mui/icons-material/DriveFileMoveRounded';
+import DuplicateIcon from '@mui/icons-material/ContentCopy';
 import {
   Accordion,
   AccordionDetails,
@@ -86,6 +87,8 @@ export const FieldEditor = ({
   const [openMoveDialog, setOpenMoveDialog] = useState(false);
   const [targetViewId, setTargetViewId] = useState('');
   const [selectedFormId, setSelectedFormId] = useState<string | null>(null);
+  const [openDuplicateDialog, setOpenDuplicateDialog] = useState(false);
+  const [duplicateTitle, setDuplicateTitle] = useState('');
 
   const fieldComponent = field['component-name'];
 
@@ -126,6 +129,32 @@ export const FieldEditor = ({
   const addFieldBelow = (event: React.SyntheticEvent) => {
     event.stopPropagation();
     addFieldCallback(fieldName);
+  };
+
+  const handleOpenDuplicateDialog = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+    const currentLabel = getFieldLabel();
+    setDuplicateTitle(currentLabel + ' Copy');
+    setOpenDuplicateDialog(true);
+  };
+
+  const handleCloseDuplicateDialog = () => {
+    setOpenDuplicateDialog(false);
+    setDuplicateTitle('');
+  };
+
+  const duplicateField = () => {
+    if (duplicateTitle.trim()) {
+      dispatch({
+        type: 'ui-specification/fieldDuplicated',
+        payload: {
+          originalFieldName: fieldName,
+          newFieldName: duplicateTitle.trim(),
+          viewId,
+        },
+      });
+      handleCloseDuplicateDialog();
+    }
   };
 
   const handleCloseMoveDialog = () => {
@@ -314,6 +343,15 @@ export const FieldEditor = ({
                   <PlaylistAddIcon />
                 </IconButton>
               </Tooltip>
+              <Tooltip title="Duplicate Field">
+                <IconButton
+                  onClick={handleOpenDuplicateDialog}
+                  aria-label="duplicate"
+                  size="small"
+                >
+                  <DuplicateIcon />
+                </IconButton>
+              </Tooltip>
               <Tooltip title="Move up">
                 <IconButton onClick={moveFieldUp} aria-label="up" size="small">
                   <ArrowDropUpRoundedIcon />
@@ -393,6 +431,41 @@ export const FieldEditor = ({
             disabled={!selectedFormId || !targetViewId}
           >
             Move
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={openDuplicateDialog}
+        onClose={handleCloseDuplicateDialog}
+        aria-labelledby="duplicate-dialog-title"
+        maxWidth="sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DialogTitle id="duplicate-dialog-title" textAlign="center">
+          Duplicate Field
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{mb: 2}}>
+            Enter a title for the duplicated field.
+          </Typography>
+          <TextField
+            autoFocus
+            fullWidth
+            value={duplicateTitle}
+            onChange={(e) => setDuplicateTitle(e.target.value)}
+            label="Field Title"
+            variant="outlined"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDuplicateDialog}>Cancel</Button>
+          <Button 
+            onClick={duplicateField}
+            disabled={!duplicateTitle.trim()}
+          >
+            Duplicate
           </Button>
         </DialogActions>
       </Dialog>

--- a/designer/src/state/uiSpec-reducer.ts
+++ b/designer/src/state/uiSpec-reducer.ts
@@ -245,6 +245,50 @@ export const uiSpecificationReducer = createSlice({
         );
       }
     },
+    fieldDuplicated: (
+      state,
+      action: PayloadAction<{
+        originalFieldName: string;
+        newFieldName: string;
+        viewId: string;
+      }>
+    ) => {
+      const {originalFieldName, newFieldName, viewId} = action.payload;
+
+      // check if original field exists
+      if (!(originalFieldName in state.fields)) {
+        throw new Error(
+          `Cannot duplicate unknown field ${originalFieldName}`
+        );
+      }
+
+      // create a deep copy of the original field
+      const originalField = state.fields[originalFieldName];
+      const newField: FieldType = JSON.parse(JSON.stringify(originalField));
+
+      // generate a unique field label/name
+      let fieldLabel = slugify(newFieldName);
+      let N = 1;
+      while (fieldLabel in state.fields) {
+        fieldLabel = slugify(newFieldName + ' ' + N);
+        N += 1;
+      }
+
+      // update the new field's label and name
+      newField['component-parameters'].label = newFieldName;
+      newField['component-parameters'].name = fieldLabel;
+
+      // add the new field to the state
+      state.fields[fieldLabel] = newField;
+
+      // add the new field to the view right after the original field
+      const fields = state.fviews[viewId].fields;
+      const position = fields.indexOf(originalFieldName) + 1;
+      state.fviews[viewId].fields = fields
+        .slice(0, position)
+        .concat([fieldLabel])
+        .concat(fields.slice(position));
+    },
     sectionRenamed: (
       state,
       action: PayloadAction<{viewId: string; label: string}>
@@ -500,6 +544,7 @@ export const {
   fieldRenamed,
   fieldAdded,
   fieldDeleted,
+  fieldDuplicated,
   sectionRenamed,
   sectionAdded,
   sectionDeleted,


### PR DESCRIPTION
# feat: field duplication function in designer

## JIRA Ticket

[BSS-645](https://jira.csiro.au/browse/BSS-645)

## Description

This PR adds a new feature to allow users to duplicate fields with a customizable title through a dialog interface.

## Proposed Changes

- Added `openDuplicateDialog` and `duplicateTitle` state variables.
- Split duplication logic into three functions:
  - `handleOpenDuplicateDialog`: Opens dialog with a pre-filled title.
  - `handleCloseDuplicateDialog`: Closes dialog and resets the title.
  - `duplicateField`: Handles duplication with the new title.
- Added a `Dialog` component with a text field, input validation, and action buttons.
- Implemented `fieldDuplicated` reducer to handle field duplication, ensuring unique names and maintaining state integrity.

## How to Test

1. Click the duplicate icon on a field.
2. Verify that a dialog appears with the original field's title appended with " Copy".
3. Modify the title in the text field (optional).
4. Ensure the "Duplicate" button is disabled if the title is empty.
5. Click "Cancel" to close it without duplicating.
6. Click "Duplicate" with a valid title and verify that:
    - A new field appears right after the original field.
    - The new field has the same properties as the original but with a unique title and name.
    - The new field is correctly added to the state and UI.

## Additional Information

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
