### PR TITLE
fix: template actions crash 💥

### DIFF
--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -79,7 +79,6 @@ import {
 } from './relationships/RelatedInformation';
 import UGCReport from './UGCReport';
 import {getUsefulFieldNameFromUiSpec, ViewComponent} from './view';
-import {c} from 'vitest/dist/reporters-5f784f42';
 
 type RecordFormProps = {
   navigate: NavigateFunction;
@@ -795,7 +794,7 @@ class RecordForm extends React.Component<any, RecordFormState> {
     const allSections =
       this.props.ui_specification.viewsets[this.getViewsetName()].views;
 
-    const allVisited = allSections.every((section: string) =>
+    allSections.every((section: string) =>
       this.state.visitedSteps.has(section)
     );
   }

--- a/web/src/components/dialogs/edit-template.tsx
+++ b/web/src/components/dialogs/edit-template.tsx
@@ -68,8 +68,8 @@ export const EditTemplateDialog = () => {
                   <a
                     href={`data:text/json;charset=utf-8,${encodeURIComponent(
                       JSON.stringify({
-                        metadata: data.metadata,
-                        'ui-specification': data['ui-specification'],
+                        metadata: data?.metadata,
+                        'ui-specification': data?.['ui-specification'],
                       })
                     )}`}
                     download={`${templateId}.json`}

--- a/web/src/components/dialogs/edit-template.tsx
+++ b/web/src/components/dialogs/edit-template.tsx
@@ -29,7 +29,7 @@ import {
 export const EditTemplateDialog = () => {
   const {user} = useAuth();
   const {templateId} = Route.useParams();
-  const {data} = useGetTemplates(user, templateId);
+  const {data, isLoading} = useGetTemplates(user, templateId);
   const [open, setOpen] = useState(false);
 
   return (
@@ -64,7 +64,7 @@ export const EditTemplateDialog = () => {
                 <ListDescription>
                   1. Download the template file.
                 </ListDescription>
-                <Button variant="outline">
+                <Button variant="outline" disabled={isLoading}>
                   <a
                     href={`data:text/json;charset=utf-8,${encodeURIComponent(
                       JSON.stringify({

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -19,7 +19,7 @@ import {Route} from '@/routes/_protected/templates/$templateId';
 const TemplateActions = () => {
   const {user} = useAuth();
   const {templateId} = Route.useParams();
-  const {data} = useGetTemplates(user, templateId);
+  const {data, isLoading} = useGetTemplates(user, templateId);
   const archived = data?.metadata.project_status === 'archived';
 
   return (
@@ -33,7 +33,7 @@ const TemplateActions = () => {
             </ListDescription>
           </ListItem>
           <ListItem>
-            <Button variant="outline">
+            <Button variant="outline" disabled={isLoading}>
               <a
                 href={`data:text/json;charset=utf-8,${encodeURIComponent(
                   JSON.stringify({

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -37,8 +37,8 @@ const TemplateActions = () => {
               <a
                 href={`data:text/json;charset=utf-8,${encodeURIComponent(
                   JSON.stringify({
-                    metadata: data.metadata,
-                    'ui-specification': data['ui-specification'],
+                    metadata: data?.metadata,
+                    'ui-specification': data?.['ui-specification'],
                   })
                 )}`}
                 download={`${templateId}.json`}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -58,7 +58,7 @@
     --muted-foreground: 0 0% 63.9%;
     --accent: 0 0% 14.9%;
     --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;


### PR DESCRIPTION
## JIRA Ticket

[BSS-840](https://jira.csiro.au/browse/BSS-840)

## Description

Fixed a bug where the page would crash when switching between templates with the action tab open.

## Proposed Changes

- added optional chaining to the prop calls from the data query to avoid error throwing when null
- added disabled prop to button when data has not loaded

## How to Test

1. Navigate to a template
2. Open the actions tab
3. Switch between templates using the sidebar with the actions tab open

## Additional Information

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
