### PR TITLE
fix addlinktoexisting config default value issue - now set to treu by…

### DIFF
--- a/app/src/gui/components/record/relationships/create_links/index.tsx
+++ b/app/src/gui/components/record/relationships/create_links/index.tsx
@@ -79,7 +79,7 @@ export default function CreateLinkComponent(
               />
             )}
 
-            {props.allowLinkToExisting !== false && (
+            {(props.allowLinkToExisting ?? true) && (
               <ExpandMoreButton
                 disableElevation
                 expand={expanded}
@@ -107,7 +107,7 @@ export default function CreateLinkComponent(
       </Grid>
       <Grid container spacing={2}>
         <Grid item xs={12}>
-          {props.allowLinkToExisting !== false && (
+          {(props.allowLinkToExisting ?? true) && (
             <Collapse in={expanded} timeout="auto" unmountOnExit sx={{mt: 1}}>
               <CreateRecordLink {...props} />
             </Collapse>

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -504,7 +504,7 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
             handleSubmit={() => props.form.submitForm()}
             save_new_record={save_new_record}
             handleCreateError={remove_related_child}
-            allowLinkToExisting={props.allowLinkToExisting ?? false}
+            allowLinkToExisting={props.allowLinkToExisting ?? true}
           />
         </Grid>
         {props.form.isValid === false && (

--- a/app/src/gui/pages/record-create.tsx
+++ b/app/src/gui/pages/record-create.tsx
@@ -166,8 +166,6 @@ function DraftRecordEdit(props: DraftRecordEditProps) {
   const [is_link_ready, setIs_link_ready] = useState(false);
   const [progress, setProgress] = useState(0);
 
-  console.log(parentLinks);
-
   const uiSpecId = useAppSelector(state =>
     selectProjectById(state, project_id)
   )?.uiSpecificationId;

--- a/designer/src/fields.tsx
+++ b/designer/src/fields.tsx
@@ -331,7 +331,7 @@ const fields: {[key: string]: FieldType} = {
       related_type: '',
       relation_type: 'faims-core::Child',
       multiple: false,
-      allowLinkToExisting: false,
+      allowLinkToExisting: true,
     },
     validationSchema: [['yup.string']],
     initialValue: '',


### PR DESCRIPTION

## JIRA Ticket

[BSS-964
](https://jira.csiro.au/browse/BSS-964

)## Description

Fixed the issue of default value of addlinktoexisting config value
Now you should have allowlinktoexisting set to true by default, should break anything for existing notebooks.
![image](https://github.com/user-attachments/assets/4ab728f5-22fd-49f6-ad87-8aac70423192)

![image](https://github.com/user-attachments/assets/a4c41bf7-0e69-414c-ba25-1fe8c4199fc5)


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
