### PR TITLE
records count fix for visible types

### DIFF
--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -23,6 +23,7 @@ import {MetadataDisplayComponent} from './MetadataDisplay';
 import {OverviewMap} from './overview_map';
 import {RecordsTable} from './record_table';
 import NotebookSettings from './settings';
+import {getVisibleTypes} from '../../../uiSpecification';
 
 // Define how tabs appear in the query string arguments, providing a two way map
 type TabIndexLabel =
@@ -204,6 +205,14 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
         uiSpecification.visible_types[0]
       : 'Record';
 
+  const visibleTypes = getVisibleTypes(uiSpecification);
+  const visibleMyRecords = records.myRecords.filter(r =>
+    visibleTypes.includes(r.type)
+  );
+  const visibleOtherRecords = records.otherRecords.filter(r =>
+    visibleTypes.includes(r.type)
+  );
+
   return (
     <Box>
       <Box>
@@ -276,7 +285,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
               allowScrollButtonsMobile={true}
             >
               <Tab
-                label={`My ${recordLabel}s (${records.myRecords.length})`}
+                label={`My ${recordLabel}s (${visibleMyRecords.length})`}
                 value={0}
                 {...a11yProps(0, `${NOTEBOOK_NAME}-myrecords`)}
               />
@@ -288,10 +297,10 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
                 />
               )}
 
-              {(tabIndex === 2 || records.otherRecords.length > 0) && (
+              {(tabIndex === 2 || visibleOtherRecords.length > 0) && (
                 <Tab
                   value={2}
-                  label={`Other ${recordLabel}s (${records.otherRecords.length})`}
+                  label={`Other ${recordLabel}s (${visibleOtherRecords.length})`}
                   {...a11yProps(2, `${NOTEBOOK_NAME}-otherrecords`)}
                 />
               )}


### PR DESCRIPTION
JIRA Ticket
[BSS-752](https://jira.csiro.au/browse/BSS-752)

Description
PR fixes a bug where the "My Records" and "Other Records" tab counts included records from invisible form types (i.e., typesx not listed in uiSpecification.visible_types

How to Test
Go to the Notebook View.

Check the counts in the “My Records” and “Other Records” tabs.

Make sure: - Only records with type in visible_types are counted.

Hidden types (not in visible_types) do not appear in tab counts.

image

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
