### PR TITLE
feat: enable CDK google oauth configuration

### DIFF
--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -59,6 +59,13 @@ export interface SMTPGeneralConfig {
   cacheExpirySeconds?: number;
 }
 
+export interface SocialProvidersConfig {
+  google?: {
+    // must contain CLIENT_ID and CLIENT_SECRET
+    secretArn: string;
+  };
+}
+
 /**
  * Properties for the FaimsConductor construct
  */
@@ -97,6 +104,8 @@ export interface FaimsConductorProps {
   smtpCredsArn: string;
   /** SMTP general configuration */
   smtpConfig: SMTPGeneralConfig;
+  /** Social providers info (if enabled) */
+  socialProviders?: SocialProvidersConfig;
 }
 
 /**
@@ -159,6 +168,33 @@ export class FaimsConductor extends Construct {
       props.smtpCredsArn
     );
 
+    const socialProviderList: string[] = [];
+    if (props.socialProviders?.google) {
+      socialProviderList.push('google');
+    }
+    const renderedProviderList = socialProviderList.join(';');
+
+    const googleSecretArn = props.socialProviders?.google?.secretArn;
+    const googleSecret = googleSecretArn
+      ? sm.Secret.fromSecretCompleteArn(
+          this,
+          'GoogleOAuthSecret',
+          googleSecretArn
+        )
+      : undefined;
+    const googleConfigSecrets = googleSecret
+      ? {
+          GOOGLE_CLIENT_ID: ecs.Secret.fromSecretsManager(
+            googleSecret,
+            'CLIENT_ID'
+          ),
+          GOOGLE_CLIENT_SECRET: ecs.Secret.fromSecretsManager(
+            googleSecret,
+            'CLIENT_SECRET'
+          ),
+        }
+      : undefined;
+
     conductorTaskDfn.addContainer('conductor-container-dfn', {
       image: conductorContainerImage,
       portMappings: [
@@ -193,6 +229,13 @@ export class FaimsConductor extends Construct {
         EMAIL_REPLY_TO: props.smtpConfig.replyTo || props.smtpConfig.fromEmail,
         TEST_EMAIL_ADDRESS: props.smtpConfig.testEmailAddress,
         SMTP_CACHE_EXPIRY_SECONDS: `${props.smtpConfig.cacheExpirySeconds || DEFAULT_SMTP_CACHE_EXPIRY}`,
+
+        // social providers (if at least one configured)
+        ...(socialProviderList.length > 0
+          ? {
+              CONDUCTOR_AUTH_PROVIDERS: renderedProviderList,
+            }
+          : {}),
       },
       secrets: {
         COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(
@@ -211,6 +254,9 @@ export class FaimsConductor extends Construct {
         SMTP_SECURE: ecs.Secret.fromSecretsManager(smtpSecret, 'secure'),
         SMTP_USER: ecs.Secret.fromSecretsManager(smtpSecret, 'user'),
         SMTP_PASSWORD: ecs.Secret.fromSecretsManager(smtpSecret, 'pass'),
+
+        // Include google config if provided
+        ...(googleConfigSecrets ?? {}),
       },
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'faims-conductor',

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -12,6 +12,14 @@ import {z} from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
 
+const SocialProvidersConfigSchema = z.object({
+  google: z
+    .object({
+      secretArn: z.string(),
+    })
+    .optional(),
+});
+
 const SMTPConfigSchema = z.object({
   /** Email service type (SMTP or MOCK) */
   emailServiceType: z.enum(['SMTP']),
@@ -260,6 +268,8 @@ export const ConfigSchema = z.object({
   web: WebConfigSchema,
   /** Email service configuration */
   smtp: SMTPConfigSchema,
+  /** Social sign in providers */
+  socialProviders: SocialProvidersConfigSchema,
 });
 
 // Infer the types from the schemas
@@ -424,6 +434,7 @@ export class FaimsInfraStack extends cdk.Stack {
         testEmailAddress: config.smtp.testEmailAddress,
         cacheExpirySeconds: config.smtp.cacheExpirySeconds,
       },
+      socialProviders: config.socialProviders,
     });
 
     // FRONT-END

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -269,7 +269,7 @@ export const ConfigSchema = z.object({
   /** Email service configuration */
   smtp: SMTPConfigSchema,
   /** Social sign in providers */
-  socialProviders: SocialProvidersConfigSchema,
+  socialProviders: SocialProvidersConfigSchema.optional(),
 });
 
 // Infer the types from the schemas


### PR DESCRIPTION
Self explanatory - adds config variables from AWS Secret. CLIENT_ID and CLIENT_SECRET required JSON fields of the secret. 