### PR TITLE
fix: DebouncedTextField Improvements, fix help text changes reverting other field changes

### DIFF
--- a/designer/src/components/Fields/BaseFieldEditor.tsx
+++ b/designer/src/components/Fields/BaseFieldEditor.tsx
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {MDXEditorMethods} from '@mdxeditor/editor';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Alert,
@@ -25,6 +28,9 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import {debounce} from 'lodash';
+import {useRef, useState} from 'react';
+import {VITE_TEMPLATE_PROTECTIONS} from '../../buildconfig';
 import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {FieldType} from '../../state/initial';
 import {
@@ -32,15 +38,8 @@ import {
   ConditionTranslation,
   ConditionType,
 } from '../condition';
-
-import {VITE_TEMPLATE_PROTECTIONS} from '../../buildconfig';
 import DebouncedTextField from '../debounced-text-field';
 import {MdxEditor} from '../mdx-editor';
-import {useRef, useState} from 'react';
-import {MDXEditorMethods} from '@mdxeditor/editor';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import {debounce} from 'lodash';
 
 type Props = {
   fieldName: string;

--- a/designer/src/components/Fields/BaseFieldEditor.tsx
+++ b/designer/src/components/Fields/BaseFieldEditor.tsx
@@ -40,6 +40,7 @@ import {useRef, useState} from 'react';
 import {MDXEditorMethods} from '@mdxeditor/editor';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {debounce} from 'lodash';
 
 type Props = {
   fieldName: string;
@@ -229,9 +230,12 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
                         <Box mt={2} sx={{maxHeight: 300, overflowY: 'auto'}}>
                           <MdxEditor
                             initialMarkdown={state.advancedHelperText}
-                            handleChange={markdown =>
-                              updateProperty('advancedHelperText', markdown)
-                            }
+                            handleChange={debounce(
+                              markdown =>
+                                updateProperty('advancedHelperText', markdown),
+                              500,
+                              {leading: false, trailing: true}
+                            )}
                             editorRef={ref}
                           />
                           <Alert severity="info" sx={{mt: 2}}>

--- a/designer/src/components/Fields/OptionsEditor.tsx
+++ b/designer/src/components/Fields/OptionsEditor.tsx
@@ -52,10 +52,10 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TextField,
   Tooltip,
   Typography,
 } from '@mui/material';
-import DebouncedTextField from '../debounced-text-field';
 import {useState} from 'react';
 import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {FieldType} from '../../state/initial';
@@ -581,7 +581,7 @@ export const OptionsEditor = ({
               <form onSubmit={addOption}>
                 <Grid container spacing={1} alignItems="center">
                   <Grid item xs>
-                    <DebouncedTextField
+                    <TextField
                       fullWidth
                       size="small"
                       placeholder="Add Option"
@@ -759,7 +759,7 @@ export const OptionsEditor = ({
         >
           <DialogTitle>Edit Option</DialogTitle>
           <DialogContent>
-            <DebouncedTextField
+            <TextField
               autoFocus
               margin="dense"
               label="Option Text"


### PR DESCRIPTION
# fix: DebouncedTextField Improvements, fix help text changes reverting other field changes

## JIRA Tickets

[BSS-917](https://jira.csiro.au/browse/BSS-917) - **Designer: editing help text reverts other changes in a field**

[BSS-898](https://jira.csiro.au/browse/BSS-898) - **Remove debounce on designer option select input**

## Description

This pull request addresses some performances issues with DebouncedTextField and fixes issues where field changes could be lost. This effectively resolves **BSS-917,** an issue where editing help text was reverting other changes in a field.

Also, DebouncedTextField usage has been removed the OptionsEditor component.

## Proposed Changes

- Rewrote the DebouncedTextField component.
- Reduced default debounce text field time from 500ms -> 200ms.
- We now flush the debounce function instead of cancelling it to prevent data loss.
- Updated debounce function from a _useRef_ to _useMemo_, so it is not unnecessarily recreated.
- Removed DebouncedTextField usage from the OptionsEditor component.

## How to Test

- Modify a field option (For example, toggle _uncertainty_).
- Modify the helper text.
- Ensure that the option you changed does not revert to its original state.

## Checklist

- [X] I have confirmed all commits have been signed.
- [X] I have added JSDoc style comments to any new functions or classes.
- [X] Relevant documentation such as READMEs, guides, and class comments are updated.
