### PR TITLE
Enable escaped formulas in CSV export

### DIFF
--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -882,7 +882,7 @@ export const streamNotebookRecordsAsCSV = async (
         Object.keys(outputData).forEach((key: string) => {
           columns.push(key);
         });
-        stringifier = stringify({columns, header: true});
+        stringifier = stringify({columns, header: true, escape_formulas: true});
         // pipe output to the respose
         stringifier.pipe(res);
         header_done = true;


### PR DESCRIPTION

# Enable escaped formulas in CSV export

## JIRA Ticket

[BSS-939](https://jira.csiro.com/browse/BSS-939)

## Description

Enables escaping formulas to avoid CSV injection attacks.

## How to Test

Enter data in a notebook cell starting with =, value should be quoted (\=) in csv export.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
