### PR TITLE
fix: cannot add child records when there are form errors

### DIFF
--- a/app/src/constants/routes.tsx
+++ b/app/src/constants/routes.tsx
@@ -46,64 +46,88 @@ export const HELP = '/help';
 export const CREATE_NEW_SURVEY = '/create-new-survey';
 export const USER_ACTIVE_TESTR = '/test';
 
-export function getRecordRoute(
-  serverId: string,
-  project_id: ProjectID,
-  record_id: RecordID,
-  revision_id: RevisionID
-) {
-  if (!!serverId && !!project_id && !!record_id && !!revision_id) {
+/**
+ * Generates a route to a record in the format
+ *
+ * @returns /surveys/<server>/<project>/records/<recordId>/revision/<revisionId>
+ */
+export function getExistingRecordRoute({
+  serverId,
+  projectId,
+  recordId,
+  revisionId,
+}: {
+  serverId: string;
+  projectId: ProjectID;
+  recordId: RecordID;
+  revisionId: RevisionID;
+}) {
+  if (!!serverId && !!projectId && !!recordId && !!revisionId) {
     return (
       INDIVIDUAL_NOTEBOOK_ROUTE +
       serverId +
       '/' +
-      project_id +
+      projectId +
       RECORD_EXISTING +
-      record_id +
+      recordId +
       REVISION +
-      revision_id
+      revisionId
     );
   }
+  console.error('Trying to create record route with missing details!');
+  console.error({serverId, projectId, recordId, revisionId});
   throw Error(
     'project_id, record_id and revision_id are required for this route'
   );
 }
 
-// this function is to get route for draft-- depend on edit draft or created draft??? TODO need to check created draft route
-export function getDraftRoute(
+/**
+ * Generates a route for a new draft
+ * @param serverId the server
+ * @param projectId the project
+ * @param draftId the ID of the draft - this is pre-seeded
+ * @param existingRecordInformation existing record? If provided instead returns the existing record route
+ * @param formId the ID of the form
+ * @param recordId the ID of the record
+ * @returns The route to navigate to
+ */
+export function getNewDraftRoute(
   serverId: string,
-  project_id: ProjectID,
-  draft_id: string,
-  existing: null | {record_id: RecordID; revision_id: RevisionID},
-  type_name: string,
-  record_id: string
+  projectId: ProjectID,
+  draftId: string,
+  existingRecordInformation: null | {
+    record_id: RecordID;
+    revision_id: RevisionID;
+  },
+  formId: string,
+  recordId: string
 ) {
-  if (existing !== null)
+  if (existingRecordInformation !== null)
     return (
       INDIVIDUAL_NOTEBOOK_ROUTE +
       serverId +
       '/' +
-      project_id +
+      projectId +
       RECORD_EXISTING +
       // existing+
-      existing.record_id +
+      existingRecordInformation.record_id +
       REVISION +
-      existing.revision_id +
+      existingRecordInformation.revision_id +
       RECORD_DRAFT +
-      draft_id
+      draftId
     );
   else {
     return (
       INDIVIDUAL_NOTEBOOK_ROUTE +
       serverId +
       '/' +
-      project_id +
+      projectId +
       RECORD_CREATE +
-      type_name +
+      formId +
       RECORD_DRAFT +
-      draft_id +
+      draftId +
       RECORD_RECORD +
-      record_id
+      recordId
     );
   }
 }

--- a/app/src/gui/components/notebook/add_record_by_type.tsx
+++ b/app/src/gui/components/notebook/add_record_by_type.tsx
@@ -67,12 +67,12 @@ export default function AddRecordButtons({
     /*  if we have selected a record (via QR scanning) then redirect to it here */
     return (
       <Navigate
-        to={ROUTES.getRecordRoute(
-          serverId,
-          projectId || 'dummy',
-          (selectedRecord.record_id || '').toString(),
-          (selectedRecord.revision_id || '').toString()
-        )}
+        to={ROUTES.getExistingRecordRoute({
+          serverId: serverId,
+          projectId: projectId || 'dummy',
+          recordId: (selectedRecord.record_id || '').toString(),
+          revisionId: (selectedRecord.revision_id || '').toString(),
+        })}
       />
     );
   } else {

--- a/app/src/gui/components/notebook/draft_table.tsx
+++ b/app/src/gui/components/notebook/draft_table.tsx
@@ -132,7 +132,7 @@ export function DraftsTable(props: DraftsRecordProps) {
    */
   const handleRowClick: GridEventListener<'rowClick'> = params => {
     history(
-      ROUTES.getDraftRoute(
+      ROUTES.getNewDraftRoute(
         serverId,
         project_id ?? 'dummy',
         params.row._id as DraftMetadata['_id'],

--- a/app/src/gui/components/notebook/overview_map.tsx
+++ b/app/src/gui/components/notebook/overview_map.tsx
@@ -219,12 +219,12 @@ export const OverviewMap = memo((props: OverviewMapProps) => {
           {selectedFeature && (
             <Box sx={{padding: '50px'}}>
               <Link
-                to={ROUTES.getRecordRoute(
-                  props.serverId,
-                  props.project_id || 'dummy',
-                  selectedFeature.record_id,
-                  selectedFeature.revision_id
-                )}
+                to={ROUTES.getExistingRecordRoute({
+                  serverId: props.serverId,
+                  projectId: props.project_id,
+                  recordId: selectedFeature.record_id,
+                  revisionId: selectedFeature.revision_id,
+                })}
               >
                 {selectedFeature.name}
               </Link>

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -795,12 +795,12 @@ export function RecordsTable(props: RecordsTableProps) {
   const handleRowClick = useCallback<GridEventListener<'rowClick'>>(
     params => {
       history(
-        ROUTES.getRecordRoute(
+        ROUTES.getExistingRecordRoute({
           serverId,
-          project_id || 'dummy',
-          (params.row.record_id || '').toString(),
-          (params.row.revision_id || '').toString()
-        )
+          projectId: project_id,
+          recordId: (params.row.record_id || '').toString(),
+          revisionId: (params.row.revision_id || '').toString(),
+        })
       );
     },
     [history, project_id]

--- a/app/src/gui/components/record/confirmExitDialog.tsx
+++ b/app/src/gui/components/record/confirmExitDialog.tsx
@@ -25,7 +25,6 @@ import {useEffect} from 'react';
 import {useNavigate} from 'react-router';
 import {CloseOptionType} from './formButton';
 
-
 /**
  * Confirm Exit dialog - checks that we really want to exit the current form
  * - backLink - the link we'll follow back to the parent record/record list
@@ -135,7 +134,6 @@ export const ConfirmExitDialog = ({
     </Dialog>
   );
 };
-
 
 /**
  * Confirm Cancel Dialog - checks that we really want to cancel out of the current form

--- a/app/src/gui/components/record/conflict/conflictfield.tsx
+++ b/app/src/gui/components/record/conflict/conflictfield.tsx
@@ -231,6 +231,7 @@ export function FieldWithAnnotation(props: FieldWithAnnotationProp) {
               fieldConfig,
               fieldName,
               formProps,
+              undefined,
               isSyncing,
               true
             )}

--- a/app/src/gui/components/record/fields.tsx
+++ b/app/src/gui/components/record/fields.tsx
@@ -18,15 +18,16 @@
  *   TODO
  */
 
-import React from 'react';
+import {RevisionID} from '@faims3/data-model';
 import {Field, FormikProps} from 'formik';
-
+import React from 'react';
 import {getComponentByName} from '../../component_registry';
 
 export function getComponentFromFieldConfig(
   fieldConfig: any,
   fieldName: string,
   formProps: FormikProps<{[key: string]: unknown}>,
+  forceSave?: () => Promise<RevisionID>,
   isSyncing = 'false',
   disabled = false
 ) {
@@ -63,6 +64,7 @@ export function getComponentFromFieldConfig(
         formProps.handleChange(event);
       }}
       disabled={disabled}
+      forceSave={forceSave}
     />
   ) : (
     <Field
@@ -81,6 +83,7 @@ export function getComponentFromFieldConfig(
       }}
       issyncing={isSyncing}
       disabled={disabled}
+      forceSave={forceSave}
     />
   );
 }

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1094,7 +1094,6 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
    * succeeding!
    */
   async forceSave(formProps: FormikProps<any>): Promise<RevisionID> {
-    console.error('FORCED');
     formProps.setSubmitting(true);
     // TODO improve type hacking!
     return (await this.save({

--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -1086,6 +1086,24 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
     );
   }
 
+  /**
+   * Bypasses the normal formik checks - passed down to related record selector
+   * to force a submission. Overrides the ambiguous save return type by type
+   * casting.
+   * @returns A revision ID as a promise - this is in the case of the save
+   * succeeding!
+   */
+  async forceSave(formProps: FormikProps<any>): Promise<RevisionID> {
+    console.error('FORCED');
+    formProps.setSubmitting(true);
+    // TODO improve type hacking!
+    return (await this.save({
+      values: formProps.values,
+      closeOption: 'continue',
+      setSubmitting: formProps.setSubmitting,
+    })) as RevisionID;
+  }
+
   private handleCancel(ui_specification: ProjectUIModel) {
     const relationState = this.props.location?.state;
     // first case is if we have a parent record, there should be
@@ -1131,7 +1149,7 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
    * Deal with the case where we are cancelling out of a form but the form
    * is a child record.  The parent will have been modified before we
    * started to add the child link, so we need to remove it.
-   * 
+   *
    * - relationState - the location state passed in to this route containing context info
    * - ui_specification - the current uiSpec
    */
@@ -1173,12 +1191,12 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
           upsertFAIMSData({dataDb, record: parentRecord}).then(revisionId => {
             // now parent link will be out of date as it refers to
             // the old revision so we need a new one
-            const revLink = ROUTES.getRecordRoute(
-              this.props.serverId,
-              this.props.project_id,
-              relationState.parent_record_id,
-              revisionId
-            );
+            const revLink = ROUTES.getExistingRecordRoute({
+              serverId: this.props.serverId,
+              projectId: this.props.project_id,
+              recordId: relationState.parent_record_id,
+              revisionId,
+            });
             this.navigateTo(revLink);
           });
         }
@@ -1423,12 +1441,12 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
               })
                 .then(new_revision_id => {
                   // update location state to point to the parent record
-                  locationState['parent_link'] = ROUTES.getRecordRoute(
-                    this.props.serverId,
-                    this.props.project_id,
-                    (locationState.parent_record_id || '').toString(),
-                    (new_revision_id || '').toString()
-                  );
+                  locationState['parent_link'] = ROUTES.getExistingRecordRoute({
+                    serverId: this.props.serverId,
+                    projectId: this.props.project_id,
+                    recordId: (locationState.parent_record_id || '').toString(),
+                    revisionId: (new_revision_id || '').toString(),
+                  });
                   // and add the reference ot the child record id
                   locationState['child_record_id'] = new_record_id;
                   // navigate to the page to create a new record with the updated state
@@ -1743,6 +1761,9 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
                                 currentStepId={this.state.view_cached ?? ''}
                                 isRevisiting={this.state.isRevisiting}
                                 handleSectionClick={this.handleSectionClick}
+                                forceSave={async () => {
+                                  return await this.forceSave(formProps);
+                                }}
                               />
                             </Form>
                           </div>
@@ -1870,6 +1891,9 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
                         currentStepId={this.state.view_cached ?? ''}
                         isRevisiting={this.state.isRevisiting}
                         handleSectionClick={this.handleSectionClick}
+                        forceSave={async () => {
+                          return await this.forceSave(formProps);
+                        }}
                       />
                       <FormButtonGroup
                         record_type={this.state.type_cached}

--- a/app/src/gui/components/record/formButton.tsx
+++ b/app/src/gui/components/record/formButton.tsx
@@ -21,20 +21,20 @@
  *  - Publish and Close Record(TBD)
  */
 
+import {ProjectUIModel} from '@faims3/data-model';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import {
   Box,
   Button,
-  Tooltip,
-  IconButton,
   Grid,
+  IconButton,
+  Tooltip,
   Typography,
 } from '@mui/material';
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import CircularProgress from '@mui/material/CircularProgress';
-import {CustomMobileStepper} from './recordStepper';
-import {ProjectUIModel} from '@faims3/data-model';
 import {useState} from 'react';
 import {ConfirmCancelDialog} from './confirmExitDialog';
+import {CustomMobileStepper} from './recordStepper';
 
 interface FormProps {
   isSubmitting: boolean;
@@ -142,7 +142,6 @@ export default function FormButtonGroup({
   formProps,
   handleFormSubmit,
   visitedSteps,
-  isRecordSubmitted,
   views,
   ui_specification,
   layout,

--- a/app/src/gui/components/record/recordStepper.tsx
+++ b/app/src/gui/components/record/recordStepper.tsx
@@ -166,10 +166,9 @@ export default function RecordStepper(props: RecordStepperProps) {
                         fontWeight: 'bold',
                         width: '26px',
                         height: '26px',
-                        boxShadow:
-                          isCurrent
-                            ? '0px 4px 12px rgba(0, 0, 0, 0.3)'
-                            : '0px 2px 4px rgba(0, 0, 0, 0.15)',
+                        boxShadow: isCurrent
+                          ? '0px 4px 12px rgba(0, 0, 0, 0.3)'
+                          : '0px 2px 4px rgba(0, 0, 0, 0.15)',
                         transition: 'all 0.3s ease-in-out',
                         zIndex: 10,
                       },

--- a/app/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/app/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -78,12 +78,12 @@ export async function generateLocationState(
       location_state: {
         field_id: parentLink.field_id,
         parent: latest_record?.relationship?.parent,
-        parent_link: ROUTES.getRecordRoute(
+        parent_link: ROUTES.getExistingRecordRoute({
           serverId,
-          project_id,
-          parentLink.record_id,
-          revision_id
-        ),
+          projectId: project_id,
+          recordId: parentLink.record_id,
+          revisionId: revision_id,
+        }),
         parent_record_id: parentLink.record_id,
         type: 'Child',
         // relation_type_vocabPair: relationship.parent.relation_type_vocabPair,
@@ -540,12 +540,12 @@ async function get_field_RelatedFields(
             latest_record?.updated_by ?? '',
             latest_record?.updated
           ),
-          ROUTES.getRecordRoute(
+          ROUTES.getExistingRecordRoute({
             serverId,
-            child_record.project_id,
-            child_record.record_id,
-            revision_id
-          ),
+            projectId: child_record.project_id,
+            recordId: child_record.record_id,
+            revisionId: revision_id,
+          }),
           linked_vocab,
           record_id,
           hrid,
@@ -555,12 +555,12 @@ async function get_field_RelatedFields(
           section_label,
           field,
           field_name,
-          ROUTES.getRecordRoute(
+          ROUTES.getExistingRecordRoute({
             serverId,
-            child_record?.project_id,
-            record_id,
-            current_revision_id
-          ),
+            projectId: child_record?.project_id,
+            recordId: record_id,
+            revisionId: current_revision_id,
+          }),
           relation_type,
           latest_record?.deleted ?? false,
           is_deleted
@@ -651,12 +651,12 @@ export async function addLinkedRecord(
         ),
         latest_record?.deleted === true
           ? ''
-          : ROUTES.getRecordRoute(
+          : ROUTES.getExistingRecordRoute({
               serverId,
-              child_record.project_id,
-              child_record.record_id,
-              current_revision_id
-            ),
+              projectId: child_record.project_id,
+              recordId: child_record.record_id,
+              revisionId: current_revision_id,
+            }),
         linked_vocab,
         parent_link.record_id,
         hrid,
@@ -668,12 +668,12 @@ export async function addLinkedRecord(
         field_name,
         latest_record?.deleted === true
           ? ''
-          : ROUTES.getRecordRoute(
+          : ROUTES.getExistingRecordRoute({
               serverId,
-              child_record.project_id,
-              parent_link.record_id,
-              revision_id
-            ),
+              projectId: child_record.project_id,
+              recordId: parent_link.record_id,
+              revisionId: revision_id,
+            }),
         has_parent === true && index === '0' ? 'Child' : 'Linked',
         false,
         is_parent_deleted
@@ -797,12 +797,12 @@ export async function getParentPersistenceData({
           section: '',
           field_id: parent.parent.field_id,
           field_label: parent.parent.field_id,
-          route: ROUTES.getRecordRoute(
+          route: ROUTES.getExistingRecordRoute({
             serverId,
             projectId,
-            parent.parent.record_id,
-            revision_id
-          ),
+            recordId: parent.parent.record_id,
+            revisionId: revision_id,
+          }),
           children: [],
           deleted: latest_record?.deleted,
         },

--- a/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
+++ b/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
@@ -29,7 +29,7 @@ export function AddNewRecordButton(props: {
   pathname: string;
   state: LocationState;
   text: string;
-  handleSubmit: Function;
+  handleSubmit: () => Promise<RevisionID>;
   project_id: string;
   serverId: string;
   save_new_record: Function;
@@ -47,12 +47,12 @@ export function AddNewRecordButton(props: {
         .handleSubmit()
         .then((revisionID: RevisionID) => {
           const newState = props.state;
-          newState['parent_link'] = ROUTES.getRecordRoute(
-            props.serverId,
-            props.project_id,
-            (props.state.parent_record_id || '').toString(),
-            (revisionID || '').toString()
-          );
+          newState['parent_link'] = ROUTES.getExistingRecordRoute({
+            serverId: props.serverId,
+            projectId: props.project_id,
+            recordId: (props.state.parent_record_id || '').toString(),
+            revisionId: (revisionID || '').toString(),
+          });
           newState['child_record_id'] = childRecordId;
           // wait for 300ms and then jump to the new pathname with the new state
           setTimeout(() => {
@@ -273,6 +273,7 @@ export function CreateRecordLink(props: CreateRecordLinkProps) {
                     pathname={props.pathname}
                     state={props.state}
                     text={'Add Record'}
+                    // This is just form submit - which saves the record
                     handleSubmit={props.handleSubmit}
                     project_id={props.project_id}
                     save_new_record={props.save_new_record}

--- a/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
+++ b/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
@@ -37,6 +37,7 @@ export function AddNewRecordButton(props: {
 }) {
   const [submitting, setSubmitting] = React.useState(false);
   const history = useNavigate();
+  const dispatch = useAppDispatch();
   const handleSubmit = () => {
     setSubmitting(true);
     // here we make a new record id for the child and populate the form with the
@@ -63,6 +64,14 @@ export function AddNewRecordButton(props: {
         })
         .catch((error: Error) => {
           logError(error);
+          dispatch(
+            addAlert({
+              message: 'Error saving this record before adding a link.',
+              severity: 'error',
+            })
+          );
+          // so that the display resets and we don't have a spinner
+          setSubmitting(false);
           if (props.handleError !== undefined)
             props.handleError(childRecordId, childRecordId);
         });

--- a/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -39,7 +39,7 @@ import {
   GridRowParams,
 } from '@mui/x-data-grid';
 import React, {useEffect, useState} from 'react';
-import {getRecordRoute} from '../../../../../constants/routes';
+import {getExistingRecordRoute} from '../../../../../constants/routes';
 import {selectProjectById} from '../../../../../context/slices/projectSlice';
 import {useAppSelector} from '../../../../../context/store';
 import {
@@ -217,12 +217,12 @@ export function DataGridFieldLinksComponent(
       fn();
     }, [props.child_record]);
 
-    const route = getRecordRoute(
-      props.serverId,
-      props.child_record.project_id,
-      props.child_record.record_id,
-      props.child_record.revision_id
-    );
+    const route = getExistingRecordRoute({
+      serverId: props.serverId,
+      projectId: props.child_record.project_id,
+      recordId: props.child_record.record_id,
+      revisionId: props.child_record.revision_id,
+    });
 
     if (props.child_record.record_id === props.current_record_id) {
       return <RecordRouteDisplay>This record</RecordRouteDisplay>;

--- a/app/src/gui/components/record/relationships/parent_form.tsx
+++ b/app/src/gui/components/record/relationships/parent_form.tsx
@@ -69,6 +69,10 @@ export default function ParentForm(props: ParentFormProps) {
               isRevisiting={false}
               handleSectionClick={() => {}}
               handleChangeTab={() => {}}
+              // FAKE
+              forceSave={async () => {
+                return '';
+              }}
             />
           </Form>
         );

--- a/app/src/gui/components/record/relationships/parent_panel.tsx
+++ b/app/src/gui/components/record/relationships/parent_panel.tsx
@@ -123,6 +123,10 @@ function ParentForm(props: ParentFormProps) {
               isRevisiting={false}
               handleSectionClick={() => {}}
               handleChangeTab={() => {}}
+              // FAKE
+              forceSave={async () => {
+                return '';
+              }}
             />
           </Form>
         );

--- a/app/src/gui/components/record/relationships/types.tsx
+++ b/app/src/gui/components/record/relationships/types.tsx
@@ -1,6 +1,11 @@
 import React, {Dispatch, SetStateAction} from 'react';
 
-import {RecordID, RecordReference, ProjectID, RevisionID} from '@faims3/data-model';
+import {
+  RecordID,
+  RecordReference,
+  ProjectID,
+  RevisionID,
+} from '@faims3/data-model';
 import {SelectChangeEvent} from '@mui/material';
 export interface TabPanelProps {
   children?: React.ReactNode;

--- a/app/src/gui/components/record/relationships/types.tsx
+++ b/app/src/gui/components/record/relationships/types.tsx
@@ -1,6 +1,6 @@
 import React, {Dispatch, SetStateAction} from 'react';
 
-import {RecordID, RecordReference, ProjectID} from '@faims3/data-model';
+import {RecordID, RecordReference, ProjectID, RevisionID} from '@faims3/data-model';
 import {SelectChangeEvent} from '@mui/material';
 export interface TabPanelProps {
   children?: React.ReactNode;
@@ -126,7 +126,7 @@ export interface CreateRecordLinkProps {
   handleChange: (e: SelectChangeEvent) => void;
   SetSelectedRecord: Dispatch<SetStateAction<RecordReference | null>>;
   add_related_child?: () => void;
-  handleSubmit: () => void;
+  handleSubmit: () => Promise<RevisionID>;
   save_new_record: () => void;
   handleCreateError: (id: any, hrid: any) => Promise<any>;
 }

--- a/app/src/gui/components/record/view.tsx
+++ b/app/src/gui/components/record/view.tsx
@@ -19,7 +19,7 @@
  *   20220620 BBS Adjusted sm to 11 from 8 to get rid of the awful margin reported in FAIMS3-328
  */
 
-import {ProjectUIModel} from '@faims3/data-model';
+import {ProjectUIModel, RevisionID} from '@faims3/data-model';
 import NoteIcon from '@mui/icons-material/Note';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import {
@@ -61,6 +61,7 @@ type ViewProps = {
   currentStepId: string;
   isRevisiting: boolean;
   handleSectionClick: (section: string) => void;
+  forceSave: () => Promise<RevisionID>;
 };
 type SingleComponentProps = {
   fieldName: string;
@@ -74,6 +75,7 @@ type SingleComponentProps = {
   handleChangeTab?: any;
   isSyncing?: string;
   disabled?: boolean; // add for view tab or edit tab
+  forceSave: () => Promise<RevisionID>;
 };
 
 /**
@@ -169,6 +171,7 @@ function SingleComponent(props: SingleComponentProps) {
             fields[fieldName],
             fieldName,
             props.formProps,
+            props.forceSave,
             props.isSyncing,
             props.disabled
           )}
@@ -297,6 +300,7 @@ export function ViewComponent(props: ViewProps) {
           conflictfields={props.conflictfields}
           handleChangeTab={props.handleChangeTab}
           disabled={props.disabled}
+          forceSave={props.forceSave}
         />
       ))}
 

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -131,8 +131,8 @@ export default function NoteBooks() {
             }}
           >
             {row.name ??
-            // Just as a backwards compat thing, consider looking for name in
-            // metadata
+              // Just as a backwards compat thing, consider looking for name in
+              // metadata
               row.metadata.name ??
               'Unknown ' + NOTEBOOK_NAME_CAPITALIZED}
           </Typography>

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -25,6 +25,7 @@ import {
   getPossibleRelatedRecords,
   RecordMetadata,
   RecordReference,
+  RevisionID,
 } from '@faims3/data-model';
 import {Grid, SelectChangeEvent, Typography} from '@mui/material';
 import {FieldProps} from 'formik';
@@ -134,13 +135,17 @@ interface RelatedRecordSelectorProps extends FieldProps {
   current_form_label?: string;
   isconflict?: boolean;
   allowLinkToExisting?: boolean;
+
+  // This is actually passed to all components - but we only need it here
+  // currently
+  forceSave: () => Promise<RevisionID>;
 }
 
 export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
   const activeToken = useAppSelector(selectActiveToken)!.parsedToken;
-  const project_id = props.form.values['_project_id'] as string;
-  const serverId = props.form.values['_server_id'] as string;
-  const record_id = props.form.values['_id'];
+  const project_id: string = props.form.values['_project_id'];
+  const serverId: string = props.form.values['_server_id'];
+  const record_id: string = props.form.values['_id'];
   const field_name = props.field.name;
   const uiSpecId = useAppSelector(selectAllProjects).find(
     p => p.projectId === project_id
@@ -288,6 +293,7 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
     parent: {},
     relation_type_vocabPair: relationshipPair, //pass the value of vocalPair
   };
+
   const disabled = props.disabled ?? false;
   const location_state: any = location.state;
   if (location_state !== undefined && location_state !== null) {
@@ -505,7 +511,7 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
               props.related_type
             }
             state={newState}
-            handleSubmit={() => props.form.submitForm()}
+            handleSubmit={props.forceSave}
             save_new_record={save_new_record}
             handleCreateError={remove_related_child}
             allowLinkToExisting={props.allowLinkToExisting ?? true}

--- a/app/src/gui/fields/maps/MapWrapper.tsx
+++ b/app/src/gui/fields/maps/MapWrapper.tsx
@@ -196,7 +196,7 @@ function MapWrapper(props: MapProps) {
           }
         });
 
-        map.updateSize(); 
+        map.updateSize();
         map.getView().setZoom(props.zoom || 17);
       }
     }, 300);

--- a/app/src/utils/generateStepperColors.tsx
+++ b/app/src/utils/generateStepperColors.tsx
@@ -19,7 +19,7 @@ export const getStepColor = (
   sectionId: string,
   currentStepId: string,
   hasError: boolean,
-  visitedSteps: Set<string>,
+  visitedSteps: Set<string>
 ): string => {
   const colors = theme.stepperColors;
   if (sectionId === currentStepId) return colors.current; // Current step color

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faims3",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faims3",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -39,7 +39,7 @@
     },
     "api": {
       "name": "@faims3/api",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@faims3/data-model": "*",
         "archiver": "^6.0.1",
@@ -136,7 +136,7 @@
     },
     "app": {
       "name": "@faims3/app",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@bugsnag/js": "^7.20.2",
         "@bugsnag/plugin-react": "^7.19.0",
@@ -745,7 +745,7 @@
     },
     "designer": {
       "name": "@faims3/designer",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -1860,7 +1860,7 @@
     },
     "library/data-model": {
       "name": "@faims3/data-model",
-      "version": "1.1.6",
+      "version": "1.2.0",
       "license": "Apache",
       "dependencies": {
         "@demvsystems/yup-ast": "^1.2.2",
@@ -57480,7 +57480,7 @@
       }
     },
     "web": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@faims3/data-model": "*",
         "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
This is due to formik refusing to run onSubmit when there are form errors. The RelatedRecordSelector relied on this behaviour (hence probably why old FAIMS folk instead chose to **sneakily** disable adding a child record until all errors are gone - good one!!). Instead we pass through 'forceSave' which bypasses this check. Very gross approach but it's the smallest intervention to fix the problem.