### PR TITLE
fix: import template bug 🐞

### DIFF
--- a/api/src/couchdb/templates.ts
+++ b/api/src/couchdb/templates.ts
@@ -75,7 +75,7 @@ export const createTemplate = async (
   const templatesDb = getTemplatesDb();
 
   // Get a unique id for the template Id
-  const templateId = generateTemplateId(payload.template_name);
+  const templateId = generateTemplateId(payload.metadata.name);
 
   // inject templateId into the metadata
   // TODO see BSS-343

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -521,11 +521,6 @@ describe('template API tests', () => {
       });
   });
 
-  it('check name field is stripped of white space', async () => {
-    // Create a sample template
-    const {template} = await createSampleTemplate(app, {});
-  });
-
   // Auth checks
   // ===========
   it('list templates not authorised', async () => {

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -526,29 +526,6 @@ describe('template API tests', () => {
     const {template} = await createSampleTemplate(app, {});
   });
 
-  it('invalid input due to insufficient field length', async () => {
-    const fakeId = '1234';
-    await requestAuthAndType(
-      request(app)
-        .put(`${TEMPLATE_API_BASE}/${fakeId}`)
-        .send({
-          metadata: {},
-          // must be > 5 long
-          'ui-specification': {},
-        } as PutUpdateTemplateInput)
-    )
-      // Expect 400 bad request
-      .expect(400)
-      // And check the body has the error properties we want
-      .then(res => {
-        expect(res.body).to.be.an('array');
-        expect(res.body.length).to.equal(1);
-        const err = res.body[0];
-        expect(err).to.have.property('type');
-        expect(err.type).to.equal('Body');
-      });
-  });
-
   // Auth checks
   // ===========
   it('list templates not authorised', async () => {

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -88,7 +88,6 @@ const createSampleTemplate = async (
     request(app)
       .post(`${TEMPLATE_API_BASE}`)
       .send({
-        template_name: options.templateName ?? 'exampletemplate',
         ...nb,
         ...(options.payloadExtras ?? {}),
       } as PostCreateTemplateInput),
@@ -306,7 +305,6 @@ describe('template API tests', () => {
     // update some details and check properties
 
     // change the template name and add a metadata field
-    template.template_name = 'updated name';
     template.metadata.updated_field = 'updated-value';
 
     // update the existing template
@@ -319,7 +317,6 @@ describe('template API tests', () => {
       // Check the new properties
       expect(newTemplate.version).to.equal(2);
       expect(newTemplate.metadata.updated_field).to.equal('updated-value');
-      expect(newTemplate.template_name).to.equal('updated name');
     });
 
     // get the template and check the same
@@ -327,7 +324,6 @@ describe('template API tests', () => {
       // Check the new properties
       expect(newTemplate.version).to.equal(2);
       expect(newTemplate.metadata.updated_field).to.equal('updated-value');
-      expect(newTemplate.template_name).to.equal('updated name');
     });
   });
 
@@ -408,7 +404,6 @@ describe('template API tests', () => {
         .put(`${TEMPLATE_API_BASE}/${fakeId}`)
         .send({
           metadata: {},
-          template_name: 'faketemplate',
           'ui-specification': {},
         } as PutUpdateTemplateInput)
     )
@@ -433,7 +428,6 @@ describe('template API tests', () => {
         .put(`${TEMPLATE_API_BASE}/${fakeId}`)
         .send({
           metadata: {},
-          template_name: 'faketemplate',
           'ui-specification': {},
         } as PutUpdateTemplateInput)
     )
@@ -511,7 +505,6 @@ describe('template API tests', () => {
         .put(`${TEMPLATE_API_BASE}/${fakeId}`)
         .send({
           // missing! metadata: {},
-          template_name: 'faketemplate',
           'ui-specification': {},
         } as PutUpdateTemplateInput)
     )
@@ -530,10 +523,7 @@ describe('template API tests', () => {
 
   it('check name field is stripped of white space', async () => {
     // Create a sample template
-    const {template} = await createSampleTemplate(app, {
-      templateName: ' name with whitespace    ',
-    });
-    expect(template.template_name).to.equal('name with whitespace');
+    const {template} = await createSampleTemplate(app, {});
   });
 
   it('invalid input due to insufficient field length', async () => {
@@ -544,7 +534,6 @@ describe('template API tests', () => {
         .send({
           metadata: {},
           // must be > 5 long
-          template_name: '123',
           'ui-specification': {},
         } as PutUpdateTemplateInput)
     )
@@ -557,7 +546,6 @@ describe('template API tests', () => {
         const err = res.body[0];
         expect(err).to.have.property('type');
         expect(err.type).to.equal('Body');
-        expect(JSON.stringify(err.errors)).to.include('template_name');
       });
   });
 
@@ -578,7 +566,6 @@ describe('template API tests', () => {
       .put(`${TEMPLATE_API_BASE}/12345`)
       .send({
         metadata: {},
-        template_name: '12345',
         'ui-specification': {},
       } as PutUpdateTemplateInput)
       .set('Content-Type', 'application/json')
@@ -588,7 +575,6 @@ describe('template API tests', () => {
     return await request(app)
       .post(`${TEMPLATE_API_BASE}`)
       .send({
-        template_name: 'exampletemplate',
         metadata: {},
         'ui-specification': {},
       } as PostCreateTemplateInput)
@@ -617,7 +603,6 @@ describe('template API tests', () => {
       request(app)
         .post(`${TEMPLATE_API_BASE}`)
         .send({
-          template_name: 'exampletemplate',
           metadata: {},
           'ui-specification': {},
         } as PostCreateTemplateInput),
@@ -632,7 +617,6 @@ describe('template API tests', () => {
         .put(`${TEMPLATE_API_BASE}/12345`)
         .send({
           metadata: {},
-          template_name: '12345',
           'ui-specification': {},
         } as PutUpdateTemplateInput),
       localUserToken

--- a/app/ios/App/App/Info.plist
+++ b/app/ios/App/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>202503130039</string>
+	<string>202503190443</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/app/src/gui/components/notebook/NewNotebookForListing.tsx
+++ b/app/src/gui/components/notebook/NewNotebookForListing.tsx
@@ -256,7 +256,7 @@ const NewNotebookForListing: React.FC<NewNotebookForListingProps> = props => {
             {templates.data && templates.data.templates.length > 0 ? (
               templates.data.templates.map(template => (
                 <MenuItem key={template._id} value={template._id}>
-                  {template.template_name}
+                  {template.metadata.name}
                 </MenuItem>
               ))
             ) : (

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -79,7 +79,6 @@ import {
 } from './relationships/RelatedInformation';
 import UGCReport from './UGCReport';
 import {getUsefulFieldNameFromUiSpec, ViewComponent} from './view';
-import {c} from 'vitest/dist/reporters-5f784f42';
 
 type RecordFormProps = {
   navigate: NavigateFunction;
@@ -795,7 +794,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
     const allSections =
       this.props.ui_specification.viewsets[this.getViewsetName()].views;
 
-    const allVisited = allSections.every((section: string) =>
+    allSections.every((section: string) =>
       this.state.visitedSteps.has(section)
     );
   }

--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -799,11 +799,6 @@ export type NotebookAuthSummary = z.infer<typeof NotebookAuthSummarySchema>;
 
 // The editable properties for a template
 export const TemplateEditableDetailsSchema = z.object({
-  // What is the display name of the template?
-  template_name: z
-    .string()
-    .trim()
-    .min(5, 'Please provide a template name of at least 5 character length.'),
   // The UI specification for this template
   'ui-specification': UiSpecificationSchema,
   // The metadata from the designer - copied into new notebooks

--- a/web/src/components/forms/update-template-form.tsx
+++ b/web/src/components/forms/update-template-form.tsx
@@ -3,6 +3,7 @@ import {Form} from '@/components/form';
 import {readFileAsText} from '@/lib/utils';
 import {z} from 'zod';
 import {NOTEBOOK_NAME} from '@/constants';
+import {Route} from '@/routes/_protected/templates/$templateId';
 
 export const fields = [
   {
@@ -24,6 +25,7 @@ interface UpdateTemplateFormProps {
  */
 export function UpdateTemplateForm({setDialogOpen}: UpdateTemplateFormProps) {
   const {user} = useAuth();
+  const {templateId} = Route.useParams();
 
   const onSubmit = async ({file}: {file: File}) => {
     if (!user) return {type: 'submit', message: 'User not authenticated'};
@@ -32,12 +34,8 @@ export function UpdateTemplateForm({setDialogOpen}: UpdateTemplateFormProps) {
 
     if (!jsonString) return {type: 'submit', message: 'Error reading file'};
 
-    const {_id} = JSON.parse(jsonString);
-
-    if (!_id) return {type: 'submit', message: 'Error parsing file'};
-
     const response = await fetch(
-      `${import.meta.env.VITE_API_URL}/api/templates/${_id}`,
+      `${import.meta.env.VITE_API_URL}/api/templates/${templateId}`,
       {
         method: 'PUT',
         headers: {


### PR DESCRIPTION
## JIRA Ticket

[BSS-824](https://jira.csiro.au/browse/BSS-824)

## Description

Fixed bug where template upload was still expecting the `template_name` field (this had been removed in a previous PR).

## Proposed Changes

- updated current uses of `template_name` to use `metadata.name`
- updated template tests not to expect `template_name`
- updated frontend to handle the json without `template_name`

## How to Test

1. Review the backend changes (especially around how template names are defined)
2. In the `/web` platform navigate to a template
3. Test the update template flow in the actions tab

## Additional Information

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
