### PR TITLE
Fix broken drafts route

### DIFF
--- a/app/src/constants/routes.tsx
+++ b/app/src/constants/routes.tsx
@@ -70,6 +70,7 @@ export function getRecordRoute(
 
 // this function is to get route for draft-- depend on edit draft or created draft??? TODO need to check created draft route
 export function getDraftRoute(
+  serverId: string,
   project_id: ProjectID,
   draft_id: string,
   existing: null | {record_id: RecordID; revision_id: RevisionID},
@@ -79,6 +80,8 @@ export function getDraftRoute(
   if (existing !== null)
     return (
       INDIVIDUAL_NOTEBOOK_ROUTE +
+      serverId +
+      '/' +
       project_id +
       RECORD_EXISTING +
       // existing+
@@ -91,6 +94,8 @@ export function getDraftRoute(
   else {
     return (
       INDIVIDUAL_NOTEBOOK_ROUTE +
+      serverId +
+      '/' +
       project_id +
       RECORD_CREATE +
       type_name +

--- a/app/src/gui/components/notebook/draft_table.tsx
+++ b/app/src/gui/components/notebook/draft_table.tsx
@@ -53,6 +53,7 @@ export function DraftsTable(props: DraftsRecordProps) {
   const handleRowClick: GridEventListener<'rowClick'> = params => {
     history(
       ROUTES.getDraftRoute(
+        serverId,
         project_id ?? 'dummy',
         params.row._id as DraftMetadata['_id'],
         params.row.existing! as DraftMetadata['existing'],


### PR DESCRIPTION

## JIRA Ticket

[BSS-830
](https://jira.csiro.au/browse/BSS-830)

## Description

This PR fixes an issue where clicking on a draft record in a notebook would lead to a 404 broken link instead of opening the draft.


## How to Test
-  Click on a Ativated survey Survey/Notebook that has drafts.
- If drafts already exist, click on a draft record. It should correctly navigate to the draft page instead of showing 404.
- If no drafts exist, create a new draft
- Click on the newly created draft.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
