### PR TITLE
feat: control links feature with config variable

### DIFF
--- a/app/.env.dist
+++ b/app/.env.dist
@@ -49,3 +49,5 @@ VITE_MAP_STYLE=basic
 VITE_APP_STORE_CONNECT_TEAM_ID="SOMETHING"
 # Should filters be shown in the Records/Drafts UI, 'true' is FAIMS, 'false' is BSS
 VITE_ENABLE_RECORD_FILTERS=true 
+# Should we show the record links feature?
+VITE_SHOW_RECORD_LINKS=false

--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -403,6 +403,13 @@ function offline_maps(): boolean {
   return (offline_maps && map_source !== 'osm') || false;
 }
 
+/**
+ * Should we show the record links feature?
+ */
+function showRecordLinks(): boolean {
+  return import.meta.env.VITE_SHOW_RECORD_LINKS === 'true';
+}
+
 // this should disappear once we have listing activation set up
 export const AUTOACTIVATE_LISTINGS = true;
 export const CONDUCTOR_URLS = get_conductor_urls();
@@ -431,3 +438,4 @@ export const OFFLINE_MAPS = offline_maps();
 export const MAP_SOURCE_KEY = get_map_key();
 export const MAP_SOURCE = get_map_source();
 export const MAP_STYLE = get_map_style();
+export const SHOW_RECORD_LINKS = showRecordLinks();

--- a/app/src/gui/components/record/RecordData.tsx
+++ b/app/src/gui/components/record/RecordData.tsx
@@ -34,6 +34,7 @@ import RecordForm from './form';
 import RelationshipsViewComponent from './relationships';
 import {ParentLinkProps, RecordLinkProps} from './relationships/types';
 import DraftSyncStatus from './sync_status';
+import {SHOW_RECORD_LINKS} from '../../../buildconfig';
 interface RecordDataTypes {
   project_id: ProjectID;
   serverId: string;
@@ -69,6 +70,13 @@ export default function RecordData(props: RecordDataTypes) {
   const [ViewName, setViewName] = React.useState(null);
   const location = useLocation();
 
+  const showRecordLinks = SHOW_RECORD_LINKS;
+  const recordLinksLoading = SHOW_RECORD_LINKS && !props.is_link_ready;
+  const recordLinksViable =
+    SHOW_RECORD_LINKS &&
+    !recordLinksLoading &&
+    props.record_to_field_links.length > 0;
+
   return (
     <Box bgcolor={grey[100]}>
       <DraftSyncStatus
@@ -76,8 +84,12 @@ export default function RecordData(props: RecordDataTypes) {
         is_saving={props.isDraftSaving}
         error={props.draftError}
       />
-      {props.is_link_ready ? (
-        props.record_to_field_links.length > 0 && (
+      {showRecordLinks ? (
+        recordLinksLoading ? (
+          // Show loading as we are waiting but links are enabled
+          <CircularProgress size={24} />
+        ) : recordLinksViable ? (
+          // We have links enabled, not loading, and viable
           <RelationshipsViewComponent
             record_to_field_links={props.record_to_field_links}
             record_id={props.record_id}
@@ -86,10 +98,10 @@ export default function RecordData(props: RecordDataTypes) {
             handleSetSection={setViewName}
             handleUnlink={props.handleUnlink}
           />
-        )
-      ) : (
-        <CircularProgress size={24} />
-      )}
+        ) : // Do not show record links as it is not viable
+        null
+      ) : // do not show record links - as it is disabled
+      null}
       <RecordForm
         serverId={props.serverId}
         project_id={props.project_id}


### PR DESCRIPTION
# feat: control links feature with config variable

## JIRA Ticket

https://jira.csiro.au/browse/BSS-958
https://jira.csiro.au/browse/BSS-965

## Description

Default hides the links feature on the existing record data page - use `VITE_SHOW_RECORD_LINKS='true'` in the /app environment to enable it. Also tidies up/documents the conditions a bit for loading vs hiding etc. 

## Screenshots

### Config `False` 

![image](https://github.com/user-attachments/assets/1dc5a7b6-3e1e-47dc-8130-4b3c281c21ae)

### Config `True` 

![image](https://github.com/user-attachments/assets/016c464d-dd04-416b-8aaf-4c0fdd2f3f65)


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
