### PR TITLE
fix: incorrect API configuration causing /auth-return relative redirect

### DIFF
--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -76,6 +76,7 @@ export class FaimsFrontEnd extends Construct {
 
   // derived property
   designerUrl: string;
+  faimsAppUrl: string;
 
   constructor(scope: Construct, id: string, props: FaimsFrontEndProps) {
     super(scope, id);
@@ -85,6 +86,7 @@ export class FaimsFrontEnd extends Construct {
 
     // use the first domain name to form canonical URL
     this.designerUrl = `https://${props.designerDomainNames[0]}`;
+    this.faimsAppUrl = `https://${props.faimsDomainNames[0]}`;
 
     // Main Faims frontend
     this.deployFaims(props);
@@ -320,6 +322,8 @@ export class FaimsFrontEnd extends Construct {
     const environment: {[key: string]: string} = {
       VITE_WEB_URL: `https://${props.webDomainName}`,
       VITE_API_URL: props.conductorUrl,
+      // FAIMS /app URL (uses first domain if multiple provided)
+      VITE_APP_URL: this.faimsAppUrl,
       VITE_DESIGNER_URL: this.designerUrl,
       VITE_NOTEBOOK_NAME: props.notebookName,
     };

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -16,7 +16,7 @@ if (API_URL === '') {
 
 export const APP_URL =
   (import.meta.env.VITE_APP_URL as string | undefined) ?? '';
-if (API_URL === '') {
+if (APP_URL === '') {
   throw new Error('Missing required env variable VITE_APP_URL');
 }
 


### PR DESCRIPTION
# fix: incorrect API configuration causing /auth-return relative redirect

VITE_APP_URL was added, but there were two issues

1. typo to check API_URL instead of APP_URL in the buildconfig
2. cdk code doesn't include this