### PR TITLE
advanced helper text update

### DIFF
--- a/designer/src/components/Fields/BaseFieldEditor.tsx
+++ b/designer/src/components/Fields/BaseFieldEditor.tsx
@@ -29,7 +29,7 @@ import {
   Typography,
 } from '@mui/material';
 import {debounce} from 'lodash';
-import {useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {VITE_TEMPLATE_PROTECTIONS} from '../../buildconfig';
 import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {FieldType} from '../../state/initial';
@@ -109,11 +109,18 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
     allowHiding: allowHidingEnabled,
   };
 
-  const hasAdvancedSupport = 'advancedHelperText' in cParams;
+  // const hasAdvancedSupport =
+  //   'advancedHelperText' in field['component-parameters'] ||
+  //   typeof field['component-parameters'].advancedHelperText === 'string';
 
-  const [showAdvanced, setShowAdvanced] = useState(
-    hasAdvancedSupport && !!cParams.advancedHelperText
-  );
+  const hasAdvancedSupport =
+    Object.prototype.hasOwnProperty.call(
+      field['component-parameters'],
+      'advancedHelperText'
+    ) || typeof field['component-parameters'].advancedHelperText === 'string';
+
+  const showAdvanced = !!state.advancedHelperText?.trim();
+
   const [expanded, setExpanded] = useState(true);
 
   const updateFieldFromState = (newState: StateType) => {
@@ -195,8 +202,9 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
                         <Checkbox
                           checked={showAdvanced}
                           onChange={e => {
-                            setShowAdvanced(e.target.checked);
                             if (!e.target.checked) {
+                              updateProperty('advancedHelperText', '');
+                            } else {
                               updateProperty('advancedHelperText', '');
                             }
                           }}

--- a/designer/src/components/Fields/BaseFieldEditor.tsx
+++ b/designer/src/components/Fields/BaseFieldEditor.tsx
@@ -29,7 +29,7 @@ import {
   Typography,
 } from '@mui/material';
 import {debounce} from 'lodash';
-import {useEffect, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import {VITE_TEMPLATE_PROTECTIONS} from '../../buildconfig';
 import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {FieldType} from '../../state/initial';


### PR DESCRIPTION
# feat/fix/chore: pr title

## JIRA Ticket

[<JIRA_TICKET>](https://jira.csiro.com/browse/<JIRA_TICKET>)

## Description

Briefly describe the purpose of this pull request.

## Proposed Changes

Removed useState for showAdvanced
Previously, the checkbox visibility (showAdvanced) was controlled via useState, but this only evaluated once on component mount and did not sync with Redux field updates. This caused the checkbox to not appear unless the user typed in the helper text box, also simplified onchange logic,
Replaced useState with derived boolean from field state
Now, showAdvanced is computed directly

## How to Test

- Just upload a new survey json and see if the advanced helper text checkbox is displaying well and if you check it, it should show the rich text editor and allow you to write stuff in it in a smooth manner as expected.


## Checklist

- [x] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
