### PR TITLE
Publish buttons visibility and configuration

### DIFF
--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -786,29 +786,64 @@ class RecordForm extends React.Component<any, RecordFormState> {
     return new_values;
   }
 
+  checkAllSectionsVisited() {
+    const allSections =
+      this.props.ui_specification.viewsets[this.getViewsetName()].views;
+
+    const allVisited = allSections.every((section: string) =>
+      this.state.visitedSteps.has(section)
+    );
+
+    console.log('All Sections:', allSections);
+    console.log('All Sections Visited?', allVisited);
+
+    if (allVisited) {
+      console.log('All sections are now visited.');
+    } else {
+      console.log('ome sections are still unvisited.');
+    }
+  }
+
   onChangeStepper(view_name: string, activeStepIndex: number) {
-    this.setState(prevState => {
-      const {activeStep} = prevState;
+    this.setState(
+      prevState => {
+        const {activeStep} = prevState;
 
-      const wasVisitedBefore = prevState.visitedSteps.has(view_name);
+        const wasVisitedBefore = prevState.visitedSteps.has(view_name);
 
-      // add to visitedSteps if it has not been visited before
-      const updatedVisitedSteps = new Set(prevState.visitedSteps);
-      updatedVisitedSteps.add(view_name);
+        console.log('Current Step:', view_name);
+        console.log('Previous Steps:', prevState.visitedSteps);
+        console.log('Was Visited Before:', wasVisitedBefore);
 
-      const isFirstStep = activeStepIndex === 0;
+        // add to visitedSteps if it has not been visited before
+        const updatedVisitedSteps = new Set(prevState.visitedSteps);
+        updatedVisitedSteps.add(view_name);
+        console.log('Updated Visited Steps:', updatedVisitedSteps);
 
-      const isRevisiting =
-        wasVisitedBefore || (isFirstStep && activeStep !== activeStepIndex);
+        const isFirstStep = activeStepIndex === 0;
 
-      return {
-        ...prevState,
-        view_cached: view_name,
-        activeStep: activeStepIndex,
-        visitedSteps: updatedVisitedSteps,
-        isRevisiting,
-      };
-    });
+        const isRevisiting =
+          wasVisitedBefore || (isFirstStep && activeStep !== activeStepIndex);
+
+        console.log('Is Revisiting:', isRevisiting);
+
+        return {
+          ...prevState,
+          view_cached: view_name,
+          activeStep: activeStepIndex,
+          visitedSteps: updatedVisitedSteps,
+          isRevisiting,
+        };
+      },
+      () => {
+        // 🔹 Add a callback function after setState to verify if all sections are visited
+        console.log(
+          'Final Visited Steps (after update):',
+          this.state.visitedSteps
+        );
+        this.checkAllSectionsVisited(); // Check if all sections are visited
+      }
+    );
   }
 
   onChangeTab(event: React.ChangeEvent<{}>, newValue: string) {
@@ -1390,7 +1425,14 @@ class RecordForm extends React.Component<any, RecordFormState> {
                 const publishButtonBehaviour =
                   this.props.ui_specification.viewsets[this.getViewsetName()]
                     ?.publishButtonBehaviour || 'always';
-                console.log('publishButtonBehaviour', publishButtonBehaviour);
+
+                console.log(
+                  ' Publish Button Behaviour:',
+                  publishButtonBehaviour
+                );
+                console.log(' All Sections Visited?', allSectionsVisited);
+                console.log(' Form Has Errors?', hasErrors);
+
                 const showPublishButton =
                   publishButtonBehaviour === 'always' ||
                   (publishButtonBehaviour === 'visited' &&
@@ -1398,6 +1440,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
                   (publishButtonBehaviour === 'noErrors' &&
                     allSectionsVisited &&
                     !hasErrors);
+
                 // Recompute derived values if something has changed
                 const {values, setValues} = formProps;
                 // Compare current values with last processed values

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -793,15 +793,6 @@ class RecordForm extends React.Component<any, RecordFormState> {
     const allVisited = allSections.every((section: string) =>
       this.state.visitedSteps.has(section)
     );
-
-    console.log('All Sections:', allSections);
-    console.log('All Sections Visited?', allVisited);
-
-    if (allVisited) {
-      console.log('All sections are now visited.');
-    } else {
-      console.log('ome sections are still unvisited.');
-    }
   }
 
   onChangeStepper(view_name: string, activeStepIndex: number) {
@@ -811,21 +802,14 @@ class RecordForm extends React.Component<any, RecordFormState> {
 
         const wasVisitedBefore = prevState.visitedSteps.has(view_name);
 
-        console.log('Current Step:', view_name);
-        console.log('Previous Steps:', prevState.visitedSteps);
-        console.log('Was Visited Before:', wasVisitedBefore);
-
         // add to visitedSteps if it has not been visited before
         const updatedVisitedSteps = new Set(prevState.visitedSteps);
         updatedVisitedSteps.add(view_name);
-        console.log('Updated Visited Steps:', updatedVisitedSteps);
 
         const isFirstStep = activeStepIndex === 0;
 
         const isRevisiting =
           wasVisitedBefore || (isFirstStep && activeStep !== activeStepIndex);
-
-        console.log('Is Revisiting:', isRevisiting);
 
         return {
           ...prevState,
@@ -836,11 +820,6 @@ class RecordForm extends React.Component<any, RecordFormState> {
         };
       },
       () => {
-        // 🔹 Add a callback function after setState to verify if all sections are visited
-        console.log(
-          'Final Visited Steps (after update):',
-          this.state.visitedSteps
-        );
         this.checkAllSectionsVisited(); // Check if all sections are visited
       }
     );
@@ -1425,13 +1404,6 @@ class RecordForm extends React.Component<any, RecordFormState> {
                 const publishButtonBehaviour =
                   this.props.ui_specification.viewsets[this.getViewsetName()]
                     ?.publishButtonBehaviour || 'always';
-
-                console.log(
-                  ' Publish Button Behaviour:',
-                  publishButtonBehaviour
-                );
-                console.log(' All Sections Visited?', allSectionsVisited);
-                console.log(' Form Has Errors?', hasErrors);
 
                 const showPublishButton =
                   publishButtonBehaviour === 'always' ||

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1327,16 +1327,9 @@ class RecordForm extends React.Component<any, RecordFormState> {
         viewsetName,
         {}
       );
-      // Publish buttons behaviour
-      // const publishButtonBehaviour =
-      //   ui_specification.viewsets[viewsetName]?.publishButtonBehaviour ||
-      //   'always';
-
-      // console.log('publishbuttonbehaviour', publishButtonBehaviour);
 
       // Track visited sections and errors
       const allSectionsVisited = this.state.visitedSteps.size === views.length;
-      console.log('allsectionsvisited', allSectionsVisited);
 
       return (
         <Box>

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -78,6 +78,7 @@ import {
 } from './relationships/RelatedInformation';
 import UGCReport from './UGCReport';
 import {getUsefulFieldNameFromUiSpec, ViewComponent} from './view';
+import {c} from 'vitest/dist/reporters-5f784f42';
 
 type RecordFormProps = {
   navigate: NavigateFunction;
@@ -1305,6 +1306,23 @@ class RecordForm extends React.Component<any, RecordFormState> {
         viewsetName
       );
       const description = this.requireDescription(viewName);
+      const views = getViewsMatchingCondition(
+        this.props.ui_specification,
+        initialValues,
+        [],
+        viewsetName,
+        {}
+      );
+      // Publish buttons behaviour
+      // const publishButtonBehaviour =
+      //   ui_specification.viewsets[viewsetName]?.publishButtonBehaviour ||
+      //   'always';
+
+      // console.log('publishbuttonbehaviour', publishButtonBehaviour);
+
+      // Track visited sections and errors
+      const allSectionsVisited = this.state.visitedSteps.size === views.length;
+      console.log('allsectionsvisited', allSectionsVisited);
 
       return (
         <Box>
@@ -1368,6 +1386,18 @@ class RecordForm extends React.Component<any, RecordFormState> {
               }}
             >
               {formProps => {
+                const hasErrors = Object.keys(formProps.errors).length > 0;
+                const publishButtonBehaviour =
+                  this.props.ui_specification.viewsets[this.getViewsetName()]
+                    ?.publishButtonBehaviour || 'always';
+                console.log('publishButtonBehaviour', publishButtonBehaviour);
+                const showPublishButton =
+                  publishButtonBehaviour === 'always' ||
+                  (publishButtonBehaviour === 'visited' &&
+                    allSectionsVisited) ||
+                  (publishButtonBehaviour === 'noErrors' &&
+                    allSectionsVisited &&
+                    !hasErrors);
                 // Recompute derived values if something has changed
                 const {values, setValues} = formProps;
                 // Compare current values with last processed values
@@ -1516,6 +1546,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
                         formProps={formProps}
                         ui_specification={ui_specification}
                         views={views}
+                        showPublishButton={showPublishButton}
                         handleFormSubmit={(is_close: string) => {
                           formProps.setSubmitting(true);
                           this.setTimeout(() => {
@@ -1613,6 +1644,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
                         formProps={formProps}
                         ui_specification={ui_specification}
                         views={views}
+                        showPublishButton={showPublishButton}
                         handleFormSubmit={(is_close: string) => {
                           formProps.setSubmitting(true);
                           this.setTimeout(() => {

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -32,7 +32,7 @@ import {
   upsertFAIMSData,
 } from '@faims3/data-model';
 import {Alert, Box, Divider, Typography} from '@mui/material';
-import {Form, Formik} from 'formik';
+import {Form, Formik, FormikProps} from 'formik';
 import React from 'react';
 import {NavigateFunction} from 'react-router-dom';
 import * as ROUTES from '../../../constants/routes';
@@ -173,6 +173,7 @@ type RecordFormState = {
 
 class RecordForm extends React.Component<any, RecordFormState> {
   draftState: RecordDraftState | null = null;
+  private formikRef = React.createRef<FormikProps<any>>();
 
   // List of timeouts that unmount must cancel
   timeouts: (typeof setTimeout)[] = [];
@@ -1335,6 +1336,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
         <Box>
           <div>
             <Formik
+              innerRef={this.formikRef}
               initialValues={initialValues}
               // We are manually running the validate function now - if you
               // leave this here this schema validation will take precedence

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -822,6 +822,13 @@ class RecordForm extends React.Component<any, RecordFormState> {
       },
       () => {
         this.checkAllSectionsVisited(); // Check if all sections are visited
+
+        if (
+          this.state.visitedSteps.size === this.state.views.length &&
+          this.formikRef?.current
+        ) {
+          this.formikRef.current.validateForm();
+        }
       }
     );
   }
@@ -1404,9 +1411,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
                   publishButtonBehaviour === 'always' ||
                   (publishButtonBehaviour === 'visited' &&
                     allSectionsVisited) ||
-                  (publishButtonBehaviour === 'noErrors' &&
-                    allSectionsVisited &&
-                    !hasErrors);
+                  (publishButtonBehaviour === 'noErrors' && !hasErrors);
 
                 // Recompute derived values if something has changed
                 const {values, setValues} = formProps;

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -796,6 +796,20 @@ class RecordForm extends React.Component<any, RecordFormState> {
     );
   }
 
+  /**
+   * Handles navigation between form sections (steps).
+   *
+   * Tracks visited sections and updates the active step.
+   * When all sections are visited, forces Formik to revalidate the form
+   * to ensure the "Publish" button is shown correctly.
+   *
+   * This function supports the `publishButtonBehaviour` setting, which controls
+   * when the publish button should be displayed:
+   *
+   * - `'always'`: The publish button is always visible.
+   * - `'visited'`: The publish button is shown only after all sections are visited.
+   * - `'noErrors'`: The publish button is shown only after all the errors/required fields of the form as addressed.
+   */
   onChangeStepper(view_name: string, activeStepIndex: number) {
     this.setState(
       prevState => {

--- a/app/src/gui/components/record/formButton.tsx
+++ b/app/src/gui/components/record/formButton.tsx
@@ -75,6 +75,7 @@ interface FormButtonGroupProps {
 
   visitedSteps: Set<string>;
   isRecordSubmitted: boolean;
+  showPublishButton?: boolean;
 }
 
 /**
@@ -151,6 +152,7 @@ export default function FormButtonGroup({
   views,
   ui_specification,
   layout,
+  showPublishButton = true,
 }: FormButtonGroupProps) {
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
 
@@ -169,25 +171,29 @@ export default function FormButtonGroup({
       <Grid container spacing={2}>
         <Grid item xs={10.5}>
           <Box sx={{display: 'flex', flexDirection: 'column', gap: 1}}>
-            <FormSubmitButton
-              color="primary"
-              data-testid="publish-close-record"
-              disabled={disabled}
-              formProps={formProps}
-              text={`Publish and close ${record_type}`}
-              is_close="close"
-              handleFormSubmit={handleFormSubmit}
-              is_final_view={is_final_view}
-            />
-            <FormSubmitButton
-              color="secondary"
-              disabled={disabled}
-              formProps={formProps}
-              text={`Publish and new ${record_type}`}
-              is_close="new"
-              handleFormSubmit={handleFormSubmit}
-              is_final_view={is_final_view}
-            />
+            {showPublishButton && (
+              <>
+                <FormSubmitButton
+                  color="primary"
+                  data-testid="publish-close-record"
+                  disabled={disabled}
+                  formProps={formProps}
+                  text={`Publish and close ${record_type}`}
+                  is_close="close"
+                  handleFormSubmit={handleFormSubmit}
+                  is_final_view={is_final_view}
+                />
+                <FormSubmitButton
+                  color="secondary"
+                  disabled={disabled}
+                  formProps={formProps}
+                  text={`Publish and new ${record_type}`}
+                  is_close="new"
+                  handleFormSubmit={handleFormSubmit}
+                  is_final_view={is_final_view}
+                />
+              </>
+            )}
           </Box>
         </Grid>
         <Grid

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -25,8 +25,13 @@ import React from 'react';
 import {useAppDispatch, useAppSelector} from '../state/hooks';
 import {FieldType} from '../state/initial';
 
-type FormSettingsPanelProps = {
-  viewSetId: string;
+type ViewSetType = {
+  views: string[];
+  label: string;
+  summary_fields?: string[];
+  layout?: 'inline' | 'tabs';
+  hridField?: string;
+  publishButtonBehaviour?: 'always' | 'visited' | 'noErrors';
 };
 
 /**
@@ -64,18 +69,34 @@ const SettingSection = ({
   </div>
 );
 
-export const FormSettingsPanel = ({viewSetId}: FormSettingsPanelProps) => {
+export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
   const dispatch = useAppDispatch();
   const fields = useAppSelector(
     state => state.notebook['ui-specification'].fields
   );
-  const viewSet = useAppSelector(
+  const viewSet: ViewSetType = useAppSelector(
     state => state.notebook['ui-specification'].viewsets[viewSetId]
   );
   const fviews = useAppSelector(
     state => state.notebook['ui-specification'].fviews
   );
   const [expanded, setExpanded] = React.useState(false);
+
+  /**
+   * Updates the Publish Button Behavior setting
+   */
+  const handlePublishButtonBehaviourChange = (event: any) => {
+    dispatch({
+      type: 'ui-specification/viewSetPublishButtonBehaviourUpdated',
+      payload: {
+        viewSetId,
+        publishButtonBehaviour: event.target.value as
+          | 'always'
+          | 'visited'
+          | 'noErrors',
+      },
+    });
+  };
 
   /**
    * Collects all fields that belong to any view in the current viewset
@@ -197,6 +218,27 @@ export const FormSettingsPanel = ({viewSetId}: FormSettingsPanelProps) => {
 
       <Collapse in={expanded}>
         <CardContent>
+          {/* Publish Button Behavior*/}
+          <SettingSection
+            title="Publish Button Behavior"
+            description="Configure when the Publish and Close buttons should be shown."
+          >
+            <Select
+              fullWidth
+              value={viewSet.publishButtonBehaviour || 'always'}
+              onChange={handlePublishButtonBehaviourChange}
+            >
+              <MenuItem value="always">Always Show</MenuItem>
+              <MenuItem value="visited">
+                Show Once All Sections Visited
+              </MenuItem>
+              <MenuItem value="noErrors">
+                Show Only When No Errors Exist
+              </MenuItem>
+            </Select>
+          </SettingSection>
+
+          {/* Layout Style section  */}
           <SettingSection
             title="Layout Style"
             description="Choose how form sections are displayed. The 'tabs' layout will display questions split up into their sections. The 'inline' layout will display all questions in a single scrollable form."
@@ -204,13 +246,22 @@ export const FormSettingsPanel = ({viewSetId}: FormSettingsPanelProps) => {
             <Select
               fullWidth
               value={viewSet.layout || 'tabs'}
-              onChange={handleLayoutChange}
+              onChange={event =>
+                dispatch({
+                  type: 'ui-specification/viewSetLayoutUpdated',
+                  payload: {
+                    viewSetId,
+                    layout: event.target.value as 'inline' | 'tabs' | undefined,
+                  },
+                })
+              }
             >
               <MenuItem value="tabs">Tabs</MenuItem>
               <MenuItem value="inline">Inline</MenuItem>
             </Select>
           </SettingSection>
 
+          {/* Summary fields section */}
           <SettingSection
             title="Summary Fields"
             description="Select the field(s) you would like to display in the record list table."
@@ -233,6 +284,7 @@ export const FormSettingsPanel = ({viewSetId}: FormSettingsPanelProps) => {
             />
           </SettingSection>
 
+          {/* HRID  */}
           <SettingSection
             title="Human-Readable ID Field"
             description="A HRID is a human readable label for the record, which will be displayed in the record table. Select a required string field to use as the human-readable ID. You can use a TemplatedStringField to construct complex HRIDs."

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -100,9 +100,9 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
    */
   const handlePublishButtonBehaviourChange = (event: any) => {
     const newValue = event.target.value;
-    console.log('Dropdown changed to:', newValue); // Debugging log
+    console.log('Dropdown changed to:', newValue);
 
-    setSelectedPublishBehaviour(newValue); // ✅ Update local state
+    setSelectedPublishBehaviour(newValue);
 
     dispatch({
       type: 'ui-specification/viewSetPublishButtonBehaviourUpdated',

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -100,7 +100,6 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
    */
   const handlePublishButtonBehaviourChange = (event: any) => {
     const newValue = event.target.value;
-    console.log('Dropdown changed to:', newValue);
 
     setSelectedPublishBehaviour(newValue);
 

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -158,19 +158,6 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
     .filter((x): x is {label: string; value: string} => x !== null);
 
   /**
-   * Updates the form layout setting
-   */
-  const handleLayoutChange = (event: any) => {
-    dispatch({
-      type: 'ui-specification/viewSetLayoutUpdated',
-      payload: {
-        viewSetId,
-        layout: event.target.value as 'inline' | 'tabs' | undefined,
-      },
-    });
-  };
-
-  /**
    * Updates the selected summary fields
    */
   const handleSummaryFieldsChange = (

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -204,11 +204,6 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
     ? hridFieldOptions.find(opt => opt.value === viewSet.hridField) || null
     : null;
 
-  console.log(
-    'rrrrrrrrrrrrrrrrDropdown Value:',
-    viewSet.publishButtonBehaviour
-  );
-
   return (
     <Card sx={{width: '100%', mt: 2}}>
       <CardContent

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -99,10 +99,10 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
    */
   const handlePublishButtonBehaviourChange = (event: any) => {
     const newValue = event.target.value;
-    setSelectedPublishBehaviour(newValue); // ✅ Update local state
+    setSelectedPublishBehaviour(newValue);
 
     dispatch({
-      type: 'ui-specification/viewSetPublishButtonBehaviourUpdated', // ✅ FIXED DISPATCH
+      type: 'ui-specification/viewSetPublishButtonBehaviourUpdated',
       payload: {
         viewSetId,
         publishButtonBehaviour: newValue as 'always' | 'visited' | 'noErrors',

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -71,29 +71,44 @@ const SettingSection = ({
 
 export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
   const dispatch = useAppDispatch();
+
   const fields = useAppSelector(
     state => state.notebook['ui-specification'].fields
   );
-  const viewSet: ViewSetType = useAppSelector(
-    state => state.notebook['ui-specification'].viewsets[viewSetId]
+  const viewSet: ViewSetType | undefined = useAppSelector(
+    state =>
+      state.notebook?.['ui-specification']?.viewsets?.[viewSetId] || undefined
   );
   const fviews = useAppSelector(
     state => state.notebook['ui-specification'].fviews
   );
   const [expanded, setExpanded] = React.useState(false);
 
+  const publishButtonBehaviour = viewSet?.publishButtonBehaviour || 'always';
+
+  const [selectedPublishBehaviour, setSelectedPublishBehaviour] =
+    React.useState('always');
+
+  React.useEffect(() => {
+    if (viewSet?.publishButtonBehaviour) {
+      setSelectedPublishBehaviour(viewSet.publishButtonBehaviour);
+    }
+  }, [viewSet?.publishButtonBehaviour]);
+
   /**
    * Updates the Publish Button Behavior setting
    */
   const handlePublishButtonBehaviourChange = (event: any) => {
+    const newValue = event.target.value;
+    console.log('Dropdown changed to:', newValue); // Debugging log
+
+    setSelectedPublishBehaviour(newValue); // ✅ Update local state
+
     dispatch({
       type: 'ui-specification/viewSetPublishButtonBehaviourUpdated',
       payload: {
         viewSetId,
-        publishButtonBehaviour: event.target.value as
-          | 'always'
-          | 'visited'
-          | 'noErrors',
+        publishButtonBehaviour: newValue as 'always' | 'visited' | 'noErrors',
       },
     });
   };
@@ -189,6 +204,11 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
     ? hridFieldOptions.find(opt => opt.value === viewSet.hridField) || null
     : null;
 
+  console.log(
+    'rrrrrrrrrrrrrrrrDropdown Value:',
+    viewSet.publishButtonBehaviour
+  );
+
   return (
     <Card sx={{width: '100%', mt: 2}}>
       <CardContent
@@ -225,7 +245,7 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
           >
             <Select
               fullWidth
-              value={viewSet.publishButtonBehaviour || 'always'}
+              value={selectedPublishBehaviour}
               onChange={handlePublishButtonBehaviourChange}
             >
               <MenuItem value="always">Always Show</MenuItem>

--- a/designer/src/components/form-settings.tsx
+++ b/designer/src/components/form-settings.tsx
@@ -84,11 +84,10 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
   );
   const [expanded, setExpanded] = React.useState(false);
 
-  const publishButtonBehaviour = viewSet?.publishButtonBehaviour || 'always';
-
   const [selectedPublishBehaviour, setSelectedPublishBehaviour] =
     React.useState('always');
 
+  // Ensure selected value persists and is updated in the Redux store
   React.useEffect(() => {
     if (viewSet?.publishButtonBehaviour) {
       setSelectedPublishBehaviour(viewSet.publishButtonBehaviour);
@@ -96,15 +95,14 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
   }, [viewSet?.publishButtonBehaviour]);
 
   /**
-   * Updates the Publish Button Behavior setting
+   * Updates the Publish Button Behavior setting in Redux and persists it
    */
   const handlePublishButtonBehaviourChange = (event: any) => {
     const newValue = event.target.value;
-
-    setSelectedPublishBehaviour(newValue);
+    setSelectedPublishBehaviour(newValue); // ✅ Update local state
 
     dispatch({
-      type: 'ui-specification/viewSetPublishButtonBehaviourUpdated',
+      type: 'ui-specification/viewSetPublishButtonBehaviourUpdated', // ✅ FIXED DISPATCH
       payload: {
         viewSetId,
         publishButtonBehaviour: newValue as 'always' | 'visited' | 'noErrors',

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -115,6 +115,7 @@ export type NotebookUISpec = {
       summary_fields?: string[];
       layout?: 'inline' | 'tabs';
       hridField?: string;
+      publishButtonBehaviour: 'always'; // setting default as always.
     };
   };
   visible_types: string[];

--- a/designer/src/state/initial.ts
+++ b/designer/src/state/initial.ts
@@ -115,7 +115,7 @@ export type NotebookUISpec = {
       summary_fields?: string[];
       layout?: 'inline' | 'tabs';
       hridField?: string;
-      publishButtonBehaviour: 'always'; // setting default as always.
+      publishButtonBehaviour: 'always' | 'visited' | 'noErrors';
     };
   };
   visible_types: string[];

--- a/designer/src/state/uiSpec-reducer.ts
+++ b/designer/src/state/uiSpec-reducer.ts
@@ -282,7 +282,8 @@ export const uiSpecificationReducer = createSlice({
       state.fields[fieldLabel] = newField;
 
       // add the new field to the view right after the original field
-      const position = state.fviews[viewId].fields.indexOf(originalFieldName) + 1;
+      const position =
+        state.fviews[viewId].fields.indexOf(originalFieldName) + 1;
       state.fviews[viewId].fields.splice(position, 0, fieldLabel);
     },
     sectionRenamed: (
@@ -402,6 +403,7 @@ export const uiSpecificationReducer = createSlice({
       const newViewSet = {
         label: formName,
         views: [],
+        publishButtonBehaviour: 'always' as 'always' | 'visited' | 'noErrors',
       };
       const formID = slugify(formName);
       // add this to the viewsets
@@ -412,6 +414,7 @@ export const uiSpecificationReducer = createSlice({
         state.visible_types.push(formID);
       }
     },
+
     viewSetDeleted: (state, action: PayloadAction<{viewSetId: string}>) => {
       const {viewSetId} = action.payload;
 
@@ -529,6 +532,20 @@ export const uiSpecificationReducer = createSlice({
         state.visible_types.splice(state.visible_types.length, 0, viewSetId);
       }
     },
+
+    viewSetPublishButtonBehaviourUpdated: (
+      state,
+      action: PayloadAction<{
+        viewSetId: string;
+        publishButtonBehaviour: 'always' | 'visited' | 'noErrors';
+      }>
+    ) => {
+      const {viewSetId, publishButtonBehaviour} = action.payload;
+      if (viewSetId in state.viewsets) {
+        state.viewsets[viewSetId].publishButtonBehaviour =
+          publishButtonBehaviour;
+      }
+    },
   },
 });
 
@@ -552,6 +569,7 @@ export const {
   viewSetMoved,
   viewSetRenamed,
   formVisibilityUpdated,
+  viewSetPublishButtonBehaviourUpdated,
   viewSetLayoutUpdated,
   viewSetSummaryFieldsUpdated,
 } = uiSpecificationReducer.actions;


### PR DESCRIPTION
## JIRA Ticket

[BSS-785
](https://jira.csiro.au/browse/BSS-785)

## Description

Introduced the publishbuttonbehaviour configuration setting in "form settings" (Desginer), which will allow users to configure when the publish button should be visible based on the three scenarios. The selected setting is stored in redux and correctly exported to the downloaded JSON of the survey/notebook.

 Implemented Scenarios: 

-  Always Show ("always")
The Publish button is always visible, regardless of the form's state.
This is the default behavior for backward compatibility.

-  Show Once All Sections Visited ("visited")
The Publish button only appears when all form sections have been visited at least once.
A section is considered visited when the user navigates to it.

-  Show Only When No Errors Exist ("noErrors")
The Publish button is only displayed if there are no validation errors in any field.
If there are errors, the button remains hidden until all issues are resolved.

## How to Test
To test end-to-end, 
- Navigate to designer (http://localhost:5010/), upload the survey JSON to be able to edit it , export it and use it in the UI to create a survey/notebook in the conductor.
- Navigate to the DESIGN tab and click on Form Settings collapsible section
    - There's a dropdown for Publish Button Behavior, select any preferred value.
   
![image](https://github.com/user-attachments/assets/0e5684cc-389f-492f-955b-f25b3eaf0cff)


- Navigate to the EXPORT tab
    - Download the notebook 
    - In the downloaded notebook, there should be a setting based on the dropdown option selected 
    ```
  "viewsets": {
      "Damage-Assessment": {
        "label": "Once all sections visited",
        "views": [
          "Damage-Assessment-Assessor-and-site-details",
          "Damage-Assessment-Location-details",
          "Damage-Assessment-Damage-details",
          "Damage-Assessment-Houses",
          "Damage-Assessment-Hazards",
          "Damage-Assessment-Once-all-sections-visited"
        ],
        "publishButtonBehaviour": "visited"
      }
    },
```


```
```
    1. for always show, it should be 'always'
    2. for show once all sections visited, it should be 'visited'
    3. for show only when no errors, it should be 'noErrors'
```
          

- Now, navigate to conductor, and create a test notebook to be able to test the scenario
 - http://localhost:8080/notebooks, create a notebook here based on scenario (always,visited.noErrors)     
- Navigate to the APP http://localhost:3000/ and refresh it so it loads the new created survey/notebook in NOT ACTIVE tab
- Activate that notebook
- Test the scenarios in the UI.

For ease of testing,I am attaching here three different survey JSON for all three scenarios.

[Show-Publish-Always.json](https://github.com/user-attachments/files/19171532/Show-Publish-Always.json)
[Show-Publish-Only-if-All-errors-resolved.json](https://github.com/user-attachments/files/19171535/Show-Publish-Only-if-All-errors-resolved.json)
[Show-Publish-once-all-sections-visited (1).json](https://github.com/user-attachments/files/19171536/Show-Publish-once-all-sections-visited.1.json)


Let me know incase of any questions. Thanks.

## Checklist
- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
```

```
