### PR TITLE
allow user to be able to deselect the selected radio item in radio gr…

### DIFF
--- a/app/src/gui/fields/radio.tsx
+++ b/app/src/gui/fields/radio.tsx
@@ -66,15 +66,24 @@ interface Props {
 
 export class RadioGroup extends React.Component<RadioGroupProps & Props> {
   /**
-   * Handles changes in the selected radio button.
-   * @param {React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>} e - The change event.
+   * Handles changes in the selected radio button, allowing users to toggle selection.
+   * If a selected radio button is clicked again, it gets deselected (value is cleared).
+   *
+   * @param {React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>} e - The change event triggered by user interaction.
    */
   handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    this.props.form.setFieldValue(this.props.field.name, e.target.value, true);
+    const {field, form} = this.props;
+    const selectedValue = e.target.value;
+
+    const newValue = field.value === selectedValue ? null : selectedValue;
+    form.setFieldValue(field.name, newValue, true);
+
+    form.setTouched({...form.touched, [field.name]: true});
   }
 
   render() {
     const {ElementProps, label, helperText, ...radioGroupProps} = this.props;
+    const {field} = this.props;
 
     return (
       <FieldWrapper
@@ -89,13 +98,26 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
         >
           <MuiRadioGroup
             {...fieldToRadioGroup(radioGroupProps)}
+            value={field.value || ''}
             onChange={e => this.handleChange(e)}
           >
             {ElementProps.options.map(option => (
               <FormControlLabel
                 key={option.key || option.value}
                 value={option.value}
-                control={<MuiRadio {...option.RadioProps} />}
+                control={
+                  <MuiRadio
+                    {...option.RadioProps}
+                    checked={field.value === option.value}
+                    onClick={() => {
+                      if (field.value === option.value) {
+                        this.handleChange({
+                          target: {value: ''},
+                        } as React.ChangeEvent<HTMLInputElement>);
+                      }
+                    }}
+                  />
+                }
                 label={option.label}
                 {...option.FormControlProps}
                 disabled={this.props.disabled ?? false}

--- a/app/src/gui/fields/radio.tsx
+++ b/app/src/gui/fields/radio.tsx
@@ -82,8 +82,8 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
   }
 
   render() {
-    const {ElementProps, label, helperText, ...radioGroupProps} = this.props;
-    const {field} = this.props;
+    const {field, form, ElementProps, label, helperText, ...radioGroupProps} =
+      this.props;
 
     return (
       <FieldWrapper
@@ -91,13 +91,9 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
         subheading={helperText}
         required={this.props.required}
       >
-        <FormControl
-          error={Boolean(
-            radioGroupProps.form.errors[radioGroupProps.field.name]
-          )}
-        >
+        <FormControl error={Boolean(form.errors?.[field.name])}>
           <MuiRadioGroup
-            {...fieldToRadioGroup(radioGroupProps)}
+            {...fieldToRadioGroup({field, form, ...radioGroupProps})}
             value={field.value || ''}
             onChange={e => this.handleChange(e)}
           >


### PR DESCRIPTION


## JIRA Ticket

[BSS-782
](https://jira.csiro.au/browse/BSS-782
)

## Description

Allow user to be able to deselect the radio item in radio group.

Formik doesn't allow the automatic render and doesn't allow radio item deselection, have added a forced trick to get this working.


## How to Test

Select the radio item within a radio group, click again to the selected radio, it should be deselected.
If clicked again it should be selected. Just a common way of selecting/deselecting a radio.



## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
