### PR TITLE
fix: optional key configuration push for npm run migrate

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -66,10 +66,19 @@ npm run watch
 
 instead, which will monitor for changes with `nodemon`.
 
-## Initialisation
+## Initialisation and migration
 
 Once the services are up and running we need to initialise the CouchDB
-database. This is done with the migrate script:
+database.
+
+If you want to include pushing the keys (only recommended for local development):
+
+```bash
+npm run migrate --keys
+```
+
+If you just want to migrate databases without applying any public key
+configuration, then exclude this flag
 
 ```bash
 npm run migrate
@@ -82,7 +91,7 @@ run in the container rather than from your local environment:
 docker compose exec conductor npm run migrate
 ```
 
-This ensures that the correct CouchDB URL is used to access the database.  The same
+This ensures that the correct CouchDB URL is used to access the database. The same
 applies for the commands below.
 
 For development, there is also a script that will populate the database with projects (notebooks

--- a/api/src/scripts/migrate.ts
+++ b/api/src/scripts/migrate.ts
@@ -1,9 +1,26 @@
 /* eslint-disable n/no-process-exit */
 import {initialiseAndMigrateDBs} from '../couchdb';
 
+/**
+ * Main function to run database initialization and migration
+ * Accepts optional --keys flag to control whether public keys should be pushed
+ */
 const main = async () => {
   try {
-    await initialiseAndMigrateDBs({force: true});
+    // Check if --keys flag is present in command line arguments
+    const pushKeys = process.argv.includes('--keys');
+
+    // Log whether keys will be configured
+    console.log(
+      `Public keys will ${pushKeys ? '' : 'not '}be configured during migration`
+    );
+
+    // Run database initialization and migration with force and pushKeys parameters
+    await initialiseAndMigrateDBs({
+      force: true,
+      pushKeys: pushKeys,
+    });
+
     console.log('Migration completed successfully');
     process.exit(0);
   } catch (error) {
@@ -12,4 +29,5 @@ const main = async () => {
   }
 };
 
+// Execute the main function
 main();

--- a/localdev.sh
+++ b/localdev.sh
@@ -103,8 +103,8 @@ else
 fi
 
 echo "Initialising database using API container"
-echo ">docker compose exec api sh -c \"cd api && npm run migrate\""
-docker compose exec api sh -c "cd api && npm run migrate"
+echo ">docker compose exec api sh -c \"cd api && npm run migrate --keys\""
+docker compose exec api sh -c "cd api && npm run migrate --keys"
 
 
 echo "Service is setup, to load notebooks and templates follow the below steps"


### PR DESCRIPTION
Makes the application of key configuration from the local .env into the deployment an opt in --keys flag rather than default behaviour. The reason for this is that in deployed prod environments, it is hard or even impossible for the local environment to match the key configuration of the deployed environment, and migration is really about database migration in this context.