### PR TITLE
Remove designer oldtextfield

### DIFF
--- a/app/src/gui/component_registry/bundle_components.ts
+++ b/app/src/gui/component_registry/bundle_components.ts
@@ -76,7 +76,6 @@ registerField(
   Checkbox
 );
 
-
 registerField(
   'formik-material-ui',
   'TextField',
@@ -239,6 +238,15 @@ registerField(
   'Multiple line Input Box',
   'Text',
   FormikTextField
+);
+
+registerField(
+  'core-material-ui',
+  'TextField',
+  'HTML text field',
+  'A simple text field',
+  'Simple',
+  TextField
 );
 
 registerField(

--- a/app/src/gui/component_registry/bundle_components.ts
+++ b/app/src/gui/component_registry/bundle_components.ts
@@ -76,14 +76,6 @@ registerField(
   Checkbox
 );
 
-registerField(
-  'core-material-ui',
-  'TextField',
-  'HTML text field',
-  'A simple text field',
-  'Simple',
-  TextField
-);
 
 registerField(
   'formik-material-ui',

--- a/designer/src/components/field-list.tsx
+++ b/designer/src/components/field-list.tsx
@@ -258,13 +258,13 @@ export const FieldList = ({viewSetId, viewId, moveFieldCallback}: Props) => {
               });
             }}
           >
-            {allFieldNames
-              .filter(fieldName => fieldName !== 'TextField')
-              .map(fieldName => (
+            {allFieldNames.map((fieldName: string) => {
+              return (
                 <MenuItem key={fieldName} value={fieldName}>
                   {fieldName}
                 </MenuItem>
-              ))}
+              );
+            })}
           </Select>
         </DialogContent>
         <DialogActions>

--- a/designer/src/components/field-list.tsx
+++ b/designer/src/components/field-list.tsx
@@ -258,13 +258,13 @@ export const FieldList = ({viewSetId, viewId, moveFieldCallback}: Props) => {
               });
             }}
           >
-            {allFieldNames.map((fieldName: string) => {
-              return (
+            {allFieldNames
+              .filter(fieldName => fieldName !== 'TextField')
+              .map(fieldName => (
                 <MenuItem key={fieldName} value={fieldName}>
                   {fieldName}
                 </MenuItem>
-              );
-            })}
+              ))}
           </Select>
         </DialogContent>
         <DialogActions>

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -15,19 +15,16 @@
 import {FieldType} from './state/initial';
 
 const fields: {[key: string]: FieldType} = {
-  TextField: {
-    'component-namespace': 'formik-material-ui',
-    'component-name': 'TextField',
+  FAIMSTextField: {
+    'component-namespace': 'faims-custom',
+    'component-name': 'FAIMSTextField',
     'type-returned': 'faims-core::String',
     'component-parameters': {
-      label: 'Text Field',
+      label: 'FAIMS Text Field',
       fullWidth: true,
       helperText: 'Enter text',
       variant: 'outlined',
       required: false,
-      InputProps: {
-        type: 'text',
-      },
     },
     validationSchema: [['yup.string']],
     initialValue: '',
@@ -437,20 +434,6 @@ const fields: {[key: string]: FieldType} = {
       label: 'Address',
     },
     validationSchema: [['yup.object'], ['yup.nullable']],
-  },
-  FAIMSTextField: {
-    'component-namespace': 'faims-custom',
-    'component-name': 'FAIMSTextField',
-    'type-returned': 'faims-core::String',
-    'component-parameters': {
-      label: 'FAIMS Text Field',
-      fullWidth: true,
-      helperText: 'Enter text',
-      variant: 'outlined',
-      required: false,
-    },
-    validationSchema: [['yup.string']],
-    initialValue: '',
   },
 
   NumberField: {


### PR DESCRIPTION

## JIRA Ticket

[BSS-827
](https://jira.csiro.au/browse/BSS-827)

## Description

-  Removed the old TextField field type from the field type selection list.
- Ensured onew text field FAIMSTextField are shown in the UI for new field creation.
- Cleaned up conditional logic in view.tsx that handled special rendering for TextField.
- Confirmed that TextField is no longer included in getFieldNames() and the component registry 

## How to Test
- Navigate to designer locally
   - cd designer
   - npm run start
   - http://localhost:5010
- Upload any notebook/survey JSON 
- Navigate to "DESIGN" tab
- Click on "add field button" and from the "Create a new field.. " popup, verify that TextField doesn't exist anymore in that field list.
- New FAIMSTextField is displayed at the top of list (as this is frequently used field in designer)

Screenshots for Reference:
BEFORE :
![image](https://github.com/user-attachments/assets/c77e0ca4-0465-4de7-8fd6-a09291f7a1c4)

AFTER:
![image](https://github.com/user-attachments/assets/73e80a73-97b1-4e80-a403-2f4e0493b28d)



## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
