### PR TITLE
Add a log of failed cache URLs to map component

### DIFF
--- a/app/src/gui/components/map/map-component.tsx
+++ b/app/src/gui/components/map/map-component.tsx
@@ -37,7 +37,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useIsOnline} from '../../../utils/customHooks';
 import {getCoordinates, useCurrentLocation} from '../../../utils/useLocation';
 import {createCenterControl} from '../map/center-control';
-import {VectorTileStore} from './tile-source';
+import {failedURLs, VectorTileStore} from './tile-source';
 import Feature from 'ol/Feature';
 import {Point} from 'ol/geom';
 import CircleStyle from 'ol/style/Circle';
@@ -345,6 +345,14 @@ export const MapComponent = (props: MapComponentProps) => {
                 <p dangerouslySetInnerHTML={{__html: attribution}} />
               )}
             </Box>
+            {failedURLs.size > 0 && (
+              <details>
+                <summary>Style Cache Misses</summary>
+                {Array.from(failedURLs).map((url, i) => (
+                  <p key={i}>{url}</p>
+                ))}
+              </details>
+            )}
           </Box>
         )}
       </Grid>

--- a/app/src/gui/components/map/tile-source.ts
+++ b/app/src/gui/components/map/tile-source.ts
@@ -35,6 +35,7 @@ import VectorTile from 'ol/VectorTile';
 import {MAP_SOURCE, MAP_SOURCE_KEY, MAP_STYLE} from '../../../buildconfig';
 import {IDBObjectStore} from './IDBObjectStore';
 import {getMapStylesheet} from './styles';
+import {logError} from '../../../logging';
 
 // When downloading maps we start at this zoom level
 const START_ZOOM = 2;
@@ -568,6 +569,10 @@ export class ImageTileStore extends TileStoreBase {
 
 // A vector tile source
 
+// For debugging the map style problem we'll keep track of any failed
+// URL requests from map styling.
+export const failedURLs = new Set<string>();
+
 export class VectorTileStore extends TileStoreBase {
   declare source: VectorTileSource;
   declare tileLayer: VectorTileLayer;
@@ -616,7 +621,8 @@ export class VectorTileStore extends TileStoreBase {
       Object.defineProperty(response, 'url', {value: fullURL});
       return response;
     } else {
-      console.error('transformRequest fail', fullURL);
+      logError(`transformRequest fail: ${fullURL}`);
+      failedURLs.add(fullURL);
       return fullURL;
     }
   }


### PR DESCRIPTION
# Add a log of failed cache URLs to map component

## JIRA Ticket

None

## Description

Logs failed map style cache hits and shows them in the UI to help debugging blue line maps.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
