### PR TITLE
fix: making db lookup resilient to projects DB migration edge case

### DIFF
--- a/api/src/couchdb/index.ts
+++ b/api/src/couchdb/index.ts
@@ -43,13 +43,13 @@ import {
   MigrationsDB,
   PeopleDB,
   PeopleDBFields,
+  PossibleConnectionInfo,
   ProjectDataObject,
+  ProjectDocument,
   ProjectID,
   ProjectMetaObject,
-  ProjectDocument,
   TeamsDB,
   TemplateDB,
-  PossibleConnectionInfo,
 } from '@faims3/data-model';
 import {initialiseJWTKey} from '../auth/keySigning/initJWTKeys';
 import {
@@ -62,7 +62,6 @@ import {
 import * as Exceptions from '../exceptions';
 import {getAllProjectsDirectory} from './notebooks';
 import {registerAdminUser} from './users';
-import {DocDB} from 'aws-sdk';
 
 const DIRECTORY_DB_NAME = 'directory';
 const PROJECTS_DB_NAME = 'projects';

--- a/api/src/couchdb/index.ts
+++ b/api/src/couchdb/index.ts
@@ -49,6 +49,7 @@ import {
   ProjectDocument,
   TeamsDB,
   TemplateDB,
+  PossibleConnectionInfo,
 } from '@faims3/data-model';
 import {initialiseJWTKey} from '../auth/keySigning/initJWTKeys';
 import {
@@ -61,6 +62,7 @@ import {
 import * as Exceptions from '../exceptions';
 import {getAllProjectsDirectory} from './notebooks';
 import {registerAdminUser} from './users';
+import {DocDB} from 'aws-sdk';
 
 const DIRECTORY_DB_NAME = 'directory';
 const PROJECTS_DB_NAME = 'projects';
@@ -308,15 +310,22 @@ export const getMetadataDb = async (
     );
   }
 
-  // Now get the metadata DB from the project document
-  if (!projectDoc.metadataDb) {
-    throw new Exceptions.InternalSystemError(
-      "The given project document does not contain a mandatory reference to it's metadata database. Unsure how to fetch metadata DB. Aborting."
-    );
+  // Now get the metadata DB from the project document (and be backwards
+  // compatible)
+  let db: PossibleConnectionInfo;
+  db = projectDoc.metadataDb;
+  if (!db) {
+    const doc = projectDoc as any;
+    db = doc.metadata_db;
+    if (!db) {
+      throw new Exceptions.InternalSystemError(
+        "The given project document does not contain a mandatory reference to it's metadata database. Unsure how to fetch metadata DB. Aborting."
+      );
+    }
   }
 
   // Build the pouch connection for this DB
-  const dbUrl = COUCHDB_INTERNAL_URL + '/' + projectDoc.metadataDb.db_name;
+  const dbUrl = COUCHDB_INTERNAL_URL + '/' + db.db_name;
   const pouch_options = pouchOptions();
 
   // Authorise against this DB
@@ -346,23 +355,28 @@ export const getDataDb = async (
 
   // Get the project doc for the given ID
   const projectDoc = await projectsDB.get(projectID);
-
-  // 404 if project doc not found
   if (!projectDoc) {
     throw new Exceptions.ItemNotFoundException(
       'Cannot find the given project ID in the projects database.'
     );
   }
 
-  // Now get the data DB for this project
-  if (!projectDoc.dataDb) {
-    throw new Exceptions.InternalSystemError(
-      "The given project document does not contain a mandatory reference to it's data database. Unsure how to fetch data DB. Aborting."
-    );
+  // Now get the metadata DB from the project document (and be backwards
+  // compatible)
+  let db: PossibleConnectionInfo;
+  db = projectDoc.dataDb;
+  if (!db) {
+    const doc = projectDoc as any;
+    db = doc.data_db;
+    if (!db) {
+      throw new Exceptions.InternalSystemError(
+        "The given project document does not contain a mandatory reference to it's data database. Unsure how to fetch data DB. Aborting."
+      );
+    }
   }
 
   // Build the pouch connection for this DB
-  const dbUrl = COUCHDB_INTERNAL_URL + '/' + projectDoc.dataDb.db_name;
+  const dbUrl = COUCHDB_INTERNAL_URL + '/' + db.db_name;
   const pouch_options = pouchOptions();
   // Authorize against this DB
   if (LOCAL_COUCHDB_AUTH !== undefined) {


### PR DESCRIPTION
# fix: making db lookup resilient to projects DB migration edge case

When we migrated project db records this changed the name of metadata/data_db to metadata/dataDb. the getMetadata/getDataDb methods are run necessarily **before** migration making them extra sensitive to migration changes. This throws an error (which is good, it's better we error than partially migrate). This PR makes these methods backwards compatible. We will need to identify the 'pre-migration' set of functions that run, and isolate them into a special place in the code so that we can have a check that those methods remain backwards compatible through all future migrations.