### PR TITLE
Fix Data Export from Control Centre

### DIFF
--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -430,7 +430,7 @@ const validateDownloadToken = async ({
       // verify issuer
       issuer: signingKey.instanceName,
     });
-    return result.payload as DownloadTokenPayload;
+    return DownloadTokenPayloadSchema.parse(result.payload);
   } catch {
     console.log('invalid token');
     return null;

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -621,33 +621,41 @@ describe('API tests', () => {
     // pull in some test data
     await restoreFromBackup('test/backup.jsonl');
 
+    const url = '/api/notebooks/1693291182736-campus-survey-demo/records/FORM2.csv';
     const adminUser = await getExpressUserFromEmailOrUsername('admin');
     if (adminUser) {
       const notebooks = await getUserProjectsDetailed(adminUser);
       expect(notebooks).to.have.lengthOf(2);
 
+      let redirectURL = '';
       await request(app)
-        .get(
-          '/api/notebooks/1693291182736-campus-survey-demo/records/FORM2.csv'
-        )
+        .get(url)
         .set('Authorization', `Bearer ${adminToken}`)
         .set('Content-Type', 'application/json')
-        .expect(200)
-        .expect('Content-Type', 'text/csv')
+        .expect(302)
         .expect(response => {
-          // response body should be csv data
-          expect(response.text).to.contain('identifier');
-          const lines = response.text.split('\n');
-          lines.forEach(line => {
-            if (line !== '' && !line.startsWith('identifier')) {
-              expect(line).to.contain('rec');
-              expect(line).to.contain('FORM2');
-              expect(line).to.contain('frev');
-            }
-          });
-          // one more newline than the number of records + header
-          expect(lines).to.have.lengthOf(19);
+          expect(response.headers.location).to.match(/\/download\/.*/);
+          redirectURL = response.headers.location;
         });
+
+      if (redirectURL)
+        await request(app)
+          .get(redirectURL)
+          .expect('Content-Type', 'text/csv')
+          .expect(response => {
+            // response body should be csv data
+            expect(response.text).to.contain('identifier');
+            const lines = response.text.split('\n');
+            lines.forEach(line => {
+              if (line !== '' && !line.startsWith('identifier')) {
+                expect(line).to.contain('rec');
+                expect(line).to.contain('FORM2');
+                expect(line).to.contain('frev');
+              }
+            });
+            // one more newline than the number of records + header
+            expect(lines).to.have.lengthOf(19);
+          });
     }
   });
 

--- a/web/src/components/forms/export-project-form.tsx
+++ b/web/src/components/forms/export-project-form.tsx
@@ -37,10 +37,17 @@ const ExportProjectForm = ({type}: {type: 'zip' | 'csv'}) => {
    * @returns {Promise<{type: string; message: string}>} The result of the form submission.
    */
   const onSubmit = async ({form}: {form: string}) => {
-    window.open(
-      `${import.meta.env.VITE_API_URL}/api/notebooks/${projectId}/records/${form}.${type}`,
-      '_blank'
-    );
+    if (user) {
+      const downloadURL = `${import.meta.env.VITE_API_URL}/api/notebooks/${projectId}/records/${form}.${type}`;
+      const response = await fetch(downloadURL, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      // open the download URL in the current window to force the download
+      if (response.redirected) window.open(response.url, '_self');
+    }
     return undefined;
   };
 


### PR DESCRIPTION
# Fix Data Export from Control Centre

## JIRA Ticket

[BSS-925](https://jira.csiro.com/browse/BSS-925)

## Description

The introduction of tokens has broken downloads in control center which relied on cookies to redirect the 
user to the download link.

## Proposed Changes

Introduces a two-step route for downloads of zip/csv data.  First request to /api/notebooks/:id/view.csv returns a redirect response to a URL containing a short lived (5 minute) JWT.   Requesting that URL gives the requested download.

Imlemented for zip and csv downloads here but can be extended to other download types.

## How to Test

Try exporting data from a notebook in the Control Center.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
