### PR TITLE
feat: admin forgot password reset workflow

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,34 @@
+# Upgrades/Migrations
+
+This document will describe the necessary steps to migrate existing deployments through versions of FAIMS.
+
+# Upgrading from v1 to v1.1
+
+## Upgrade summary
+
+TBD - currently there are the following migrations needed.
+
+## Pull request migrations
+
+The following pull requests introduced breaking changes/migrations:
+
+### [feat: admin forgot password reset workflow](https://github.com/FAIMS/FAIMS3/pull/1334)
+
+**CouchDB migration**
+
+This functionality will not work until you apply the following migration
+
+- login as cluster admin to old conductor
+- copy the bearer token
+- update /api/.env with USER_TOKEN=<>
+- setup npm env cd /api && npm i
+- run the force init action npm run forceinitdb
+- Try generating a code and make sure the workflow is functional.
+
+**Deployment configuration**
+
+Add the new `NEW_CONDUCTOR_URL` environment variable to the conductor/api build. This is already done in the aws-cdk IaC - however in existing deployments you may need to update your build configuration.
+
+**Note** ensure this includes the https:// prefix!
+
+This is a mandatory property and not including it will break the deployment.

--- a/api/.env.dist
+++ b/api/.env.dist
@@ -63,4 +63,4 @@ RATE_LIMITER_PER_WINDOW=1000
 RATE_LIMITER_ENABLED=true
 
 # What is the URL of the new conductor?
-NEW_CONDUCTOR_URL=http://localhost:5173
+NEW_CONDUCTOR_URL=http://localhost:3001

--- a/api/.env.dist
+++ b/api/.env.dist
@@ -61,3 +61,6 @@ RATE_LIMITER_PER_WINDOW=1000
 
 # Enable/disable rate limiting (default: true)
 RATE_LIMITER_ENABLED=true
+
+# What is the URL of the new conductor?
+NEW_CONDUCTOR_URL=http://localhost:5173

--- a/api/api_testing/passwordreset.http
+++ b/api/api_testing/passwordreset.http
@@ -1,0 +1,76 @@
+@resetBaseUrl = {{$dotenv BASE_URL}}/api/reset
+@token = {{$dotenv API_TOKEN}}
+
+### Initiate password reset (unauthorized - no token)
+POST {{resetBaseUrl}}
+Content-Type: application/json
+
+{
+    "email": "test@example.com"
+}
+
+### Initiate password reset
+# @name initiateReset
+POST {{resetBaseUrl}}
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "email": "test@gmail.com"
+}
+
+### Complete password reset (invalid code)
+PUT {{resetBaseUrl}}
+Content-Type: application/json
+
+{
+    "code": "INVALID_CODE",
+    "newPassword": "newSecurePassword123!"
+}
+
+### Complete password reset (success)
+# Uses the code from the previous initiate request
+PUT {{resetBaseUrl}}
+Content-Type: application/json
+
+{
+    "code": "{{initiateReset.response.body.code}}",
+    "newPassword": "newSecurePassword123!"
+}
+
+### Complete password reset (code already used)
+
+# Attempts to use the same code again
+PUT {{resetBaseUrl}}
+Content-Type: application/json
+
+{
+    "code": "{{initiateReset.response.body.code}}",
+    "newPassword": "anotherNewPassword456!"
+}
+
+### Complete password reset (password too short)
+PUT {{resetBaseUrl}}
+Content-Type: application/json
+
+{
+    "code": "{{initiateReset.response.body.code}}",
+    "newPassword": "short"
+}
+
+### Initiate password reset (invalid email format)
+POST {{resetBaseUrl}}
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "email": "not-an-email"
+}
+
+### Complete password reset (missing required fields)
+PUT {{resetBaseUrl}}
+Content-Type: application/json
+
+{
+    "code": ""
+}

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
     "start:prod": "node build/src/index.js",
     "local": "env-cmd nodemon --ignore build --ext ts --exec 'tsc --incremental && node .'",
     "initdb": "env-cmd node scripts/initialise.js",
+    "forceinitdb": "env-cmd node scripts/initialise.js --force",
     "load-notebooks": "env-cmd node scripts/loadNotebook.js ./notebooks/*.json",
     "load-templates": "env-cmd node scripts/loadTemplate.js ./notebooks/*.json",
     "test": "env-cmd cross-env NODE_ENV=test TS_NODE_PROJECT='./tsconfig.json' mocha --exit",

--- a/api/scripts/initialise.js
+++ b/api/scripts/initialise.js
@@ -21,7 +21,8 @@
 
 // how to import fetch in a node script...
 // needed to add this file to .eslintignore because it complains about 'import'
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+const fetch = (...args) =>
+  import('node-fetch').then(({default: fetch}) => fetch(...args));
 const CONDUCTOR_URL = process.env.CONDUCTOR_PUBLIC_URL;
 
 const main = async () => {
@@ -37,37 +38,35 @@ const main = async () => {
       );
       process.exit();
     }
-    
-    const token = JSON.parse(
-      Buffer.from(process.env.USER_TOKEN, 'base64').toString()
-    );
+
+    const token = process.env.USER_TOKEN;
 
     fetch(CONDUCTOR_URL + endpoint, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${token.jwt_token}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
-      }
+      },
     })
-    .then(response => response.json())
-    .then(data => {
-      console.log('data:', data);
-    })
-    .catch(error => {
-      console.log(error);
-    });
+      .then(response => response.json())
+      .then(data => {
+        console.log('data:', data);
+      })
+      .catch(error => {
+        console.log(error);
+      });
   } else {
     // Regular initialization without authentication
     fetch(CONDUCTOR_URL + endpoint, {
-      method: 'POST'
+      method: 'POST',
     })
-    .then(response => response.json())
-    .then(data => {
-      console.log('data:', data);
-    })
-    .catch(error => {
-      console.log(error);
-    });
+      .then(response => response.json())
+      .then(data => {
+        console.log('data:', data);
+      })
+      .catch(error => {
+        console.log(error);
+      });
   }
 };
 

--- a/api/scripts/initialise.js
+++ b/api/scripts/initialise.js
@@ -21,24 +21,54 @@
 
 // how to import fetch in a node script...
 // needed to add this file to .eslintignore because it complains about 'import'
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args)); 
-
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 const CONDUCTOR_URL = process.env.CONDUCTOR_PUBLIC_URL;
 
 const main = async () => {
+  // Check if --force flag is present in command line arguments
+  const forceFlag = process.argv.includes('--force');
+  const endpoint = forceFlag ? '/api/forceInitialise/' : '/api/initialise/';
 
-  fetch(CONDUCTOR_URL + '/api/initialise/', {
-    method: 'POST'
-  })
-  .then(response => response.json())
-  .then(data => {
-    console.log('data:', data);
-  })
-  .catch(error => {
-    console.log(error);
-  })
+  // If force flag is present, we need to authenticate
+  if (forceFlag) {
+    if (!process.env.USER_TOKEN) {
+      console.log(
+        'USER_TOKEN not set in .env - login to Conductor and copy your user token'
+      );
+      process.exit();
+    }
+    
+    const token = JSON.parse(
+      Buffer.from(process.env.USER_TOKEN, 'base64').toString()
+    );
 
+    fetch(CONDUCTOR_URL + endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token.jwt_token}`,
+        'Content-Type': 'application/json',
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      console.log('data:', data);
+    })
+    .catch(error => {
+      console.log(error);
+    });
+  } else {
+    // Regular initialization without authentication
+    fetch(CONDUCTOR_URL + endpoint, {
+      method: 'POST'
+    })
+    .then(response => response.json())
+    .then(data => {
+      console.log('data:', data);
+    })
+    .catch(error => {
+      console.log(error);
+    });
+  }
 };
 
-
-main()
+main();

--- a/api/src/api/emailReset.ts
+++ b/api/src/api/emailReset.ts
@@ -1,0 +1,111 @@
+import {
+  PostRequestPasswordResetRequestSchema,
+  PostRequestPasswordResetResponse,
+  PutRequestPasswordResetRequestSchema,
+  PutRequestPasswordResetResponse,
+} from '@faims3/data-model';
+import express, {Response} from 'express';
+import {processRequest} from 'zod-express-middleware';
+import {
+  buildCodeIntoUrl,
+  createNewEmailCode,
+  markCodeAsUsed,
+  validateEmailCode,
+} from '../couchdb/emailCodes';
+import {getUserFromEmailOrUsername, updateUserPassword} from '../couchdb/users';
+import * as Exceptions from '../exceptions';
+import {requireAuthenticationAPI, requireClusterAdmin} from '../middleware';
+
+export const api = express.Router();
+
+/**
+ * POST /reset
+ * Initiates a password reset by generating and sending a reset code.
+ * Requires admin authentication.
+ *
+ * @route POST /reset
+ * @param {object} req.body - The request body
+ * @param {string} req.body.email - The email address of the user requesting reset
+ * @returns {object} 200 - Success response
+ * @returns {object} 401 - Unauthorized
+ * @returns {object} 404 - User not found
+ */
+api.post(
+  '/',
+  processRequest({
+    body: PostRequestPasswordResetRequestSchema,
+  }),
+  requireAuthenticationAPI,
+  requireClusterAdmin,
+  async (req, res: Response<PostRequestPasswordResetResponse>) => {
+    if (!req.user) {
+      throw new Exceptions.UnauthorizedException(
+        'You are not allowed to initiate password resets.'
+      );
+    }
+
+    const {email} = req.body;
+
+    // Get the user by email
+    const user = await getUserFromEmailOrUsername(email);
+    if (!user) {
+      throw new Exceptions.ItemNotFoundException(
+        'No user found with the specified email address.'
+      );
+    }
+
+    // Generate reset code
+    const {code} = await createNewEmailCode(user.user_id);
+    const url = buildCodeIntoUrl(code);
+
+    res.json({
+      code,
+      url,
+    });
+  }
+);
+
+/**
+ * PUT /reset
+ * Completes a password reset using a valid reset code.
+ * This endpoint is public but requires a valid reset code.
+ *
+ * @route PUT /reset
+ * @param {object} req.body - The request body
+ * @param {string} req.body.code - The reset code
+ * @param {string} req.body.newPassword - The new password
+ * @returns {object} 200 - Success response
+ * @returns {object} 400 - Invalid code or password
+ * @returns {object} 404 - Code not found
+ */
+api.put(
+  '/',
+  processRequest({
+    body: PutRequestPasswordResetRequestSchema,
+  }),
+  async (req, res: Response<PutRequestPasswordResetResponse>) => {
+    const {code, newPassword} = req.body;
+
+    // Validate the reset code
+    const validationResult = await validateEmailCode(code);
+
+    if (!validationResult.valid || !validationResult.user) {
+      throw new Exceptions.UnauthorizedException(
+        validationResult.validationError || 'Invalid reset code.'
+      );
+    }
+
+    // Update the user's password
+    await updateUserPassword(validationResult.user.user_id, newPassword);
+
+    // Mark the code as used
+    await markCodeAsUsed(code);
+
+    res.json({
+      message: 'Password has been successfully reset.',
+    });
+  }
+);
+
+// Export the router
+export default api;

--- a/api/src/api/utilities.ts
+++ b/api/src/api/utilities.ts
@@ -39,6 +39,7 @@ import * as Exceptions from '../exceptions';
 import {
   optionalAuthenticationJWT,
   requireAuthenticationAPI,
+  requireClusterAdmin,
 } from '../middleware';
 import {slugify} from '../utils';
 
@@ -66,9 +67,21 @@ api.get('/hello/', requireAuthenticationAPI, (_req: any, res: any) => {
  *   if databases exist, this is a no-op
  */
 api.post('/initialise/', async (req, res) => {
-  initialiseDatabases();
+  initialiseDatabases({force: false});
   res.json({success: true});
 });
+
+/**
+ */
+api.post(
+  '/forceInitialise/',
+  requireAuthenticationAPI,
+  requireClusterAdmin,
+  async (req, res) => {
+    initialiseDatabases({force: true});
+    res.json({success: true});
+  }
+);
 
 /**
  * Handle info requests, basic identifying information for this server

--- a/api/src/api/utilities.ts
+++ b/api/src/api/utilities.ts
@@ -74,7 +74,7 @@ api.post('/initialise/', async (req, res) => {
 /**
  */
 api.post(
-  '/forceInitialise/',
+  '/forceInitialise',
   requireAuthenticationAPI,
   requireClusterAdmin,
   async (req, res) => {

--- a/api/src/api/utilities.ts
+++ b/api/src/api/utilities.ts
@@ -72,6 +72,8 @@ api.post('/initialise/', async (req, res) => {
 });
 
 /**
+ * Forcefully re-initialise the DB i.e. disable checks for existing design
+ * documents.
  */
 api.post(
   '/forceInitialise',

--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -323,6 +323,28 @@ function refreshTokenExpiryMinutes(): number {
   }
 }
 
+// 30 minute default expiry for email verification codes
+const DEFAULT_EMAIL_CODE_EXPIRY_MINUTES = 30;
+
+/**
+ * @returns The expiry time in minutes for email verification codes
+ */
+function emailCodeExpiryMinutes(): number {
+  const emailCodeExpiryMinutes = process.env.EMAIL_CODE_EXPIRY_MINUTES;
+  if (emailCodeExpiryMinutes === '' || emailCodeExpiryMinutes === undefined) {
+    return DEFAULT_EMAIL_CODE_EXPIRY_MINUTES;
+  }
+  try {
+    return parseInt(emailCodeExpiryMinutes);
+  } catch (err) {
+    console.error(
+      'EMAIL_CODE_EXPIRY_MINUTES unparseable, defaulting to ' +
+        DEFAULT_EMAIL_CODE_EXPIRY_MINUTES
+    );
+    return DEFAULT_EMAIL_CODE_EXPIRY_MINUTES;
+  }
+}
+
 const DEFAULT_RATE_LIMITER_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
 const DEFAULT_RATE_LIMITER_PER_WINDOW = 1000; // 1000 requests per window
 const DEFAULT_RATE_LIMITER_ENABLED = true;
@@ -379,6 +401,24 @@ function rateLimiterEnabled(): boolean {
   return rateLimiterEnabled.toLowerCase() === 'true';
 }
 
+/**
+ * What is the URL of the new conductor? Required.
+ *
+ * @returns The new conductor URL, no trailing /
+ */
+function newConductorUrl(): string {
+  let conductorUrl = process.env.NEW_CONDUCTOR_URL;
+  if (conductorUrl === '' || conductorUrl === undefined) {
+    throw Error('You must provide a NEW_CONDUCTOR_URL in your environment.');
+  } else {
+    if (conductorUrl.endsWith('/')) {
+      console.log('NEW_CONDUCTOR_URL should not end with / - removing it');
+      conductorUrl = conductorUrl.substring(0, conductorUrl.length - 1);
+    }
+    return conductorUrl;
+  }
+}
+
 export const DEVELOPER_MODE = developer_mode();
 export const COUCHDB_INTERNAL_URL = couchdb_internal_url();
 export const COUCHDB_PUBLIC_URL = couchdb_public_url();
@@ -403,6 +443,8 @@ export const DESIGNER_URL = designer_url();
 export const RATE_LIMITER_WINDOW_MS = rateLimiterWindowMs();
 export const RATE_LIMITER_PER_WINDOW = rateLimiterPerWindow();
 export const RATE_LIMITER_ENABLED = rateLimiterEnabled();
+export const EMAIL_CODE_EXPIRY_MINUTES = emailCodeExpiryMinutes();
+export const NEW_CONDUCTOR_URL = newConductorUrl();
 
 /**
  * Checks the KEY_SOURCE env variable to ensure its a KEY_SOURCE or defaults to

--- a/api/src/core.ts
+++ b/api/src/core.ts
@@ -54,6 +54,7 @@ const indexContent = readFileSync(
 import markdownit from 'markdown-it';
 import {api as notebookApi} from './api/notebooks';
 import {api as templatesApi} from './api/templates';
+import {api as resetPasswordApi} from './api/emailReset';
 import {api as usersApi} from './api/users';
 import {api as utilityApi} from './api/utilities';
 import {
@@ -155,6 +156,7 @@ app.use('/api/notebooks', notebookApi);
 app.use('/api/templates', templatesApi);
 app.use('/api', utilityApi);
 app.use('/api/users', usersApi);
+app.use('/api/reset', resetPasswordApi);
 
 // Custom error handler which returns a JSON description of error
 // TODO specify this interface in data models

--- a/api/src/couchdb/emailCodes.ts
+++ b/api/src/couchdb/emailCodes.ts
@@ -34,7 +34,7 @@ const VERIFICATION_CODE_CHARSET =
  * @returns The URL to present to the user
  */
 export function buildCodeIntoUrl(code: string): string {
-  return `${NEW_CONDUCTOR_URL}/passwordReset?code=${code}`;
+  return `${NEW_CONDUCTOR_URL}/auth/resetPassword?code=${code}`;
 }
 
 /**

--- a/api/src/couchdb/emailCodes.ts
+++ b/api/src/couchdb/emailCodes.ts
@@ -57,7 +57,7 @@ function generateExpiryTimestamp(expiryMs: number): number {
  * @param code The verification code to hash
  * @returns An object containing the hash and salt
  */
-function hashVerificationCode(code: string): string {
+export function hashVerificationCode(code: string): string {
   return crypto.createHash('sha256').update(code).digest('hex');
 }
 

--- a/api/src/couchdb/emailCodes.ts
+++ b/api/src/couchdb/emailCodes.ts
@@ -1,0 +1,316 @@
+/**
+ * Email Code Management Module
+ *
+ * This module provides functionality for managing email verification codes in the Auth
+ * CouchDB. It includes methods for creating, validating, and retrieving email codes,
+ * as well as utility functions for code expiration.
+ */
+
+import {
+  AuthRecord,
+  AuthRecordIdPrefixMap,
+  GetEmailCodeIndex,
+  EmailCodeFields,
+  EmailCodeRecord,
+} from '@faims3/data-model';
+import {getAuthDB} from '.';
+import {v4 as uuidv4} from 'uuid';
+import {InternalSystemError, ItemNotFoundException} from '../exceptions';
+import {getUserFromEmailOrUsername} from './users';
+import {EMAIL_CODE_EXPIRY_MINUTES, NEW_CONDUCTOR_URL} from '../buildconfig';
+import crypto from 'crypto';
+
+// Expiry time in milliseconds
+const CODE_EXPIRY_MS = EMAIL_CODE_EXPIRY_MINUTES * 60 * 1000;
+
+// Configuration for verification codes
+const VERIFICATION_CODE_LENGTH = 10;
+const VERIFICATION_CODE_CHARSET =
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Takes a reset code and embeds into URL
+ * @param code The unhashed code to embed into the URL
+ * @returns The URL to present to the user
+ */
+export function buildCodeIntoUrl(code: string): string {
+  return `${NEW_CONDUCTOR_URL}/passwordReset?code=${code}`;
+}
+
+/**
+ * Generates an expiry timestamp for an email verification code.
+ *
+ * This function calculates the expiry timestamp based on the current time
+ * and a predefined expiry duration.
+ *
+ * @param expiryMs The duration in milliseconds until the code expires
+ * @returns {number} The expiry timestamp in milliseconds since the Unix epoch.
+ */
+function generateExpiryTimestamp(expiryMs: number): number {
+  return Date.now() + expiryMs;
+}
+
+/**
+ * Creates a cryptographic hash of a verification code.
+ * Uses SHA-256 with a random salt for secure storage.
+ *
+ * @param code The verification code to hash
+ * @returns An object containing the hash and salt
+ */
+function hashVerificationCode(code: string): string {
+  return crypto.createHash('sha256').update(code).digest('hex');
+}
+
+/**
+ * Generates a cryptographically secure random verification code.
+ *
+ * @param length The length of the code to generate (default: VERIFICATION_CODE_LENGTH)
+ * @param charset The characters to use in the code (default: VERIFICATION_CODE_CHARSET)
+ * @returns {string} A random verification code of the specified length
+ */
+function generateVerificationCode(
+  length: number = VERIFICATION_CODE_LENGTH,
+  charset: string = VERIFICATION_CODE_CHARSET
+): string {
+  if (length <= 0) {
+    throw new Error('Code length must be greater than 0');
+  }
+  if (charset.length === 0) {
+    throw new Error('Charset must not be empty');
+  }
+
+  // Calculate how many random bytes we need
+  // We need enough bytes to have sufficient entropy for our charset
+  const randomBytes = crypto.randomBytes(length * 2);
+  let result = '';
+
+  for (let i = 0; i < length; i++) {
+    // Use two bytes for each character to ensure uniform distribution
+    const randomValue = (randomBytes[i * 2] << 8) + randomBytes[i * 2 + 1];
+    result += charset[randomValue % charset.length];
+  }
+
+  return result;
+}
+
+/**
+ * Creates a new email verification code for a given user.
+ * @param userId The ID of the user for whom the code is being created.
+ * @param purpose The purpose of the email code (e.g., 'verification', 'password-reset')
+ * @returns A Promise that resolves to an object containing the AuthRecord and the raw verification code
+ */
+export const createNewEmailCode = async (
+  userId: string,
+  expiryMs: number = CODE_EXPIRY_MS
+): Promise<{record: EmailCodeRecord; code: string}> => {
+  const authDB = getAuthDB();
+  const code = generateVerificationCode();
+  const hash = hashVerificationCode(code);
+  const dbId = AuthRecordIdPrefixMap.get('emailcode') + uuidv4();
+  const expiryTimestampMs = generateExpiryTimestamp(expiryMs);
+
+  const newEmailCode: EmailCodeFields = {
+    documentType: 'emailcode',
+    userId,
+    code: hash,
+    used: false,
+    expiryTimestampMs,
+  };
+
+  const response = await authDB.put({_id: dbId, ...newEmailCode});
+  const record = await authDB.get<EmailCodeRecord>(response.id);
+
+  // Return both the database record and the raw code
+  return {record, code};
+};
+
+/**
+ * Validates an email verification code for a given user.
+ * @param code The verification code to validate (not hashed)
+ * @param userId Optional user ID to validate against.
+ * @returns A Promise that resolves to an object indicating validity and any validation errors.
+ */
+export const validateEmailCode = async (
+  code: string,
+  userId?: string
+): Promise<{valid: boolean; user?: Express.User; validationError?: string}> => {
+  try {
+    // Hash the code
+    const hashedCode = hashVerificationCode(code);
+
+    // Try to find the code (hashed)
+    const codeDoc: EmailCodeRecord | null = await getCodeByCode(hashedCode);
+
+    if (!codeDoc) {
+      return {
+        valid: false,
+        validationError: 'Invalid reset code.',
+      };
+    }
+
+    if (userId && codeDoc.userId !== userId) {
+      return {
+        valid: false,
+        validationError: 'Reset code does not belong to the specified user.',
+      };
+    }
+
+    if (codeDoc.used) {
+      return {
+        valid: false,
+        validationError: 'Reset code has already been used.',
+      };
+    }
+
+    if (codeDoc.expiryTimestampMs < Date.now()) {
+      return {valid: false, validationError: 'Code has expired.'};
+    }
+
+    const user = await getUserFromEmailOrUsername(codeDoc.userId);
+    if (!user) {
+      return {
+        valid: false,
+        validationError: 'Could not find associated user.',
+      };
+    }
+
+    return {valid: true, user};
+  } catch (error) {
+    console.error(
+      'Unhandled error validating email code. Code: ',
+      code,
+      ' Error: ',
+      error,
+      console.trace()
+    );
+    return {valid: false, validationError: 'Internal server error'};
+  }
+};
+
+/**
+ * Marks an email code as used.
+ * @param code The verification code to mark as used (not hashed)
+ * @returns A Promise that resolves to the updated AuthRecord.
+ */
+export const markCodeAsUsed = async (code: string): Promise<AuthRecord> => {
+  const hashedCode = hashVerificationCode(code);
+  const codeDoc: EmailCodeRecord | null = await getCodeByCode(hashedCode);
+
+  if (!codeDoc) {
+    throw new ItemNotFoundException('Could not find the specified code.');
+  }
+
+  codeDoc.used = true;
+
+  const authDB = getAuthDB();
+  await authDB.put(codeDoc);
+  return codeDoc;
+};
+
+/**
+ * Retrieves all email codes for a given user.
+ * @param userId The ID of the user whose codes are being retrieved.
+ * @returns A Promise that resolves to an array of AuthRecords.
+ */
+export const getCodesByUserId = async (
+  userId: string
+): Promise<AuthRecord[]> => {
+  const authDB = getAuthDB();
+
+  const result = await authDB.query<AuthRecord>(
+    'viewsDocument/emailCodesByUserId',
+    {
+      key: userId,
+      include_docs: true,
+    }
+  );
+
+  return result.rows.filter(r => !!r.doc).map(row => row.doc!);
+};
+
+/**
+ * Retrieves an email code document by its code value.
+ * @param code The verification code to search for.
+ * @returns A Promise that resolves to the AuthRecord associated with the code.
+ */
+export const getCodeByCode = async (
+  code: string
+): Promise<EmailCodeRecord | null> => {
+  const authDB = getAuthDB();
+
+  const result = await authDB.query<EmailCodeRecord>(
+    'viewsDocument/emailCodesByCode',
+    {
+      key: code,
+      include_docs: true,
+    }
+  );
+
+  const filtered = result.rows.filter(r => !!r.doc).map(row => row.doc!);
+
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  if (filtered.length > 1) {
+    throw new InternalSystemError(
+      'Duplicate items sharing a code. Cannot validate this email code.'
+    );
+  }
+
+  return filtered[0];
+};
+
+/**
+ * Retrieves all email codes in the database.
+ * @returns A Promise that resolves to an array of all AuthRecords.
+ */
+export const getAllCodes = async (): Promise<AuthRecord[]> => {
+  const authDB = getAuthDB();
+
+  const result = await authDB.query<AuthRecord>('viewsDocument/emailCodes', {
+    include_docs: true,
+  });
+
+  return result.rows.map(row => row.doc as AuthRecord);
+};
+
+/**
+ * Deletes an email code based on the specified index and identifier.
+ *
+ * @param index The index to use for finding the code ('id' or 'code').
+ * @param identifier The value to search for using the specified index.
+ * @returns A Promise that resolves when the code is successfully deleted.
+ * @throws Error if the code is not found or if there's an issue with deletion.
+ */
+export const deleteEmailCode = async (
+  index: GetEmailCodeIndex,
+  identifier: string
+): Promise<void> => {
+  const authDB = getAuthDB();
+  let codeDoc: AuthRecord | null = null;
+
+  if (index === 'id') {
+    try {
+      codeDoc = await authDB.get(identifier);
+    } catch (error) {
+      if ((error as any).status === 404) {
+        throw new Error(`Email code with ID ${identifier} not found.`);
+      }
+      throw error;
+    }
+  } else if (index === 'code') {
+    codeDoc = await getCodeByCode(identifier);
+    if (!codeDoc) {
+      throw new Error(`Email code with code ${identifier} not found.`);
+    }
+  } else {
+    throw new Error(`Invalid index type: ${index}`);
+  }
+
+  try {
+    await authDB.remove(codeDoc._id, codeDoc._rev);
+  } catch (error) {
+    throw new Error(`Failed to delete email code: ${(error as Error).message}`);
+  }
+};

--- a/api/src/couchdb/index.ts
+++ b/api/src/couchdb/index.ts
@@ -314,11 +314,15 @@ export const getDataDb = async (
   return new PouchDB(dbUrl, pouch_options);
 };
 
-export const initialiseDatabases = async () => {
+export const initialiseDatabases = async ({
+  force = false,
+}: {
+  force?: boolean;
+}) => {
   // Setup the auth DB
   const authDB = getAuthDB();
   try {
-    await initialiseAuthDb(authDB);
+    await initialiseAuthDb(authDB, {force});
   } catch (error) {
     console.log('Could not initialise the auth database', error);
     throw error;
@@ -326,7 +330,7 @@ export const initialiseDatabases = async () => {
 
   const directoryDB = getDirectoryDB();
   try {
-    await initialiseDirectoryDB(directoryDB);
+    await initialiseDirectoryDB(directoryDB, {force});
   } catch (error) {
     console.log('something wrong with directory db init', error);
     throw error;
@@ -334,7 +338,7 @@ export const initialiseDatabases = async () => {
 
   const projectsDB = getProjectsDB();
   try {
-    await initialiseProjectsDB(projectsDB);
+    await initialiseProjectsDB(projectsDB, {force});
   } catch (error) {
     console.log('something wrong with projects db init', error);
     throw error;
@@ -350,7 +354,7 @@ export const initialiseDatabases = async () => {
   }
 
   try {
-    await initialiseTemplatesDb(templatesDb);
+    await initialiseTemplatesDb(templatesDb, {force});
   } catch {
     throw new Exceptions.InternalSystemError(
       'Something wrong during templates db initialisation'

--- a/api/src/couchdb/initialise.ts
+++ b/api/src/couchdb/initialise.ts
@@ -220,9 +220,7 @@ export const initialiseDirectoryDB = async (
   }
 };
 
-export const initialiseUserDB = async (
-  db: PouchDB.Database | undefined
-) => {
+export const initialiseUserDB = async (db: PouchDB.Database | undefined) => {
   // register a local admin user with the same password as couchdb
   // if there isn't already one there
   if (db && LOCAL_COUCHDB_AUTH) {

--- a/api/src/couchdb/initialise.ts
+++ b/api/src/couchdb/initialise.ts
@@ -63,7 +63,8 @@ const adminOnlySecurityHelper = async (
 };
 
 export const initialiseProjectsDB = async (
-  db: PouchDB.Database | undefined
+  db: PouchDB.Database | undefined,
+  {force = false}: {force?: boolean}
 ) => {
   // Permissions doc goes into _design/permissions in a project
   // javascript in here will run inside CouchDB
@@ -80,25 +81,37 @@ export const initialiseProjectsDB = async (
     }`,
   };
   if (db) {
-    try {
-      await db.get(projectPermissionsDoc._id);
-    } catch {
-      await db.put(projectPermissionsDoc);
+    let write = false;
+
+    if (force) {
+      write = true;
+    } else {
+      // do we already have a default document?
+      try {
+        await db.get(projectPermissionsDoc._id);
+        write = false;
+      } catch {
+        write = true;
+      }
     }
 
-    // can't save security on an in-memory database so skip if testing
-    if (process.env.NODE_ENV !== 'test') {
-      const security = db.security();
-      await adminOnlySecurityHelper(security, [
-        CLUSTER_ADMIN_GROUP_NAME,
-        '_admin',
-      ]);
+    if (write) {
+      await db.put(projectPermissionsDoc);
+      // can't save security on an in-memory database so skip if testing
+      if (process.env.NODE_ENV !== 'test') {
+        const security = db.security();
+        await adminOnlySecurityHelper(security, [
+          CLUSTER_ADMIN_GROUP_NAME,
+          '_admin',
+        ]);
+      }
     }
   }
 };
 
 export const initialiseTemplatesDb = async (
-  db: PouchDB.Database | undefined
+  db: PouchDB.Database | undefined,
+  {force = false}: {force?: boolean}
 ) => {
   // Permissions doc goes into _design/permissions in a project
   // javascript in here will run inside CouchDB
@@ -115,9 +128,21 @@ export const initialiseTemplatesDb = async (
     }`,
   };
   if (db) {
-    try {
-      await db.get(projectPermissionsDoc._id);
-    } catch {
+    let write = false;
+
+    if (force) {
+      write = true;
+    } else {
+      // do we already have a default document?
+      try {
+        await db.get(projectPermissionsDoc._id);
+        write = false;
+      } catch {
+        write = true;
+      }
+    }
+
+    if (write) {
       try {
         await db.put(projectPermissionsDoc);
       } catch (e) {
@@ -126,21 +151,22 @@ export const initialiseTemplatesDb = async (
         );
         throw e;
       }
-    }
 
-    // can't save security on an in-memory database so skip if testing
-    if (process.env.NODE_ENV !== 'test') {
-      const security = db.security();
-      await adminOnlySecurityHelper(security, [
-        CLUSTER_ADMIN_GROUP_NAME,
-        '_admin',
-      ]);
+      // can't save security on an in-memory database so skip if testing
+      if (process.env.NODE_ENV !== 'test') {
+        const security = db.security();
+        await adminOnlySecurityHelper(security, [
+          CLUSTER_ADMIN_GROUP_NAME,
+          '_admin',
+        ]);
+      }
     }
   }
 };
 
 export const initialiseDirectoryDB = async (
-  db: PouchDB.Database | undefined
+  db: PouchDB.Database | undefined,
+  {force = false}: {force?: boolean}
 ) => {
   const directoryDoc = {
     _id: 'default',
@@ -166,10 +192,21 @@ export const initialiseDirectoryDB = async (
   };
 
   if (db) {
-    // do we already have a default document?
-    try {
-      await db.get('default');
-    } catch {
+    let write = false;
+
+    if (force) {
+      write = true;
+    } else {
+      // do we already have a default document?
+      try {
+        await db.get('default');
+        write = false;
+      } catch {
+        write = true;
+      }
+    }
+
+    if (write) {
       await db.put(directoryDoc);
       await db.put(permissions);
 
@@ -183,7 +220,9 @@ export const initialiseDirectoryDB = async (
   }
 };
 
-export const initialiseUserDB = async (db: PouchDB.Database | undefined) => {
+export const initialiseUserDB = async (
+  db: PouchDB.Database | undefined
+) => {
   // register a local admin user with the same password as couchdb
   // if there isn't already one there
   if (db && LOCAL_COUCHDB_AUTH) {
@@ -229,7 +268,10 @@ export const initialiseUserDB = async (db: PouchDB.Database | undefined) => {
  * @param db The database to initialise, intentionally not typed so as to not
  * include type errors for interacting with permission and security documents.
  */
-export const initialiseAuthDb = async (db: PouchDB.Database): Promise<void> => {
+export const initialiseAuthDb = async (
+  db: PouchDB.Database,
+  {force = true}: {force?: boolean}
+): Promise<void> => {
   // To check if we are initialised - we check for presence of expected
   // documents
   let initialised = true;
@@ -248,9 +290,9 @@ export const initialiseAuthDb = async (db: PouchDB.Database): Promise<void> => {
     initialised = false;
   }
 
-  //if (initialised) {
-  //  return;
-  //}
+  if (!force && initialised) {
+    return;
+  }
 
   // can't save security on an in-memory database so skip if testing
   if (process.env.NODE_ENV !== 'test') {

--- a/api/src/couchdb/initialise.ts
+++ b/api/src/couchdb/initialise.ts
@@ -248,9 +248,9 @@ export const initialiseAuthDb = async (db: PouchDB.Database): Promise<void> => {
     initialised = false;
   }
 
-  if (initialised) {
-    return;
-  }
+  //if (initialised) {
+  //  return;
+  //}
 
   // can't save security on an in-memory database so skip if testing
   if (process.env.NODE_ENV !== 'test') {

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -113,7 +113,7 @@ app.get('/', async (req, res) => {
 app.post('/fallback-initialise', async (req, res) => {
   if (!databaseValidityReport.valid) {
     console.log('running initialise');
-    await initialiseDatabases();
+    await initialiseDatabases({});
     const vv = await verifyCouchDBConnection();
     console.log('updated valid', databaseValidityReport, vv);
   }

--- a/api/test/couchdb.test.ts
+++ b/api/test/couchdb.test.ts
@@ -73,7 +73,7 @@ describe('notebook api', () => {
   });
 
   it('check initialise', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
 
     const directoryDB = getDirectoryDB();
     expect(directoryDB).not.to.equal(undefined);
@@ -130,7 +130,7 @@ describe('notebook api', () => {
   });
 
   it('can create a notebook', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
     const user = await getUserFromEmailOrUsername('admin');
 
     const jsonText = fs.readFileSync(
@@ -167,7 +167,7 @@ describe('notebook api', () => {
   });
 
   it('getNotebookMetadata', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
 
     const jsonText = fs.readFileSync(
       './notebooks/sample_notebook.json',
@@ -209,7 +209,7 @@ describe('notebook api', () => {
   });
 
   it('getNotebookUISpec', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
 
     const jsonText = fs.readFileSync(
       './notebooks/sample_notebook.json',
@@ -232,7 +232,7 @@ describe('notebook api', () => {
   });
 
   it('get notebook roles', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
 
     const jsonText = fs.readFileSync(
       './notebooks/sample_notebook.json',
@@ -254,7 +254,7 @@ describe('notebook api', () => {
   });
 
   it('updateNotebook', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
     const user = await getUserFromEmailOrUsername('admin');
 
     const jsonText = fs.readFileSync(

--- a/api/test/devtools.test.ts
+++ b/api/test/devtools.test.ts
@@ -35,7 +35,7 @@ registerClient(callbackObject);
 
 if (DEVELOPER_MODE) {
   it('createRecords', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({});
 
     const jsonText = fs.readFileSync(
       './notebooks/sample_notebook.json',

--- a/api/test/emailReset.test.ts
+++ b/api/test/emailReset.test.ts
@@ -1,0 +1,162 @@
+import {expect} from 'chai';
+import PouchDB from 'pouchdb';
+import request from 'supertest';
+import {app} from '../src/routes';
+import {
+  adminToken,
+  adminUserName,
+  beforeApiTests,
+  localUserName,
+  localUserToken,
+  requestAuthAndType,
+} from './utils';
+import {getUserFromEmailOrUsername} from '../src/couchdb/users';
+import {
+  PostRequestPasswordResetRequest,
+  PutRequestPasswordResetRequest,
+} from '@faims3/data-model';
+import {
+  createNewEmailCode,
+  validateEmailCode,
+  markCodeAsUsed,
+  getCodeByCode,
+  hashVerificationCode,
+} from '../src/couchdb/emailCodes';
+
+PouchDB.plugin(require('pouchdb-adapter-memory'));
+PouchDB.plugin(require('pouchdb-find'));
+
+describe('password reset tests', () => {
+  beforeEach(beforeApiTests);
+
+  it('initiate password reset requires admin authentication', async () => {
+    // Should fail without auth token
+    await request(app)
+      .post('/api/reset')
+      .send({
+        email: localUserName,
+      } as PostRequestPasswordResetRequest)
+      .expect(401);
+
+    // Should fail with non-admin token
+    await requestAuthAndType(
+      request(app)
+        .post('/api/reset')
+        .send({
+          email: localUserName,
+        } as PostRequestPasswordResetRequest),
+      localUserToken
+    ).expect(401);
+  });
+
+  it('initiate password reset for valid user', async () => {
+    const response = await requestAuthAndType(
+      request(app)
+        .post('/api/reset')
+        .send({
+          email: localUserName,
+        } as PostRequestPasswordResetRequest),
+      adminToken
+    ).expect(200);
+
+    expect(response.body.code).to.be.a('string');
+    expect(response.body.url).to.be.a('string');
+    expect(response.body.url).to.include(response.body.code);
+  });
+
+  it('initiate password reset fails for invalid user', async () => {
+    await requestAuthAndType(
+      request(app)
+        .post('/api/reset')
+        .send({
+          email: 'nonexistent@example.com',
+        } as PostRequestPasswordResetRequest),
+      adminToken
+    ).expect(404);
+  });
+
+  it('complete password reset with valid code', async () => {
+    // First get a user and create a reset code
+    const localUser = await getUserFromEmailOrUsername(localUserName);
+    expect(localUser).to.not.be.undefined;
+    
+    const {code} = await createNewEmailCode(localUser!.user_id!);
+    
+    // Now try to reset the password
+    const newPassword = 'NewSecurePassword123!';
+    await request(app)
+      .put('/api/reset')
+      .send({
+        code: code,
+        newPassword: newPassword,
+      } as PutRequestPasswordResetRequest)
+      .expect(200);
+
+    // Verify the code is now marked as used
+    const hashedCode = hashVerificationCode(code);
+    const codeDoc = await getCodeByCode(hashedCode);
+    expect(codeDoc?.used).to.be.true;
+
+    // Try to use the same code again - should fail
+    await request(app)
+      .put('/api/reset')
+      .send({
+        code: code,
+        newPassword: 'AnotherPassword123!',
+      } as PutRequestPasswordResetRequest)
+      .expect(401);
+  });
+
+  it('complete password reset fails with invalid code', async () => {
+    await request(app)
+      .put('/api/reset')
+      .send({
+        code: 'invalid-code',
+        newPassword: 'NewPassword123!',
+      } as PutRequestPasswordResetRequest)
+      .expect(401);
+  });
+
+  it('complete password reset fails with expired code', async () => {
+    // Create a code with very short expiry
+    const localUser = await getUserFromEmailOrUsername(localUserName);
+    const {code} = await createNewEmailCode(localUser!.user_id!, 10); // 10ms expiry
+
+    // Wait for code to expire
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    await request(app)
+      .put('/api/reset')
+      .send({
+        code: code,
+        newPassword: 'NewPassword123!',
+      } as PutRequestPasswordResetRequest)
+      .expect(401);
+  });
+
+  it('email code validation works correctly', async () => {
+    const localUser = await getUserFromEmailOrUsername(localUserName);
+    const {code} = await createNewEmailCode(localUser!.user_id!);
+
+    // Valid code check
+    let validation = await validateEmailCode(code);
+    expect(validation.valid).to.be.true;
+    expect(validation.user).to.not.be.undefined;
+    expect(validation.validationError).to.be.undefined;
+
+    // Check with correct user ID
+    validation = await validateEmailCode(code, localUser!.user_id);
+    expect(validation.valid).to.be.true;
+
+    // Check with wrong user ID
+    const adminUser = await getUserFromEmailOrUsername(adminUserName);
+    validation = await validateEmailCode(code, adminUser!.user_id);
+    expect(validation.valid).to.be.false;
+
+    // Mark code as used
+    await markCodeAsUsed(code);
+    validation = await validateEmailCode(code);
+    expect(validation.valid).to.be.false;
+    expect(validation.validationError).to.include('already been used');
+  });
+});

--- a/api/test/emailReset.test.ts
+++ b/api/test/emailReset.test.ts
@@ -79,9 +79,9 @@ describe('password reset tests', () => {
     // First get a user and create a reset code
     const localUser = await getUserFromEmailOrUsername(localUserName);
     expect(localUser).to.not.be.undefined;
-    
+
     const {code} = await createNewEmailCode(localUser!.user_id!);
-    
+
     // Now try to reset the password
     const newPassword = 'NewSecurePassword123!';
     await request(app)

--- a/api/test/invites.test.ts
+++ b/api/test/invites.test.ts
@@ -44,7 +44,9 @@ const uispec: EncodedProjectUIModel = {
 };
 
 describe('Invites', () => {
-  beforeEach(initialiseDatabases);
+  beforeEach(async () => {
+    await initialiseDatabases({});
+  });
 
   it('create invite', async () => {
     const project_id = await createNotebook('Test Notebook', uispec, {});

--- a/api/test/mocks.ts
+++ b/api/test/mocks.ts
@@ -70,7 +70,7 @@ export const resetDatabases = async () => {
   if (templatesDB) {
     await clearDB(templatesDB);
   }
-  await initialiseDatabases();
+  await initialiseDatabases({});
 };
 
 export const cleanDataDBS = async () => {

--- a/api/test/users.test.ts
+++ b/api/test/users.test.ts
@@ -261,7 +261,7 @@ describe('user creation', () => {
   });
 
   it('listing users for notebooks', async () => {
-    await initialiseDatabases();
+    await initialiseDatabases({force: false});
 
     const jsonText = fs.readFileSync(
       './notebooks/sample_notebook.json',

--- a/app/src/gui/components/record/view.tsx
+++ b/app/src/gui/components/record/view.tsx
@@ -356,28 +356,31 @@ export function ViewComponent(props: ViewProps) {
                 Other sections have errors. Click to navigate:
               </Typography>
 
-              {otherSectionsWithErrors.map((section, _index) => (
-                <Link
-                  key={section}
-                  component="button"
-                  variant="body2"
-                  onClick={() => props.handleSectionClick(section)}
-                  sx={{
-                    display: 'inline-flex',
-                    color: theme.palette.highlightColor.main,
-                    fontSize: {xs: '0.85rem', sm: '1rem'},
-                    fontWeight: 'bold',
-                    textDecoration: 'underline',
-                    '&:hover': {
-                      color: theme.palette.secondary.main,
-                      transform: 'scale(1.02)',
-                    },
-                    mt: 1,
-                  }}
-                >
-                  {ui_specification.views[section]?.label || section}
-                </Link>
-              ))}
+              {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                otherSectionsWithErrors.map((section, _index) => (
+                  <Link
+                    key={section}
+                    component="button"
+                    variant="body2"
+                    onClick={() => props.handleSectionClick(section)}
+                    sx={{
+                      display: 'inline-flex',
+                      color: theme.palette.highlightColor.main,
+                      fontSize: {xs: '0.85rem', sm: '1rem'},
+                      fontWeight: 'bold',
+                      textDecoration: 'underline',
+                      '&:hover': {
+                        color: theme.palette.secondary.main,
+                        transform: 'scale(1.02)',
+                      },
+                      mt: 1,
+                    }}
+                  >
+                    {ui_specification.views[section]?.label || section}
+                  </Link>
+                ))
+              }
             </Box>
           )}
         </Alert>
@@ -404,6 +407,7 @@ function displayErrors(
   thisView: string,
   ui_specification: ProjectUIModel,
   currentFields: string[],
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _otherSections?: string[]
 ) {
   if (!errors) return <p>No errors to display</p>;

--- a/app/src/gui/pages/notebook.tsx
+++ b/app/src/gui/pages/notebook.tsx
@@ -54,7 +54,7 @@ export default function Notebook() {
     <Stack spacing={2}>
       <Stack direction="row" alignItems={'center'} spacing={2}>
         <BackButton
-        label="Back"
+          label="Back"
           onClick={() => history(ROUTES.INDEX)}
         ></BackButton>
 

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -33,8 +33,6 @@ import {
   CircularProgress,
   Dialog,
   DialogActions,
-  DialogContent,
-  DialogTitle,
   Grid,
   Paper,
 } from '@mui/material';
@@ -65,8 +63,8 @@ import InheritedDataComponent from '../components/record/inherited_data';
 import {getParentPersistenceData} from '../components/record/relationships/RelatedInformation';
 import {ParentLinkProps} from '../components/record/relationships/types';
 import DraftSyncStatus from '../components/record/sync_status';
-import Breadcrumbs from '../components/ui/breadcrumbs';
 import BackButton from '../components/ui/BackButton';
+import Breadcrumbs from '../components/ui/breadcrumbs';
 
 interface DraftCreateActionProps {
   project_id: ProjectID;
@@ -293,8 +291,6 @@ export default function RecordCreate() {
   const projectId = location.pathname.split('/')[2];
 
   const [openDialog, setOpenDialog] = useState(false);
-  //for android back button
-  const [androidBackPressed, setAndroidBackPressed] = useState(false);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -321,7 +317,6 @@ export default function RecordCreate() {
   }, [project_id]);
 
   let showBreadcrumbs = false;
-  const history = useNavigate();
 
   const breadcrumbs = [
     // {link: ROUTES.INDEX, title: 'Home'},
@@ -353,7 +348,6 @@ export default function RecordCreate() {
   useEffect(() => {
     const handleBackEvent = (event: Event) => {
       event.preventDefault();
-      setAndroidBackPressed(true);
       setOpenDialog(true);
     };
     window.history.pushState(null, '', window.location.href);

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -50,6 +50,8 @@ export interface FaimsConductorProps {
   couchDBPort: number;
   /** CouchDB endpoint (format: https://domain:port) */
   couchDBEndpoint: string;
+  /** Public URL for the /web (new conductor) */
+  webUrl: string;
   /** Public URL for web app */
   webAppPublicUrl: string;
   /** Public URL for Android app */
@@ -144,6 +146,7 @@ export class FaimsConductor extends Construct {
           IOS_APP_PUBLIC_URL: props.iosAppPublicUrl,
           KEY_SOURCE: 'AWS_SM',
           AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
+          VITE_NEW_CONDUCTOR_URL: props.webUrl
         },
         secrets: {
           COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -146,7 +146,7 @@ export class FaimsConductor extends Construct {
           IOS_APP_PUBLIC_URL: props.iosAppPublicUrl,
           KEY_SOURCE: 'AWS_SM',
           AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
-          VITE_NEW_CONDUCTOR_URL: props.webUrl
+          VITE_NEW_CONDUCTOR_URL: props.webUrl,
         },
         secrets: {
           COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -146,7 +146,7 @@ export class FaimsConductor extends Construct {
           IOS_APP_PUBLIC_URL: props.iosAppPublicUrl,
           KEY_SOURCE: 'AWS_SM',
           AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
-          VITE_NEW_CONDUCTOR_URL: props.webUrl,
+          NEW_CONDUCTOR_URL: props.webUrl,
         },
         secrets: {
           COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -393,7 +393,7 @@ export class FaimsInfraStack extends cdk.Stack {
       sharedBalancer: networking.sharedBalancer,
       config: config.conductor,
       cookieSecret: cookieSecret,
-      webUrl: domains.web,
+      webUrl: `https://${domains.web}`,
     });
 
     // FRONT-END

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -393,6 +393,7 @@ export class FaimsInfraStack extends cdk.Stack {
       sharedBalancer: networking.sharedBalancer,
       config: config.conductor,
       cookieSecret: cookieSecret,
+      webUrl: domains.web,
     });
 
     // FRONT-END

--- a/infrastructure/aws-cdk/src/deregister-lambda/src/index.ts
+++ b/infrastructure/aws-cdk/src/deregister-lambda/src/index.ts
@@ -1,5 +1,5 @@
+import {EventBridgeEvent} from 'aws-lambda';
 import {AutoScaling, ServiceDiscovery} from 'aws-sdk';
-import {EventBridgeEvent, Context} from 'aws-lambda';
 
 const servicediscovery = new ServiceDiscovery();
 const autoscaling = new AutoScaling();
@@ -15,9 +15,7 @@ export const handler = async (
   event: EventBridgeEvent<
     'EC2 Instance-terminate Lifecycle Action',
     ASGLifecycleEvent
-  >,
-  // eslint-disable-next-line no-unused-vars
-  context: Context
+  >
 ): Promise<{statusCode: number; body: string}> => {
   console.log('Received event:', JSON.stringify(event, null, 2));
 

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -233,3 +233,41 @@ export const GetTemplateByIdResponseSchema = TemplateDocumentSchema;
 export type GetTemplateByIdResponse = z.infer<
   typeof GetTemplateByIdResponseSchema
 >;
+
+// EMAIL RESET
+
+// POST /reset request schema
+export const PostRequestPasswordResetRequestSchema = z.object({
+  email: z.string().email(),
+});
+export type PostRequestPasswordResetRequest = z.infer<
+  typeof PostRequestPasswordResetRequestSchema
+>;
+
+// POST /reset response schema
+export const PostRequestPasswordResetResponseSchema = z.object({
+  // The reset code
+  code: z.string(),
+  // The URL which embeds this code in the proper format
+  url: z.string(),
+});
+export type PostRequestPasswordResetResponse = z.infer<
+  typeof PostRequestPasswordResetResponseSchema
+>;
+
+// PUT /reset request schema
+export const PutRequestPasswordResetRequestSchema = z.object({
+  code: z.string(),
+  newPassword: z.string().min(10),
+});
+export type PutRequestPasswordResetRequest = z.infer<
+  typeof PutRequestPasswordResetRequestSchema
+>;
+
+// PUT /reset response schema
+export const PutRequestPasswordResetResponseSchema = z.object({
+  message: z.string(),
+});
+export type PutRequestPasswordResetResponse = z.infer<
+  typeof PutRequestPasswordResetResponseSchema
+>;

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -238,7 +238,7 @@ export type GetTemplateByIdResponse = z.infer<
 
 // POST /reset request schema
 export const PostRequestPasswordResetRequestSchema = z.object({
-  email: z.string().email(),
+  email: z.string(),
 });
 export type PostRequestPasswordResetRequest = z.infer<
   typeof PostRequestPasswordResetRequestSchema

--- a/library/data-model/src/data_storage/authDB/design.ts
+++ b/library/data-model/src/data_storage/authDB/design.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
+
 /**
  * Converts a JavaScript function to a CouchDB-compatible string representation.
  */
@@ -17,6 +18,9 @@ function convertToCouchDBString(func) {
 export const viewsDocument = {
   _id: '_design/viewsDocument',
   views: {
+    // REFRESH TOKENS
+    // ==============
+
     // All refresh tokens by _id
     refreshTokens: {
       map: convertToCouchDBString(doc => {
@@ -68,6 +72,65 @@ export const viewsDocument = {
         ) {
           // Emit the record by token
           emit(doc.token, doc);
+        }
+      }),
+    },
+
+    // EMAIL RESETS
+    // ==============
+
+    // All email resets by _id
+    emailCodes: {
+      map: convertToCouchDBString(doc => {
+        const DOCUMENT_TYPE = 'emailcode';
+        const ID_PREFIX = 'emailcode_';
+
+        // Check that document type is defined and that the type is refresh and
+        // the prefix is correct
+        if (
+          doc.documentType &&
+          doc.documentType === DOCUMENT_TYPE &&
+          doc._id.indexOf(ID_PREFIX) === 0
+        ) {
+          // Emit the whole refresh object indexed by the _id
+          emit(doc._id, doc);
+        }
+      }),
+    },
+    // Refresh tokens for a specific user (by user id)
+    emailCodesByUserId: {
+      map: convertToCouchDBString(doc => {
+        const DOCUMENT_TYPE = 'emailcode';
+        const ID_PREFIX = 'emailcode_';
+
+        // Check that document type is defined and that the type is refresh and
+        // the prefix is correct
+        if (
+          doc.documentType &&
+          doc.documentType === DOCUMENT_TYPE &&
+          doc._id.indexOf(ID_PREFIX) === 0 &&
+          doc.userId
+        ) {
+          // Emit the record by userId
+          emit(doc.userId, doc);
+        }
+      }),
+    },
+    // Refresh tokens by token
+    emailCodesByCode: {
+      map: convertToCouchDBString(doc => {
+        const DOCUMENT_TYPE = 'emailcode';
+        const ID_PREFIX = 'emailcode_';
+
+        // Check that document type is defined and that the type is refresh and the prefix is correct
+        if (
+          doc.documentType &&
+          doc.documentType === DOCUMENT_TYPE &&
+          doc._id.indexOf(ID_PREFIX) === 0 &&
+          doc.code
+        ) {
+          // Emit the record by token
+          emit(doc.code, doc);
         }
       }),
     },

--- a/library/data-model/src/data_storage/authDB/document.ts
+++ b/library/data-model/src/data_storage/authDB/document.ts
@@ -1,10 +1,13 @@
 /** Provides types for the Auth database */
-export type AuthRecordTypes = 'refresh';
+export type AuthRecordTypes = 'refresh' | 'emailcode';
 
 // These indicate the available indexes to fetch things
 export type GetRefreshTokenIndex = 'id' | 'token';
 
-// Document type
+// You can fetch email codes by index or code
+export type GetEmailCodeIndex = 'id' | 'code';
+
+// Refresh token fields
 export interface RefreshRecordFields {
   // Mandatory field for auth records
   documentType: 'refresh';
@@ -22,10 +25,29 @@ export interface RefreshRecordFields {
   enabled: boolean;
 }
 
+// Refresh token fields
+export interface EmailCodeFields {
+  // Mandatory field for auth records
+  documentType: 'emailcode';
+
+  // Which user ID generated this code?
+  userId: string;
+
+  // What is the code
+  code: string;
+
+  // When does it expire? unix timestamp in ms
+  expiryTimestampMs: number;
+
+  // Is this reset token valid
+  enabled: boolean;
+}
+
 // ID prefix map
 export const AuthRecordIdPrefixMap = new Map<AuthRecordTypes, string>([
   // Refresh records start with prefix
   ['refresh', 'refresh_'],
+  ['emailcode', 'emailcode_'],
 ]);
 
 // NOTE: if we have multiple record types, we could update below to use a union

--- a/library/data-model/src/data_storage/authDB/document.ts
+++ b/library/data-model/src/data_storage/authDB/document.ts
@@ -33,14 +33,14 @@ export interface EmailCodeFields {
   // Which user ID generated this code?
   userId: string;
 
-  // What is the code
+  // Hashed code
   code: string;
+
+  // Has it been used?
+  used: boolean;
 
   // When does it expire? unix timestamp in ms
   expiryTimestampMs: number;
-
-  // Is this reset token valid
-  enabled: boolean;
 }
 
 // ID prefix map
@@ -52,7 +52,12 @@ export const AuthRecordIdPrefixMap = new Map<AuthRecordTypes, string>([
 
 // NOTE: if we have multiple record types, we could update below to use a union
 // of different fields and update the prefix map
-export type AuthRecordFields = RefreshRecordFields;
+export type AuthRecordFields = RefreshRecordFields | EmailCodeFields;
+
+export type EmailCodeRecord = PouchDB.Core.Document<EmailCodeFields> &
+  PouchDB.Core.RevisionIdMeta;
+export type RefreshRecord = PouchDB.Core.Document<RefreshRecordFields> &
+  PouchDB.Core.RevisionIdMeta;
 
 // Type of instantiated auth record in the database
 export type AuthRecord = PouchDB.Core.Document<AuthRecordFields> &

--- a/package-lock.json
+++ b/package-lock.json
@@ -11750,6 +11750,22 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/zod-adapter": {
+      "version": "1.106.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/zod-adapter/-/zod-adapter-1.106.0.tgz",
+      "integrity": "sha512-N8riQvRtgEzGlfwfOHLyPo5bbIP8g6tdCMVSUuhxg7BbiuluZdCEAxCcY0yx3illtLdAryksxj4HqF/xXaIMfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-router": ">=1.43.2",
+        "zod": "^3.23.8"
+      }
+    },
     "node_modules/@testim/chrome-version": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
@@ -50138,6 +50154,7 @@
         "@tanstack/react-router": "^1.87.9",
         "@tanstack/react-table": "^8.20.6",
         "@tanstack/router-devtools": "^1.87.9",
+        "@tanstack/zod-adapter": "^1.106.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "@tanstack/react-router": "^1.87.9",
     "@tanstack/react-table": "^8.20.6",
     "@tanstack/router-devtools": "^1.87.9",
+    "@tanstack/zod-adapter": "^1.106.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",

--- a/web/src/components/data-table/data-table.tsx
+++ b/web/src/components/data-table/data-table.tsx
@@ -28,6 +28,7 @@ interface DataTableProps<TData, TValue> {
   loading?: boolean;
   button?: ReactNode;
   onRowClick?: (row: TData) => void;
+  defaultRowsPerPage?: number;
 }
 
 /**
@@ -42,12 +43,13 @@ export function DataTable<TData, TValue>({
   loading,
   button,
   onRowClick,
+  defaultRowsPerPage = 10
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 5,
+    pageSize: defaultRowsPerPage,
   });
 
   const table = useReactTable({

--- a/web/src/components/dialogs/generate-password-reset.tsx
+++ b/web/src/components/dialogs/generate-password-reset.tsx
@@ -134,8 +134,7 @@ export const GeneratePasswordReset = ({
             <div className="flex justify-end">
               <Button
                 onClick={() => {
-                  resetCode.reset();
-                  setQrCodeData('');
+                  resetCode.mutate({id: userId});
                 }}
                 variant="outline"
               >

--- a/web/src/components/dialogs/generate-password-reset.tsx
+++ b/web/src/components/dialogs/generate-password-reset.tsx
@@ -1,0 +1,87 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {useAuth} from '@/context/auth-provider';
+import {useMutation} from '@tanstack/react-query';
+import React from 'react';
+import {Button} from '../ui/button';
+import {Spinner} from '../ui/spinner';
+
+/**
+ */
+export const GeneratePasswordReset = ({
+  userId,
+  open,
+  setOpen,
+}: {
+  userId?: string;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  // User auth
+  const {user} = useAuth();
+  if (!user) return null;
+
+  // Expect user ID
+  if (!userId) return null;
+
+  /**
+   * Handles submission of request for reset code
+   */
+  const resetCode = useMutation({
+    mutationKey: ['resetpassword', userId],
+    mutationFn: async ({id}: {id: string}) => {
+      return await fetch(`${import.meta.env.VITE_API_URL}/api/reset`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({
+          email: id,
+        }),
+      }).then(async res => {
+        return (await res.json()) as {code: string; url: string};
+      });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reset User Password</DialogTitle>
+          <DialogDescription>
+            Generate a password reset link for user: <b>{userId}</b>.
+          </DialogDescription>
+        </DialogHeader>
+        {resetCode.isPending ? (
+          <Spinner />
+        ) : resetCode.data ? (
+          <>
+            <p> RESULT : {resetCode.data.url}</p>
+            <Button
+              onClick={() => {
+                resetCode.reset();
+              }}
+            >
+              Clear
+            </Button>
+          </>
+        ) : (
+          <Button
+            onClick={() => {
+              resetCode.mutate({id: userId});
+            }}
+          >
+            Submit
+          </Button>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/components/forms/create-project-invite.tsx
+++ b/web/src/components/forms/create-project-invite.tsx
@@ -7,7 +7,7 @@ import {useQueryClient} from '@tanstack/react-query';
 export const fields = [
   {
     name: 'role',
-    label: `Role`,
+    label: 'Role',
     options: [
       {label: 'User', value: 'user'},
       {label: 'Team', value: 'team'},
@@ -57,7 +57,7 @@ export function CreateProjectInviteForm({
     );
 
     if (!response.ok)
-      return {type: 'submit', message: `Error creating invite.`};
+      return {type: 'submit', message: 'Error creating invite.'};
 
     QueryClient.invalidateQueries({queryKey: ['invites', projectId]});
 
@@ -68,7 +68,7 @@ export function CreateProjectInviteForm({
     <Form
       fields={fields}
       onSubmit={onSubmit}
-      submitButtonText={`Create Invite`}
+      submitButtonText={'Create Invite'}
     />
   );
 }

--- a/web/src/components/tables/users.tsx
+++ b/web/src/components/tables/users.tsx
@@ -30,8 +30,8 @@ export const getColumns = ({
           {row
             .getValue('roles')
             .filter((role: string) => !role.includes('||'))
-            .map((role: any) => (
-              <Role key={role} role={role} />
+            .map((role: string) => (
+              <Role key={role}>{role}</Role>
             ))}
         </div>
       ),

--- a/web/src/components/tables/users.tsx
+++ b/web/src/components/tables/users.tsx
@@ -1,51 +1,76 @@
 import {ColumnDef} from '@tanstack/react-table';
+import {KeyRound, Trash} from 'lucide-react';
 import {DataTableColumnHeader} from '../data-table/column-header';
-import {Trash} from 'lucide-react';
 import {Button} from '../ui/button';
 import Role from '../ui/role-card';
 
-export const columns: ColumnDef<any>[] = [
-  {
-    accessorKey: 'name',
-    header: ({column}) => (
-      <DataTableColumnHeader column={column} title="Name" />
-    ),
-  },
-  {
-    accessorKey: 'email',
-    header: ({column}) => (
-      <DataTableColumnHeader column={column} title="Email" />
-    ),
-  },
-  {
-    accessorKey: 'roles',
-    header: 'Roles',
-    cell: ({row}: any) => (
-      <div className="flex flex-wrap gap-1">
-        {row
-          .getValue('roles')
-          .filter((role: string) => !role.includes('||'))
-          .map((role: any) => (
-            <Role key={role} role={role} />
-          ))}
-      </div>
-    ),
-  },
-  {
-    id: 'remove',
-    cell: ({row}: any) => (
-      <div className="flex justify-center items-center -my-2">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => console.log('remove', row.original._id)}
-        >
-          <Trash className="h-4 w-4" />
-        </Button>
-      </div>
-    ),
-    header: () => (
-      <div className="flex justify-center items-center">Remove</div>
-    ),
-  },
-];
+export const getColumns = ({
+  onReset,
+}: {
+  onReset: (id: string) => void;
+}): ColumnDef<any>[] => {
+  return [
+    {
+      accessorKey: 'name',
+      header: ({column}) => (
+        <DataTableColumnHeader column={column} title="Name" />
+      ),
+    },
+    {
+      accessorKey: 'email',
+      header: ({column}) => (
+        <DataTableColumnHeader column={column} title="Email" />
+      ),
+    },
+    {
+      accessorKey: 'roles',
+      header: 'Roles',
+      cell: ({row}: any) => (
+        <div className="flex flex-wrap gap-1">
+          {row
+            .getValue('roles')
+            .filter((role: string) => !role.includes('||'))
+            .map((role: any) => (
+              <Role key={role} role={role} />
+            ))}
+        </div>
+      ),
+    },
+    {
+      id: 'reset',
+      cell: ({row}: any) => (
+        <div className="flex justify-center items-center -my-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => {
+              onReset(row.original._id);
+            }}
+          >
+            <KeyRound className="h-4 w-4" />
+          </Button>
+        </div>
+      ),
+      header: () => (
+        <div className="flex justify-center items-center">Reset Password</div>
+      ),
+    },
+    {
+      id: 'remove',
+      cell: ({row}: any) => (
+        <div className="flex justify-center items-center -my-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => console.log('remove', row.original._id)}
+          >
+            <Trash className="h-4 w-4" />
+          </Button>
+        </div>
+      ),
+      header: () => (
+        <div className="flex justify-center items-center">Remove</div>
+      ),
+    },
+  ];
+};

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,28 +1,28 @@
-import * as React from "react"
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { Check } from "lucide-react"
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import {Check} from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import {cn} from '@/lib/utils';
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className
     )}
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+      className={cn('flex items-center justify-center text-current')}
     >
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
-))
-Checkbox.displayName = CheckboxPrimitive.Root.displayName
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 
-export { Checkbox }
+export {Checkbox};

--- a/web/src/components/ui/spinner.tsx
+++ b/web/src/components/ui/spinner.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Spinner = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => {
+  const computeDelay = (i: number) => `${-1.2 + i * 0.1}s`
+  const computeRotation = (i: number) => `${i * 30}deg`
+  return (
+    <div
+      className={cn("size-5", className)}
+      role="status"
+      aria-label="Loading"
+      ref={ref}
+      {...props}
+    >
+      <div className="relative left-1/2 top-1/2 size-full">
+        {[...Array<number>(12)].map((_, i) => (
+          <div
+            key={i}
+            className="absolute left-[-10%] top-[-3.9%] h-[8%] w-[24%] animate-spinner rounded-full bg-foreground"
+            style={{
+              animationDelay: computeDelay(i),
+              transform: `rotate(${computeRotation(i)}) translate(146%)`,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+})
+Spinner.displayName = "Spinner"
+
+export { Spinner }

--- a/web/src/components/ui/spinner.tsx
+++ b/web/src/components/ui/spinner.tsx
@@ -1,16 +1,16 @@
-import React from "react"
+import React from 'react';
 
-import { cn } from "@/lib/utils"
+import {cn} from '@/lib/utils';
 
 const Spinner = React.forwardRef<
   HTMLDivElement,
-  React.ComponentPropsWithoutRef<"div">
->(({ className, ...props }, ref) => {
-  const computeDelay = (i: number) => `${-1.2 + i * 0.1}s`
-  const computeRotation = (i: number) => `${i * 30}deg`
+  React.ComponentPropsWithoutRef<'div'>
+>(({className, ...props}, ref) => {
+  const computeDelay = (i: number) => `${-1.2 + i * 0.1}s`;
+  const computeRotation = (i: number) => `${i * 30}deg`;
   return (
     <div
-      className={cn("size-5", className)}
+      className={cn('size-5', className)}
       role="status"
       aria-label="Loading"
       ref={ref}
@@ -29,8 +29,8 @@ const Spinner = React.forwardRef<
         ))}
       </div>
     </div>
-  )
-})
-Spinner.displayName = "Spinner"
+  );
+});
+Spinner.displayName = 'Spinner';
 
-export { Spinner }
+export {Spinner};

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as TemplatesIndexImport } from './routes/templates/index'
 import { Route as ProjectsIndexImport } from './routes/projects/index'
 import { Route as TemplatesTemplateIdImport } from './routes/templates/$templateId'
 import { Route as ProjectsProjectIdImport } from './routes/projects/$projectId'
+import { Route as AuthResetPasswordIndexImport } from './routes/auth/resetPassword/index'
 
 // Create/Update Routes
 
@@ -60,6 +61,12 @@ const TemplatesTemplateIdRoute = TemplatesTemplateIdImport.update({
 const ProjectsProjectIdRoute = ProjectsProjectIdImport.update({
   id: '/projects/$projectId',
   path: '/projects/$projectId',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const AuthResetPasswordIndexRoute = AuthResetPasswordIndexImport.update({
+  id: '/auth/resetPassword/',
+  path: '/auth/resetPassword/',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -116,6 +123,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TemplatesIndexImport
       parentRoute: typeof rootRoute
     }
+    '/auth/resetPassword/': {
+      id: '/auth/resetPassword/'
+      path: '/auth/resetPassword'
+      fullPath: '/auth/resetPassword'
+      preLoaderRoute: typeof AuthResetPasswordIndexImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -129,6 +143,7 @@ export interface FileRoutesByFullPath {
   '/templates/$templateId': typeof TemplatesTemplateIdRoute
   '/projects': typeof ProjectsIndexRoute
   '/templates': typeof TemplatesIndexRoute
+  '/auth/resetPassword': typeof AuthResetPasswordIndexRoute
 }
 
 export interface FileRoutesByTo {
@@ -139,6 +154,7 @@ export interface FileRoutesByTo {
   '/templates/$templateId': typeof TemplatesTemplateIdRoute
   '/projects': typeof ProjectsIndexRoute
   '/templates': typeof TemplatesIndexRoute
+  '/auth/resetPassword': typeof AuthResetPasswordIndexRoute
 }
 
 export interface FileRoutesById {
@@ -150,6 +166,7 @@ export interface FileRoutesById {
   '/templates/$templateId': typeof TemplatesTemplateIdRoute
   '/projects/': typeof ProjectsIndexRoute
   '/templates/': typeof TemplatesIndexRoute
+  '/auth/resetPassword/': typeof AuthResetPasswordIndexRoute
 }
 
 export interface FileRouteTypes {
@@ -162,6 +179,7 @@ export interface FileRouteTypes {
     | '/templates/$templateId'
     | '/projects'
     | '/templates'
+    | '/auth/resetPassword'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -171,6 +189,7 @@ export interface FileRouteTypes {
     | '/templates/$templateId'
     | '/projects'
     | '/templates'
+    | '/auth/resetPassword'
   id:
     | '__root__'
     | '/'
@@ -180,6 +199,7 @@ export interface FileRouteTypes {
     | '/templates/$templateId'
     | '/projects/'
     | '/templates/'
+    | '/auth/resetPassword/'
   fileRoutesById: FileRoutesById
 }
 
@@ -191,6 +211,7 @@ export interface RootRouteChildren {
   TemplatesTemplateIdRoute: typeof TemplatesTemplateIdRoute
   ProjectsIndexRoute: typeof ProjectsIndexRoute
   TemplatesIndexRoute: typeof TemplatesIndexRoute
+  AuthResetPasswordIndexRoute: typeof AuthResetPasswordIndexRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -201,6 +222,7 @@ const rootRouteChildren: RootRouteChildren = {
   TemplatesTemplateIdRoute: TemplatesTemplateIdRoute,
   ProjectsIndexRoute: ProjectsIndexRoute,
   TemplatesIndexRoute: TemplatesIndexRoute,
+  AuthResetPasswordIndexRoute: AuthResetPasswordIndexRoute,
 }
 
 export const routeTree = rootRoute
@@ -219,7 +241,8 @@ export const routeTree = rootRoute
         "/projects/$projectId",
         "/templates/$templateId",
         "/projects/",
-        "/templates/"
+        "/templates/",
+        "/auth/resetPassword/"
       ]
     },
     "/": {
@@ -242,6 +265,9 @@ export const routeTree = rootRoute
     },
     "/templates/": {
       "filePath": "templates/index.tsx"
+    },
+    "/auth/resetPassword/": {
+      "filePath": "auth/resetPassword/index.tsx"
     }
   }
 }

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -20,6 +20,8 @@ interface TokenParams {
   refreshToken?: string;
 }
 
+const EXCLUDED_PUBLIC_ROUTES = ['/auth/resetPassword'];
+
 /**
  * Route component renders the main application layout with a sidebar.
  * It includes the main navigation and the main content.
@@ -37,6 +39,11 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
     },
     search: {token, refreshToken},
   }) => {
+    // Exclusions
+    console.log(window.location.href);
+    if (EXCLUDED_PUBLIC_ROUTES.some(r => window.location.href.includes(r)))
+      return;
+
     if (isAuthenticated) return;
 
     const {status} = await getUserDetails(token, refreshToken);
@@ -59,12 +66,15 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 function RootLayout() {
   const {isAuthenticated} = useAuth();
 
-  if (!isAuthenticated) {
-    window.location.href = `${
-      import.meta.env.VITE_API_URL
-    }/logout?redirect=${import.meta.env.VITE_WEB_URL}`;
+  // Exclusions
+  if (!EXCLUDED_PUBLIC_ROUTES.some(r => window.location.href.includes(r))) {
+    if (!isAuthenticated) {
+      window.location.href = `${
+        import.meta.env.VITE_API_URL
+      }/logout?redirect=${import.meta.env.VITE_WEB_URL}`;
 
-    return <></>;
+      return <></>;
+    }
   }
 
   return (

--- a/web/src/routes/auth/resetPassword/index.tsx
+++ b/web/src/routes/auth/resetPassword/index.tsx
@@ -1,0 +1,127 @@
+/**
+ * Provides a password reset form - public route
+ */
+import {Form} from '@/components/form';
+import {Button} from '@/components/ui/button';
+import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
+import {createFileRoute, useNavigate} from '@tanstack/react-router';
+import {zodValidator} from '@tanstack/zod-adapter';
+import {z} from 'zod';
+import {AlertTriangle} from 'lucide-react';
+
+// Validate that code exists and is non-empty
+const ResetPasswordSearchSchema = z.object({
+  code: z.preprocess(
+    // If value is undefined (no query param), use empty string
+    val => (val === undefined ? '' : String(val)),
+    z.string()
+  ),
+});
+
+export const Route = createFileRoute('/auth/resetPassword/')({
+  component: RouteComponent,
+  validateSearch: zodValidator(ResetPasswordSearchSchema),
+});
+
+function ErrorDisplay() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col space-y-6 max-w-md mx-auto mt-8">
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>Invalid Reset Link</AlertTitle>
+        <AlertDescription>
+          The password reset link you're trying to use is invalid. Please
+          request a new password reset link.
+        </AlertDescription>
+      </Alert>
+
+      <Button onClick={() => navigate({to: '/'})} className="w-full">
+        Return to Home
+      </Button>
+    </div>
+  );
+}
+
+function RouteComponent() {
+  const navigate = useNavigate();
+  const {code} = Route.useSearch();
+
+  if (!code) {
+    return <ErrorDisplay />;
+  }
+
+  const fields = [
+    {
+      name: 'newPassword',
+      label: 'New Password',
+      type: 'password',
+      schema: z.string().min(10, 'Password must be at least 10 characters'),
+    },
+    {
+      name: 'repeatedPassword',
+      label: 'Repeat Password',
+      type: 'password',
+      schema: z.string().min(10, 'Password must be at least 10 characters'),
+    },
+  ];
+
+  const onSubmit = async ({
+    newPassword,
+    repeatedPassword,
+  }: {
+    newPassword: string;
+    repeatedPassword: string;
+  }) => {
+    if (newPassword !== repeatedPassword) {
+      return {
+        type: 'error',
+        message: 'Passwords do not match',
+      };
+    }
+
+    const response = await fetch(`${import.meta.env.VITE_API_URL}/api/reset`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        code,
+        newPassword,
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        type: 'error',
+        message: 'Error resetting password.',
+      };
+    }
+
+    // Success - go home
+    navigate({to: '/'});
+  };
+
+  return (
+    <div className="flex flex-col space-y-6 max-w-md mx-auto mt-8">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-semibold">Reset Password</h1>
+        <Button variant="outline" onClick={() => navigate({to: '/'})}>
+          Go home
+        </Button>
+      </div>
+
+      <p className="text-secondary-foreground">
+        Using the form below, enter your new password twice. The password must
+        be 10 characters or longer.
+      </p>
+
+      <Form
+        fields={fields}
+        onSubmit={onSubmit}
+        submitButtonText="Reset password"
+      />
+    </div>
+  );
+}

--- a/web/src/routes/users.tsx
+++ b/web/src/routes/users.tsx
@@ -1,8 +1,10 @@
 import {useAuth} from '@/context/auth-provider';
-import {columns} from '@/components/tables/users';
+import {getColumns} from '@/components/tables/users';
 import {DataTable} from '@/components/data-table/data-table';
 import {createFileRoute} from '@tanstack/react-router';
 import {useGetUsers} from '@/hooks/get-hooks';
+import {useState} from 'react';
+import {GeneratePasswordReset} from '@/components/dialogs/generate-password-reset';
 
 export const Route = createFileRoute('/users')({
   component: RouteComponent,
@@ -18,11 +20,28 @@ function RouteComponent() {
   const {user: authUser} = useAuth();
   const {data, isPending} = useGetUsers(authUser);
 
+  const [resetDialog, setResetDialog] = useState<boolean>(false);
+  const [resetUserId, setResetUserId] = useState<string | undefined>(undefined);
+
+  const onReset = (id: string) => {
+    setResetUserId(id);
+    setResetDialog(true);
+  };
+
   return (
-    <DataTable
-      columns={columns}
-      data={data?.map((user: any) => ({...user, email: user.emails[0]})) || []}
-      loading={isPending}
-    />
+    <>
+      <DataTable
+        columns={getColumns({onReset})}
+        data={
+          data?.map((user: any) => ({...user, email: user.emails[0]})) || []
+        }
+        loading={isPending}
+      />
+      <GeneratePasswordReset
+        open={resetDialog}
+        setOpen={setResetDialog}
+        userId={resetUserId}
+      />
+    </>
   );
 }

--- a/web/src/routes/users.tsx
+++ b/web/src/routes/users.tsx
@@ -36,6 +36,7 @@ function RouteComponent() {
           data?.map((user: any) => ({...user, email: user.emails[0]})) || []
         }
         loading={isPending}
+        defaultRowsPerPage={15}
       />
       <GeneratePasswordReset
         open={resetDialog}


### PR DESCRIPTION
# feat: admin forgot password reset workflow

## JIRA Ticket

[BSS-758](https://jira.csiro.au/browse/BSS-758)

## Description

Implements a new workflow for resetting your password. 

The workflow is as follows

1. Cluster-admin initiates a password reset by specifying an email (really a userId)
2. This generates a DB persisted one-time use expiring code which is stored hashed in the DB (so access to DB cannot grant ability to use the codes) 
3. This code is returned both directly to the user once, and also as a URL
4. The user navigates to this link which is in the new conductor, opening a public route which allows the user to specify a new password
5. This sends the code + new password to the API, which updates the local strategy password for that user

The user experience makes it easy to share this link by presenting a copyable link display + QR code which can be enlarged by clicking it.

Also adds an admin only 'forceInit' endpoint which forcefully updates design docs etc (disabling the 'if the doc already exists, don't write it again' check) - this is useful since this change involves updates to the design doc which are otherwise not able to be programmatically migrated. 

## Migrations 

**Required changes!**

### CouchDB migration

This functionality will not work until you apply the following migration

1. login as cluster admin to old conductor
2. copy the bearer token
3. update `/api/.env` with `USER_TOKEN=<>`
4. setup npm env `cd /api && npm i` 
5. run the force init action `npm run forceinitdb`

Try generating a code and make sure the workflow is functional.

### Deployment configuration

Add the new `NEW_CONDUCTOR_URL` environment variable to the conductor/api build. This is already done in the `aws-cdk` IaC - however in existing deployments you may need to update your build configuration.

**Note** ensure this includes the https:// prefix!

**This is a mandatory property and not including it will break the deployment**. 

## How to Test

Follow the workflow above through the new conductor interface. check that the code cannot be used twice and that invalid codes are rejected (noting you can change the query string arg in the URL). Check the updated password works, and that the old password doesn't.

## Additional Information

- right now, external IdP users who reset their password will actually have the local strategy added - there is a ticket to track this behaviour and make it more intentional https://jira.csiro.au/browse/BSS-772
- couldn't get the data-model to work in /web - tried adding to package.json, turbo building, etc etc but it just wouldn't pick them up (in the build, the VS code interpreter liked them) https://jira.csiro.au/browse/BSS-774

## Screenshots

### Generating a code

navigate to users tab of new conductor and select the reset password button

![image](https://github.com/user-attachments/assets/0a8d3ad7-d879-4dee-9bf9-efdfa9324adc)

Then share the URL or the QR code

![image](https://github.com/user-attachments/assets/b5d1f8ea-d44b-4cc0-a100-e196edfd3ccd)

### Resetting password

Navigate to the URL via QR code or direct link.

Enter your new password and submit

![image](https://github.com/user-attachments/assets/a810b93a-573d-431b-b12d-66996dfb47a0)

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
