### PR TITLE
Can't filter map values on Safari

### DIFF
--- a/app/src/context/projects-context.tsx
+++ b/app/src/context/projects-context.tsx
@@ -104,8 +104,7 @@ export function ProjectsProvider({children}: {children: ReactNode}) {
 
         // Get the current set of projects for this listing
         const currentSet = new Set(
-          newProjectsMap
-            .values()
+          Array.from(newProjectsMap.values())
             .filter(project => project.listing === listingId)
             .map(project => project._id)
         );


### PR DESCRIPTION

# Can't filter map values on Safari

## JIRA Ticket

None

## Description

Safari doesn't support map.values().filter()


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
