### PR TITLE
fix: project names change after edit

### DIFF
--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -292,7 +292,7 @@ api.put(
     const metadata = req.body.metadata;
     const projectID = req.params.id;
     await updateNotebook(projectID, uiSpec, metadata);
-    res.json({notebook: projectID}).end();
+    return res.json({notebook: projectID});
   }
 );
 

--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -247,6 +247,8 @@ api.get(
 
     if (metadata && uiSpec) {
       res.json({
+        // include name
+        name: project.name,
         metadata,
         // TODO fully implement a UI Spec zod model, and do runtime validation
         // in all client apps

--- a/app/src/context/slices/projectSlice.ts
+++ b/app/src/context/slices/projectSlice.ts
@@ -131,6 +131,9 @@ export type ProjectIdToProjectMap = {[projectId: string]: Project};
 
 /** This is the subset of project information which is modifiable/trivial */
 export interface ProjectInformation {
+  // Name of the project
+  name: string;
+
   // This is metadata information about the project
   metadata: ProjectMetadata;
 
@@ -149,6 +152,9 @@ export interface ProjectInformation {
 export interface Project extends ProjectInformation {
   // the unique project ID (unique within the server)
   projectId: string;
+
+  // the non-unique name of the project
+  name: string;
 
   // Which server is this in? (including here too since it's helpful)
   serverId: string;
@@ -348,6 +354,7 @@ const projectsSlice = createSlice({
 
         // Superficial details
         metadata: payload.metadata,
+        name: payload.name,
 
         uiSpecificationId: compiledSpecId,
         rawUiSpecification: payload.rawUiSpecification,
@@ -596,6 +603,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // These are updated
         isActivated: true,
@@ -699,6 +707,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // These are updated (to indicate de-activation)
         isActivated: false,
@@ -839,6 +848,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // These are updated
         isActivated: true,
@@ -926,6 +936,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // Project remains activated, but syncing is stopped
         isActivated: true,
@@ -1048,6 +1059,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // These are updated
         isActivated: true,
@@ -1174,6 +1186,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // These are updated
         isActivated: true,
@@ -1303,6 +1316,7 @@ const projectsSlice = createSlice({
         uiSpecificationId: project.uiSpecificationId,
         serverId: project.serverId,
         status: project.status,
+        name: project.name,
 
         // These are updated
         isActivated: true,
@@ -1799,6 +1813,8 @@ export const initialiseProjects = createAsyncThunk<void, {serverId: string}>(
         // create
         appDispatch(
           addProject({
+            // Name is included in the GetNotebookResponse
+            name: meta.name,
             metadata: meta.metadata as ProjectMetadata,
             projectId,
             serverId,
@@ -1811,6 +1827,8 @@ export const initialiseProjects = createAsyncThunk<void, {serverId: string}>(
         // update existing record
         appDispatch(
           updateProjectDetails({
+            // Name can't change atm but might as well update it if present
+            name: meta?.name ?? project.name,
             metadata:
               (meta?.metadata as ProjectMetadata | undefined) ??
               project.metadata,

--- a/app/src/gui/components/metadataRenderer.tsx
+++ b/app/src/gui/components/metadataRenderer.tsx
@@ -26,17 +26,30 @@ import {RichTextField} from '../fields/RichText';
 
 type MetadataProps = {
   project_id: ProjectID;
-  metadata_key: string;
+  // You can force through an explicit value
+  explicitValue?: string;
+  // OR you can ask for a value by key from the metadata
+  metadata_key?: string;
   metadata_label?: string;
   chips?: boolean;
 };
 
 export default function MetadataRenderer(props: MetadataProps) {
-  const {project_id, metadata_key, metadata_label, chips = true} = props;
+  const {
+    project_id,
+    metadata_key,
+    metadata_label,
+    chips = true,
+    explicitValue,
+  } = props;
   const metadata = useAppSelector(
     state => selectProjectById(state, project_id)?.metadata
   );
-  const possibleValue = metadata?.[metadata_key];
+  const possibleValue = explicitValue
+    ? explicitValue
+    : metadata_key
+      ? metadata?.[metadata_key]
+      : 'Error';
   const value = possibleValue ? (possibleValue as string) : '';
 
   // Use RichTextField for 'pre_description' field

--- a/app/src/gui/components/notebook/MetadataDisplay.tsx
+++ b/app/src/gui/components/notebook/MetadataDisplay.tsx
@@ -55,7 +55,7 @@ export const MetadataDisplayComponent = (
           <strong>Name:</strong>{' '}
           <MetadataRenderer
             project_id={props.project.projectId}
-            metadata_key={'name'}
+            explicitValue={props.project.name ?? props.project.metadata.name}
             chips={false}
           />
         </Typography>

--- a/app/src/gui/components/notebook/NewNotebookForListing.tsx
+++ b/app/src/gui/components/notebook/NewNotebookForListing.tsx
@@ -256,7 +256,7 @@ const NewNotebookForListing: React.FC<NewNotebookForListingProps> = props => {
             {templates.data && templates.data.templates.length > 0 ? (
               templates.data.templates.map(template => (
                 <MenuItem key={template._id} value={template._id}>
-                  {template.metadata.name}
+                  {template.name}
                 </MenuItem>
               ))
             ) : (

--- a/app/src/gui/components/notebook/settings/sync_switch.tsx
+++ b/app/src/gui/components/notebook/settings/sync_switch.tsx
@@ -110,7 +110,7 @@ export default function NotebookSyncSwitch({
             <Alert severity={isSyncing ? 'warning' : 'info'}>
               <AlertTitle>Are you sure?</AlertTitle>
               Do you want to {isSyncing ? 'stop' : 'start'} syncing the{' '}
-              {project.metadata.name} {NOTEBOOK_NAME} to your device?
+              {project.name} {NOTEBOOK_NAME} to your device?
             </Alert>
             <DialogActions style={{justifyContent: 'space-between'}}>
               <Button

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -130,7 +130,11 @@ export default function NoteBooks() {
               padding: '8px 0px',
             }}
           >
-            {row.metadata.name}
+            {row.name ??
+            // Just as a backwards compat thing, consider looking for name in
+            // metadata
+              row.metadata.name ??
+              'Unknown ' + NOTEBOOK_NAME_CAPITALIZED}
           </Typography>
           <Typography variant="caption" sx={{display: 'block', mt: 1}}>
             {row.metadata.description}

--- a/app/src/gui/layout/appBar.tsx
+++ b/app/src/gui/layout/appBar.tsx
@@ -101,7 +101,7 @@ function getNestedProjects(pouchProjectList: Project[]) {
   const projectListItems: ProjectListItemProps[] = [];
   pouchProjectList.map(project_info => {
     projectListItems.push({
-      title: project_info.metadata.name,
+      title: project_info.name ?? project_info.metadata.name,
       icon: <DescriptionIcon />,
       to:
         ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE +

--- a/app/src/gui/pages/notebook.tsx
+++ b/app/src/gui/pages/notebook.tsx
@@ -70,7 +70,7 @@ export default function Notebook() {
             textOverflow: 'ellipsis',
           }}
         >
-          {project.metadata.name}
+          {project.name ?? project.metadata.name}
         </Typography>
       </Stack>
 

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -313,7 +313,7 @@ export default function RecordCreate() {
     {link: ROUTES.NOTEBOOK_LIST_ROUTE, title: `${NOTEBOOK_NAME_CAPITALIZED}s`},
     {
       link: ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + serverId + '/' + projectId,
-      title: project !== null ? project.metadata.name : projectId!,
+      title: project !== null ? (project.name ?? project.metadata.name) : projectId!,
     },
     {title: 'Draft'},
   ];

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -179,7 +179,7 @@ export default function Record() {
           },
           {
             link: ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + serverId + '/' + projectId,
-            title: project.metadata.name,
+            title: project.name ?? project.metadata.name,
           },
           {title: hrid ?? recordId},
         ]);
@@ -313,7 +313,7 @@ export default function Record() {
               {
                 link:
                   ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + serverId + '/' + projectId,
-                title: project.metadata.name,
+                title: project.name ?? project.metadata.name,
               },
               {title: hrid! ?? recordId!},
             ];
@@ -334,7 +334,7 @@ export default function Record() {
                     serverId +
                     '/' +
                     projectId,
-                  title: project.metadata.name,
+                  title: project.name ?? project.metadata.name,
                 },
                 {
                   link: newParent[0]['route'],

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -221,6 +221,8 @@ export const APINotebookGetSchema = z.object({
   'ui-specification': z.record(z.unknown()),
   ownedByTeamId: z.string().min(1).optional(),
   status: z.nativeEnum(ProjectStatus),
+  // Name of the notebook!
+  name: z.string(),
 });
 export type APINotebookGet = z.infer<typeof APINotebookGetSchema>;
 

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -8,7 +8,7 @@ import {TeamCellComponent} from '@/components/tables/cells/team-cell';
 import {ProjectStatus} from '@faims3/data-model';
 
 const detailsFields = [
-  {field: 'name', label: 'Name'},
+  {field: 'name', label: 'Name', isMetadata: false},
   {field: 'pre_description', label: 'Description'},
   {field: 'project_lead', label: 'Created by'},
   {field: 'notebook_version', label: 'Version'},

--- a/web/src/routes/_protected/projects/$projectId.tsx
+++ b/web/src/routes/_protected/projects/$projectId.tsx
@@ -48,7 +48,7 @@ function RouteComponent() {
         path: pathname,
         label: isLoading
           ? 'Loading...'
-          : ((project?.metadata.name as string) ?? projectId),
+          : ((project?.name as string) ?? projectId),
       },
     ],
     [pathname, project, isLoading]


### PR DESCRIPTION

# fix: project names change after edit

## JIRA Ticket

https://jira.csiro.au/browse/BSS-921

## Description

Improving handling of names for projects by exposing and respecting project.name instead of project.metadata.name.

Updates the API to return the project.name which is already being handled correctly. 

Updates the clients (web and API) to use this name rather than metadata.name. Also updates the redux store to expose Name directly, and merge it from API.

## How to Test

Make a notebook, check it works. Update it using web (can be the same file, that's fine), check that the name stays as the explicitly set name not the notebook metadata name. 

## Additional Information

We should improve this in the long term by removing the metadata DB and just having one place where this is configured. The specification name and the project name do not need to be/nor should be related.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
