### PR TITLE
fix: qr scan of code with existing redirect causes double redirect

### DIFF
--- a/app/src/gui/components/authentication/shortCodeOnly.tsx
+++ b/app/src/gui/components/authentication/shortCodeOnly.tsx
@@ -18,7 +18,7 @@ import {APP_ID} from '../../../buildconfig';
 import {useNotification} from '../../../context/popup';
 import {addAlert} from '../../../context/slices/alertSlice';
 import {useAppDispatch} from '../../../context/store';
-import {isWeb} from '../../../utils/helpers';
+import {isWeb, replaceOrAppendRedirect} from '../../../utils/helpers';
 import {QRCodeButton} from '../../fields/qrcode/QRCodeFormField';
 import {Server} from '../../../context/slices/projectSlice';
 
@@ -39,9 +39,15 @@ export function QRCodeButtonOnly(props: {servers: Server[]}) {
     const valid_re = valid_hosts.join('|') + '/register.*';
 
     if (url.match(valid_re)) {
+      // Process the URL with our new function
+      const finalUrl = replaceOrAppendRedirect({
+        url,
+        redirectTo: `${APP_ID}://auth-return`,
+      });
+
       // Use the capacitor browser plugin in apps
       await Browser.open({
-        url: `${url}&redirect=${APP_ID}://auth-return`,
+        url: finalUrl,
       });
     } else {
       dispatch(

--- a/app/src/gui/pages/shortcode.tsx
+++ b/app/src/gui/pages/shortcode.tsx
@@ -40,11 +40,11 @@ import {
 } from '../../buildconfig';
 import {useNotification} from '../../context/popup';
 import {addAlert} from '../../context/slices/alertSlice';
+import {Server} from '../../context/slices/projectSlice';
 import {useAppDispatch} from '../../context/store';
-import {isWeb} from '../../utils/helpers';
+import {isWeb, replaceOrAppendRedirect} from '../../utils/helpers';
 import MainCard from '../components/ui/main-card';
 import {QRCodeButton} from '../fields/qrcode/QRCodeFormField';
-import {Server} from '../../context/slices/projectSlice';
 
 type ShortCodeProps = {
   servers: Server[];
@@ -236,10 +236,15 @@ export function QRCodeRegistration(props: ShortCodeProps) {
     const valid_re = valid_hosts.join('|') + '/register.*';
 
     if (url.match(valid_re)) {
+      // Process the URL with our new function
+      const finalUrl = replaceOrAppendRedirect({
+        url,
+        redirectTo: `${APP_ID}://auth-return`,
+      });
+
       // Use the capacitor browser plugin in apps
-      // TODO should we replace the redirect query string param here instead of appending
       await Browser.open({
-        url: `${url}&redirect=${APP_ID}://auth-return`,
+        url: finalUrl,
       });
     } else {
       dispatch(

--- a/app/src/utils/helpers.tsx
+++ b/app/src/utils/helpers.tsx
@@ -27,3 +27,36 @@ export function iteratorTakeOne<V>(iterator: Iterator<V>): V | undefined {
   const result = iterator.next();
   return result.done ? undefined : result.value;
 }
+
+/**
+ * Either replaces or adds a redirect to a URL query string
+ * @param url
+ * @param redirectTo
+ * @returns
+ */
+export const replaceOrAppendRedirect = ({
+  url,
+  redirectTo,
+}: {
+  url: string;
+  redirectTo: string;
+}): string => {
+  try {
+    // Parse the URL to manipulate its parts
+    const urlObj = new URL(url);
+
+    // Check if redirect parameter exists and replace it
+    if (urlObj.searchParams.has('redirect')) {
+      urlObj.searchParams.set('redirect', redirectTo);
+    } else {
+      // Add redirect parameter if it doesn't exist
+      urlObj.searchParams.append('redirect', redirectTo);
+    }
+
+    return urlObj.toString();
+  } catch (error) {
+    // Return original URL if parsing fails
+    console.error('Error parsing URL:', error);
+    return url;
+  }
+};


### PR DESCRIPTION
# fix: qr scan of code with existing redirect causes double redirect

## JIRA Ticket

https://jira.csiro.au/browse/BSS-919

## Description

Replaces existing OR appends instead of blindly appending. This will always force a prioritisation of the app's preferred redirect. 

There could also be scope to prevent putting the redirect in in the first place (when generated from the control center) - relying on the API to have reasonable defaults - but this is harder as it would require inspecting the invite more thoroughly and determining a URL intelligently from that. 

This should fix this bug at least. 

## How to Test

Generate a team invite code in control center. Scan it on a mobile device. Ensure it opens, registers, then redirects back. 

@stevecassidy  hoping you can test on mobile.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
