### PR TITLE
Major Bug : Fix damage rating helpertext.

### DIFF
--- a/app/src/gui/components/map/center-control.tsx
+++ b/app/src/gui/components/map/center-control.tsx
@@ -1,8 +1,7 @@
-import {Control} from 'ol/control';
-import {Coordinate} from 'ol/coordinate';
 import {View} from 'ol';
-import {CreateDomIcon} from './dom-icon';
+import {Control} from 'ol/control';
 import src from '../../../target.svg';
+import {CreateDomIcon} from './dom-icon';
 
 /**
  * Creates a custom control button that centers the map view to a specified coordinate.

--- a/app/src/gui/fields/RichText.tsx
+++ b/app/src/gui/fields/RichText.tsx
@@ -28,6 +28,11 @@ interface Props {
 }
 
 export const RichTextField: React.FC<Props> = ({content}) => {
+  if (!content?.trim()) {
+    // Return nothing if content is empty or whitespace
+    return null;
+  }
+
   return (
     <div dangerouslySetInnerHTML={{__html: contentToSanitizedHtml(content)}} />
   );

--- a/app/src/gui/fields/checkbox.tsx
+++ b/app/src/gui/fields/checkbox.tsx
@@ -18,17 +18,16 @@
  *   TODO
  */
 
-import React from 'react';
-import MuiCheckbox from '@mui/material/Checkbox';
-import FormControl from '@mui/material/FormControl';
 import {
   FormControlLabel,
+  FormControlLabelProps,
   FormHelperText,
   FormHelperTextProps,
-  FormControlLabelProps,
-  Box,
 } from '@mui/material';
-import {fieldToCheckbox, CheckboxProps} from 'formik-mui';
+import MuiCheckbox from '@mui/material/Checkbox';
+import FormControl from '@mui/material/FormControl';
+import {CheckboxProps, fieldToCheckbox} from 'formik-mui';
+import React from 'react';
 import FieldWrapper from './fieldWrapper';
 
 interface Props {
@@ -44,7 +43,6 @@ export class Checkbox extends React.Component<CheckboxProps & Props> {
   render() {
     const {
       FormControlLabelProps,
-      FormHelperTextProps,
       helperText,
       advancedHelperText,
       required,
@@ -55,8 +53,6 @@ export class Checkbox extends React.Component<CheckboxProps & Props> {
     // just the plain label and helperText properties
     const label =
       this.props.label || FormControlLabelProps?.label || this.props.field.name;
-
-    const theHelperText = helperText || FormHelperTextProps?.children || '';
 
     let error = false;
     if (

--- a/app/src/gui/fields/fieldWrapper.tsx
+++ b/app/src/gui/fields/fieldWrapper.tsx
@@ -63,7 +63,9 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
   advancedHelperText,
 }) => {
   const [openDialog, setOpenDialog] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  // TODO understand why we have this but never set it other than null? Should
+  // this be a ref instead?
+  const [anchorEl] = useState<null | HTMLElement>(null);
   const muiTheme = useTheme();
   const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
   const open = Boolean(anchorEl);

--- a/app/src/gui/fields/maps/MapWrapper.tsx
+++ b/app/src/gui/fields/maps/MapWrapper.tsx
@@ -17,34 +17,37 @@
  * Description:
  *   Internals of map generation for MapFormField
  */
+
 import CloseIcon from '@mui/icons-material/Close';
 import EditIcon from '@mui/icons-material/Edit';
 import MapIcon from '@mui/icons-material/LocationOn';
+import {
+  Alert,
+  AlertTitle,
+  AppBar,
+  Box,
+  Dialog,
+  DialogActions,
+  Grid,
+  IconButton,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import Button, {ButtonProps} from '@mui/material/Button';
-import Map from 'ol/Map';
+import {Extent} from 'ol/extent';
 import GeoJSON from 'ol/format/GeoJSON';
 import {Draw, Modify} from 'ol/interaction';
 import VectorLayer from 'ol/layer/Vector';
+import Map from 'ol/Map';
 import {register} from 'ol/proj/proj4';
 import VectorSource from 'ol/source/Vector';
-import {Circle as CircleStyle, Fill, Icon, Stroke, Style} from 'ol/style';
+import {Icon, Style} from 'ol/style';
 import proj4 from 'proj4';
-import {useCallback, useEffect, useRef, useState} from 'react';
-import {transform} from 'ol/proj';
-// define some EPSG codes - these are for two sample images
-// TODO: we need to have a better way to include a useful set or allow
-// them to be defined by a project
-// e.g. https://www.npmjs.com/package/epsg-index
-// or maybe https://github.com/matafokka/geotiff-geokeys-to-proj4 allows us
-// to get things from the image?
-proj4.defs('EPSG:32636', '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs');
-proj4.defs(
-  'EPSG:28354',
-  '+proj=utm +zone=54 +south +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-);
-register(proj4);
-
-export type MapAction = 'save' | 'close';
+import {useCallback, useEffect, useState} from 'react';
+import {useNotification} from '../../../context/popup';
+import {MapComponent} from '../../components/map/map-component';
+import {theme} from '../../themes';
 
 // // To simulate movement for PR: open browser console and set `window.__USE_FAKE_GPS__ = true`
 declare global {
@@ -52,6 +55,8 @@ declare global {
     __USE_FAKE_GPS__?: boolean;
   }
 }
+
+export type MapAction = 'save' | 'close';
 
 interface MapProps extends ButtonProps {
   label: string;
@@ -68,26 +73,18 @@ interface MapProps extends ButtonProps {
   openMap?: () => void;
 }
 
-import {
-  Alert,
-  AlertTitle,
-  AppBar,
-  Box,
-  Dialog,
-  DialogActions,
-  Grid,
-  IconButton,
-  Toolbar,
-  Tooltip,
-  Typography,
-} from '@mui/material';
-import {useNotification} from '../../../context/popup';
-import {MapComponent} from '../../components/map/map-component';
-import {theme} from '../../themes';
-import {Extent} from 'ol/extent';
-import Feature from 'ol/Feature';
-import {Point} from 'ol/geom';
-import {RegularShape} from 'ol/style';
+// define some EPSG codes - these are for two sample images
+// TODO: we need to have a better way to include a useful set or allow
+// them to be defined by a project
+// e.g. https://www.npmjs.com/package/epsg-index
+// or maybe https://github.com/matafokka/geotiff-geokeys-to-proj4 allows us
+// to get things from the image?
+proj4.defs('EPSG:32636', '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs');
+proj4.defs(
+  'EPSG:28354',
+  '+proj=utm +zone=54 +south +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+);
+register(proj4);
 
 function MapWrapper(props: MapProps) {
   const [mapOpen, setMapOpen] = useState<boolean>(false);

--- a/app/src/gui/fields/radio.tsx
+++ b/app/src/gui/fields/radio.tsx
@@ -18,18 +18,18 @@
  *   TODO
  */
 
-import React from 'react';
-import MuiRadioGroup from '@mui/material/RadioGroup';
-import MuiRadio, {RadioProps} from '@mui/material/Radio';
-import FormControl from '@mui/material/FormControl';
 import {
-  FormControlLabel,
-  FormLabelProps,
-  FormHelperTextProps,
-  FormControlLabelProps,
   Box,
+  FormControlLabel,
+  FormControlLabelProps,
+  FormHelperTextProps,
+  FormLabelProps,
 } from '@mui/material';
+import FormControl from '@mui/material/FormControl';
+import MuiRadio, {RadioProps} from '@mui/material/Radio';
+import MuiRadioGroup from '@mui/material/RadioGroup';
 import {fieldToRadioGroup, RadioGroupProps} from 'formik-mui';
+import React from 'react';
 import FieldWrapper from './fieldWrapper';
 /**
  * Represents a single option in the radio group.
@@ -99,7 +99,7 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
         heading={label}
         subheading={helperText}
         required={this.props.required}
-        advancedHelperText={this.props.advancedHelperText}
+        advancedHelperText={advancedHelperText}
       >
         <FormControl sx={{mb: 4}} error={Boolean(form.errors?.[field.name])}>
           <MuiRadioGroup

--- a/web/src/routes/_protected/profile.tsx
+++ b/web/src/routes/_protected/profile.tsx
@@ -1,13 +1,12 @@
 import {Button} from '@/components/ui/button';
 import {Card} from '@/components/ui/card';
 import {List, ListDescription, ListItem, ListLabel} from '@/components/ui/list';
+import {API_URL, WEB_URL} from '@/constants';
 import {useAuth, User} from '@/context/auth-provider';
 import {createFileRoute} from '@tanstack/react-router';
-import {CheckCircle, XCircle} from 'lucide-react';
+import {CheckCircle, Key, ShieldAlert, XCircle} from 'lucide-react';
 import React from 'react';
 import {toast} from 'sonner';
-import {ShieldAlert, Key} from 'lucide-react';
-import {API_URL, APP_URL, WEB_URL} from '@/constants';
 
 export const Route = createFileRoute('/_protected/profile')({
   component: RouteComponent,


### PR DESCRIPTION

## JIRA Ticket

[BSS-798 
](https://jira.csiro.au/browse/BSS-798)

## Description

This PR resolves the issue where the word "Error" was being displayed in place of the damage rating helper text when the field content was empty.

Upon investigation, it was found that the helper text field was using a RichTextField component to render static content. When the content string was empty, the component still attempted to render, resulting in "Error" being displayed instead of simply showing nothing.

Fix: 
Added a condition to prevent RichTextField from rendering if the content is empty or null, also empty helper text fields render cleanly without unnecessary placeholder or fallback text.


## How to Test
Open Designer at http://localhost:5010 and upload a JSON with RichText helper text (empty and non-empty cases).
Added a JSON for reference here: 
Confirm in Designer preview:
[restructured-initial-assessment.json](https://github.com/user-attachments/files/19843086/restructured-initial-assessment.json)

Empty RichText does not display “Error” or any unwanted text.
Non-empty RichText renders correctly.
Open the form in the App, go to the relevant section, if using provided JSON, add a structure and verify damage rating should have a helper Text displayed if added, shouldn't display error if empty. (e.g., damage rating).
Verify:
Empty RichText shows nothing (clean UI).
Populated RichText displays as expected.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
