### PR TITLE
fix: initials function causing crash 🐞

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -17,10 +17,11 @@ export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
  * @param {string} name - The name to extract initials from.
  * @returns {string} The initials of the name.
  */
-export const initials = (name: string) => {
-  const parts = name.split(' ');
-  return parts.map(part => part[0].toUpperCase()).join('');
-};
+export const initials = (name: string) =>
+  name
+    .split(' ')
+    .map(s => s.slice(0, 1).toUpperCase())
+    .join('');
 
 /**
  * capitalize function returns the capitalized version of a string.


### PR DESCRIPTION
## JIRA Ticket

[BSS-794](https://jira.csiro.au/browse/BSS-794)

## Description

Resolving the issue where having extra spacing in name would cause the app to crash.

## Proposed Changes

- updated initials function to index the substrings using slice to avoid crashing on empty strings

## How to Test

1. Create a new account with extra spacing in the `name` e.g " Luke  Test "
2. Log in to new conductor using that account
3. Verify the app loads normally and your profile initials are displaying correctly in the bottom left of the screen

## Additional Information

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
