### PR TITLE
fix: allow field labels to be empty

### DIFF
--- a/designer/src/components/Fields/BaseFieldEditor.tsx
+++ b/designer/src/components/Fields/BaseFieldEditor.tsx
@@ -57,7 +57,7 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
   // the field label is stored in the notebook
   const getFieldLabel = () => {
     return (
-      field['component-parameters']?.label || field['component-parameters'].name
+      field['component-parameters']?.label ?? field['component-parameters'].name
     );
   };
 
@@ -89,7 +89,11 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
 
   const updateFieldFromState = (newState: StateType) => {
     const newField = JSON.parse(JSON.stringify(field)) as FieldType; // deep copy
-    if (newState.label) setFieldLabel(newField, newState.label);
+
+    if (newState.label !== undefined) {
+      setFieldLabel(newField, newState.label);
+    }
+
     newField['component-parameters'].helperText = newState.helperText;
     newField['component-parameters'].required = newState.required;
     if (newField.meta) {


### PR DESCRIPTION
# fix: allow field labels to be empty

## JIRA Ticket

[BSS-868](https://jira.csiro.au/browse/BSS-868)

## Description

This PR fixes a bug in the BaseFieldEditor where the user could not fully delete or replace the field label. Attempting to delete all characters in the field label input would keep the final character.

## Proposed Changes

- Updated `getFieldLabel` to use `??` instead of `||` operator to allow empty labels.
- Removed the conditional check `if (newState.label)` in `updateFieldFromState` to make sure empty labels are still applied.

## How to Test

1. Create a new field in the editor.
2. In the _Label_ field:
   - Type a value (e.g., "Test Field").
   - Try deleting the text one character at a time — it should now allow full deletion.
   - You should also be able to press Ctrl+A/Cmd+A and delete the whole label or type a completely new one.
3. Confirm that the label updates correctly in all cases and doesn't revert unexpectedly.

## Additional Information

This bug was affecting user experience by preventing intuitive text editing. The fix improves field editing behavior across all use cases.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.