### PR TITLE
Fix overview map re-render

### DIFF
--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -147,8 +147,6 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
   });
   const forceRecordRefresh = records.query.refetch;
 
-  console.log('notebook component', records);
-
   // Fetch drafts
   const drafts = useDraftsList({
     projectId: project.project_id,

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -147,6 +147,8 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
   });
   const forceRecordRefresh = records.query.refetch;
 
+  console.log('notebook component', records);
+
   // Fetch drafts
   const drafts = useDraftsList({
     projectId: project.project_id,
@@ -599,6 +601,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
               <OverviewMap
                 project_id={project.project_id}
                 uiSpec={uiSpec.data}
+                records={records}
               />
             )}
           </TabPanel>

--- a/app/src/gui/components/notebook/overview_map.tsx
+++ b/app/src/gui/components/notebook/overview_map.tsx
@@ -18,11 +18,8 @@
  *   Display an overview map of the records in the notebook.
  */
 
-import {
-  getMetadataForAllRecords,
-  ProjectID,
-  ProjectUIModel,
-} from '@faims3/data-model';
+import {Geolocation} from '@capacitor/geolocation';
+import {ProjectID, ProjectUIModel, RecordMetadata} from '@faims3/data-model';
 import {Box, Popover} from '@mui/material';
 import {useQuery} from '@tanstack/react-query';
 import {View} from 'ol';
@@ -40,13 +37,11 @@ import {memo, useCallback, useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
 import {createCenterControl} from '../map/center-control';
-import {Geolocation} from '@capacitor/geolocation';
-import {useAppSelector} from '../../../context/store';
-import {selectActiveUser} from '../../../context/slices/authSlice';
 
 interface OverviewMapProps {
   uiSpec: ProjectUIModel;
   project_id: ProjectID;
+  records: {allRecords: RecordMetadata[]};
 }
 
 interface FeatureProps {
@@ -68,7 +63,6 @@ export const OverviewMap = memo((props: OverviewMapProps) => {
   const [selectedFeature, setSelectedFeature] = useState<FeatureProps | null>(
     null
   );
-  const activeUser = useAppSelector(selectActiveUser);
   /**
    * Get the names of all GIS fields in this UI Specification
    * @param uiSpec UI specification for the project
@@ -93,12 +87,7 @@ export const OverviewMap = memo((props: OverviewMapProps) => {
   const getFeatures = async () => {
     const f: FeatureProps[] = [];
     if (gisFields.length > 0) {
-      const records = await getMetadataForAllRecords(
-        // TODO what do we do if no active user?
-        activeUser!.parsedToken,
-        props.project_id,
-        true
-      );
+      const records = props.records.allRecords;
       if (records) {
         records.forEach(record => {
           if (record.data) {

--- a/app/src/gui/components/notebook/overview_map.tsx
+++ b/app/src/gui/components/notebook/overview_map.tsx
@@ -36,7 +36,7 @@ import {OSM} from 'ol/source';
 import VectorSource from 'ol/source/Vector';
 import {Fill, RegularShape, Stroke, Style} from 'ol/style';
 import CircleStyle from 'ol/style/Circle';
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {memo, useCallback, useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
 import {createCenterControl} from '../map/center-control';
@@ -59,16 +59,16 @@ const defaultMapProjection = 'EPSG:3857';
 
 /**
  * Create an overview map of the records in the notebook.
+ * Wrapped in memo to prevent re-rendering when nothing has changed.
  *
  * @param props {uiSpec, project_id}
  */
-export const OverviewMap = (props: OverviewMapProps) => {
+export const OverviewMap = memo((props: OverviewMapProps) => {
   const [map, setMap] = useState<Map | undefined>(undefined);
   const [selectedFeature, setSelectedFeature] = useState<FeatureProps | null>(
     null
   );
   const activeUser = useAppSelector(selectActiveUser);
-
   /**
    * Get the names of all GIS fields in this UI Specification
    * @param uiSpec UI specification for the project
@@ -186,6 +186,17 @@ export const OverviewMap = (props: OverviewMapProps) => {
       setSelectedFeature(feature as FeatureProps);
     });
 
+    // theMap.getView().on('change:resolution', () => {
+    //   const z = theMap.getView().getZoom();
+    //   console.log('change zoom: ', z);
+    //  // if (z) props.setZoomLevel(z);
+    // });
+
+    // theMap.on('moveend', () => {
+    //   const extent = theMap.getView().getViewStateAndExtent().extent;
+    //   console.log('changed extent');
+    //   //if (extent) props.setExtent(extent);
+    // });
     return theMap;
   }, []);
 
@@ -266,6 +277,9 @@ export const OverviewMap = (props: OverviewMapProps) => {
       // set the view so that we can see the features
       // but don't zoom too much
       const extent = source.getExtent();
+      // if (!extent.includes(Infinity)) sourceExtent = extent;
+      // console.log('source extent: ', sourceExtent);
+
       // don't fit if the extent is infinite because it crashes
       if (!extent.includes(Infinity)) {
         map.getView().fit(extent, {padding: [100, 100, 100, 100], maxZoom: 12});
@@ -349,4 +363,4 @@ export const OverviewMap = (props: OverviewMapProps) => {
         </Popover>
       </>
     );
-};
+});

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -14,6 +14,8 @@ import {useAppSelector} from '../context/store';
 import {OfflineFallbackComponent} from '../gui/components/ui/OfflineFallback';
 import {directory_db} from '../sync/databases';
 import {DraftFilters, listDraftMetadata} from '../sync/draft-storage';
+import _ from 'lodash';
+
 
 export const usePrevious = <T extends {}>(value: T): T | undefined => {
   /**
@@ -358,6 +360,11 @@ export const useRecordList = ({
     networkMode: 'always',
     gcTime: 0,
     refetchInterval: refreshIntervalMs,
+    // implement a custom structural sharing function to avoid re-renders when
+    // the list of records is the same
+    structuralSharing: (oldData, newData) => {
+      return _.isEqual(oldData, newData) ? oldData : newData;
+    },
     queryFn: async () => {
       if (!token) {
         // Trying to run without token!


### PR DESCRIPTION
# Fix overview map re-render

## JIRA Ticket

[BSS-749](https://jira.csiro.com/browse/BSS-749)

## Description

The overview map would re-render every 10s and reset the  map to the initial position.

## Proposed Changes

- Added 'memo' to the overview map component to prevent re-renders if the props don't change. 
- Added a custom equality comparison to the useRecords query to prevent re-renders if the list of records is the same as last time
- Pass records from the parent into overview map so it doesn't have to get them itself.

## How to Test

View the overview map and zoom/pan the map, note that it doesn't reset after 10s.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
