### PR TITLE
Add Devcontainer Config for VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,69 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "devcontainer",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	"containerEnv": {
+		"PROFILE_NAME": "local-dev",
+		"DEVELOPER_MODE": "true",
+		"KEY_FILE_PATH": ".",
+		"CONDUCTOR_INSTANCE_NAME": "Development FAIMS Server",
+		"CONDUCTOR_DESCRIPTION": "Development server on localhost",
+		"CONDUCTOR_SHORT_CODE_PREFIX": "DEV",
+
+		"COUCHDB_USER": "admin",
+
+		"CONDUCTOR_INTERNAL_PORT": "8080",
+
+		"COUCHDB_EXTERNAL_PORT": "5984",
+		"COUCHDB_INTERNAL_URL": "http://localhost:5984",
+		"COUCHDB_PUBLIC_URL": "http://localhost:5984",
+  	"NEW_CONDUCTOR_URL": "http://localhost:3001",
+		"WEB_APP_PUBLIC_URL":"http://localhost:3000",
+		"REDIRECT_WHITELIST":" http://localhost:8080,http://localhost:3000,http://localhost:3001,org.fedarch.faims3://auth-return",
+
+		"ANDROID_APP_PUBLIC_URL":"https://play.google.com/store/apps/details?id=org.fedarch.faims3",
+		"IOS_APP_PUBLIC_URL":"https://apps.apple.com/au/app/fieldmark/id1592632372",
+		"DESIGNER_URL":"https://designer.testing.fieldmark.app",
+		
+		"EMAIL_SERVICE_TYPE":"MOCK",
+		"EMAIL_FROM_ADDRESS":"notifications@example.com",
+		"EMAIL_FROM_NAME":"FAIMS Notification",
+		"EMAIL_REPLY_TO":"support@example.com",
+
+		"CONDUCTOR_EMAIL_HOST_NAME":" localhost",
+		"CONDUCTOR_EMAIL_HOST_CONFIG": "smtps://username:password@smtp.example.com",
+		"CONDUCTOR_EMAIL_FROM_ADDRESS": "test@example.com",
+
+		"CONDUCTOR_AUTH_PROVIDERS":"",
+
+		"COUCHDB_PASSWORD": "aSecretPasswordThatCantBeGuessed",
+
+		"TEST_EMAIL_ADDRESS": "test@example.com"
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+					3000,
+					3001,
+					5010,
+					8080
+	],
+	"portsAttributes": {
+					"3000": {
+									"label": "App"
+					},
+					"3001": {
+									"label": "Control Center"
+					},
+					"8080": {
+									"label": "API"
+					},
+					"5010": {
+									"label": "Designer"
+					}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  couchdb:
+    image: couchdb:3@sha256:d341311cf03840dfb96a7c1bcf7ef5b6a6a4d2ac53e01e7a5095329cbe8cd37c
+    volumes: 
+      - type: volume
+        source: couchdb-data
+        target: /opt/couchdb/data
+    ports:
+      - "0.0.0.0:5984:5984"     
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=aSecretPasswordThatCantBeGuessed
+    networks:
+      - conductor-local-dev
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
+    networks:
+      - conductor-local-dev
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+networks:
+  conductor-local-dev: {}
+volumes:
+  couchdb-data:


### PR DESCRIPTION
# Add Devcontainer Config for VSCode

## JIRA Ticket

None

## Description

Adds configuration for devcontainer for vscode.

## Proposed Changes

This devcontainer config will create a pair of docker containers to allow working with the project in a
standardised environment.    It creates a couchdb container and a workspace container that can 
be used to run the other services.   A minimal set of environment settings suitable for development
are included in the config.  

This can be ignored if you prefer another environment.  Having this in the repo enables opening the repo
or a pull request in an isolated volume (https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume).   

On MacOS this helps because it puts the code inside the container in a volume which is much faster than bind mounting
a local directory. 

## How to Test

In VSCode try opening this PR in a container as per the above link. 

After opening the container, you will need to run `npm migrate` in the api folder and then run each of the services.   Some configuration in .env files may be needed if you don't want the default settings.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
