### PR TITLE
fix: remove stepper edge case for existing records by forcing all sections to be viewed

### DIFF
--- a/app/src/gui/components/record/RecordData.tsx
+++ b/app/src/gui/components/record/RecordData.tsx
@@ -38,6 +38,7 @@ import {SHOW_RECORD_LINKS} from '../../../buildconfig';
 interface RecordDataTypes {
   project_id: ProjectID;
   serverId: string;
+  isExistingRecord: boolean;
   record_id: RecordID;
   hrid?: string;
   record_type: string;
@@ -103,6 +104,7 @@ export default function RecordData(props: RecordDataTypes) {
       ) : // do not show record links - as it is disabled
       null}
       <RecordForm
+        isExistingRecord={props.isExistingRecord}
         serverId={props.serverId}
         project_id={props.project_id}
         record_id={props.record_id}

--- a/app/src/gui/components/record/formButton.tsx
+++ b/app/src/gui/components/record/formButton.tsx
@@ -165,7 +165,6 @@ export default function FormButtonGroup({
           onChangeStepper={onChangeStepper}
           ui_specification={ui_specification}
           visitedSteps={visitedSteps || new Set()}
-          isRecordSubmitted={isRecordSubmitted || false}
         />
       )}
       <Grid container spacing={2}>

--- a/app/src/gui/components/record/recordStepper.tsx
+++ b/app/src/gui/components/record/recordStepper.tsx
@@ -41,7 +41,6 @@ type RecordStepperProps = {
   views: string[];
   formErrors?: {[fieldName: string]: unknown};
   visitedSteps: Set<string>;
-  isRecordSubmitted: boolean;
 };
 
 const useStyles = createUseStyles({
@@ -100,14 +99,14 @@ export default function RecordStepper(props: RecordStepperProps) {
     onChangeStepper,
     views,
     formErrors,
-    isRecordSubmitted,
   } = props;
   const theme = useTheme();
 
   // function to check if stepper has erros
   const hasErrors = (sectionId: string | undefined) => {
-    if (!sectionId || !visitedSteps || !ui_specification.views[sectionId])
+    if (!sectionId || !visitedSteps || !ui_specification.views[sectionId]) {
       return false;
+    }
 
     return (
       visitedSteps.has(sectionId) &&
@@ -129,6 +128,7 @@ export default function RecordStepper(props: RecordStepperProps) {
             sx={{padding: '15px 0'}}
           >
             {views.map((sectionId: string, index: number) => {
+              const isCurrent = sectionId === views[view_index];
               return (
                 <Step key={sectionId}>
                   <StepButton
@@ -138,6 +138,11 @@ export default function RecordStepper(props: RecordStepperProps) {
                     sx={{
                       width: '94%',
                       '& .MuiStepLabel-label': {
+                        ...(isCurrent
+                          ? {
+                              transform: 'scale(1.2)',
+                            }
+                          : {}),
                         color: theme.palette.primary.dark,
                         fontweight: 'bold',
                         transition: 'color 0.3s ease-in-out',
@@ -145,12 +150,16 @@ export default function RecordStepper(props: RecordStepperProps) {
                       },
 
                       '& .MuiStepIcon-root': {
+                        ...(isCurrent
+                          ? {
+                              transform: 'scale(1.5)',
+                            }
+                          : {}),
                         color: getStepColor(
                           sectionId,
                           views[view_index],
                           hasErrors(sectionId),
-                          visitedSteps,
-                          isRecordSubmitted
+                          visitedSteps
                         ),
                         borderRadius: '50%',
                         fontSize: '1rem',
@@ -158,7 +167,7 @@ export default function RecordStepper(props: RecordStepperProps) {
                         width: '26px',
                         height: '26px',
                         boxShadow:
-                          sectionId === views[view_index]
+                          isCurrent
                             ? '0px 4px 12px rgba(0, 0, 0, 0.3)'
                             : '0px 2px 4px rgba(0, 0, 0, 0.15)',
                         transition: 'all 0.3s ease-in-out',
@@ -193,7 +202,6 @@ export default function RecordStepper(props: RecordStepperProps) {
           ui_specification={ui_specification}
           formErrors={formErrors}
           visitedSteps={visitedSteps}
-          isRecordSubmitted={isRecordSubmitted}
         />
         <Typography
           variant="h4"

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -244,6 +244,8 @@ function DraftRecordEdit(props: DraftRecordEditProps) {
             )}
 
             <RecordForm
+              // Here we are in a new record
+              isExistingRecord={false}
               serverId={project.serverId}
               project_id={project_id}
               record_id={record_id}

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -676,6 +676,8 @@ export default function Record() {
                             {(isalerting === false ||
                               draftId !== undefined) && (
                               <RecordData
+                                // here we are in an existing record
+                                isExistingRecord={true}
                                 serverId={serverId}
                                 project_id={projectId!}
                                 record_id={recordId!}
@@ -707,6 +709,8 @@ export default function Record() {
                         </Box>
                       ) : (
                         <RecordData
+                          // here we are in an existing record
+                          isExistingRecord={true}
                           serverId={serverId}
                           project_id={projectId!}
                           record_id={recordId!}

--- a/app/src/utils/generateStepperColors.tsx
+++ b/app/src/utils/generateStepperColors.tsx
@@ -20,16 +20,13 @@ export const getStepColor = (
   currentStepId: string,
   hasError: boolean,
   visitedSteps: Set<string>,
-  isRecordSubmitted: boolean
 ): string => {
   const colors = theme.stepperColors;
   if (sectionId === currentStepId) return colors.current; // Current step color
 
-  if (hasError && visitedSteps.has(sectionId) && !isRecordSubmitted) {
-    return colors.error; // Mark as error
-  }
+  if (hasError && visitedSteps.has(sectionId)) return colors.error; // Mark as error
 
-  if (visitedSteps.has(sectionId) || isRecordSubmitted) return colors.visited;
+  if (visitedSteps.has(sectionId)) return colors.visited;
 
   return colors.notVisited;
 };


### PR DESCRIPTION
# fix: remove stepper edge case for existing records by forcing all sections to be viewed

## JIRA Ticket

https://jira.csiro.au/browse/BSS-963

## Description

Adds a flag 'isExistingRecord' as prop to form.tsx. On mount, if it is an existing record, tells the stepper that all sections have been visited and that the form should try to validate. Also removes all special conditional formatting in the stepper which prevented showing proper colors when it was an existing record. Also made the formatting more obvious for which section is active.

## How to Test

Publish a form with multiple sections and errors. Go back to the record, you should see all sections have appropriate errors visible. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
