### PR TITLE
 Fix Autoincrementer settings buttons

### DIFF
--- a/app/src/gui/components/notebook/settings/auto_incrementers.tsx
+++ b/app/src/gui/components/notebook/settings/auto_incrementers.tsx
@@ -14,7 +14,6 @@ interface AutoIncrementerSettingsListProps {
 export default function AutoIncrementerSettingsList(
   props: AutoIncrementerSettingsListProps
 ) {
-  const [open, setOpen] = useState(false);
   const [references, setReferences] = useState([] as AutoIncrementReference[]);
   useEffect(() => {
     getAutoincrementReferencesForProject(props.project.projectId)
@@ -52,25 +51,12 @@ export default function AutoIncrementerSettingsList(
                   'autoincrementer_range_' + ai.form_id + ai.field_id + ai.label
                 }
               >
-                <Box mt={1}>
-                  <AutoIncrementEditForm
-                    project_id={props.project.projectId}
-                    form_id={ai.form_id}
-                    field_id={ai.field_id}
-                    label={label}
-                    open={open}
-                    handleClose={() => setOpen(false)}
-                  />
-                  <Button
-                    variant="outlined"
-                    color={'primary'}
-                    onClick={() => {
-                      setOpen(true);
-                    }}
-                  >
-                    {label}
-                  </Button>
-                </Box>
+                <AutoIncrementerButton
+                  project={props.project}
+                  form_id={ai.form_id}
+                  field_id={ai.field_id}
+                  label={label}
+                />
               </Grid>
             );
           })}
@@ -79,3 +65,36 @@ export default function AutoIncrementerSettingsList(
     </>
   );
 }
+
+interface AutoIncrementerButtonProps {
+  project: Project;
+  form_id: string;
+  field_id: string;
+  label: string;
+}
+
+const AutoIncrementerButton = (props: AutoIncrementerButtonProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box mt={1}>
+      <AutoIncrementEditForm
+        project_id={props.project.projectId}
+        form_id={props.form_id}
+        field_id={props.field_id}
+        label={props.label}
+        open={open}
+        handleClose={() => setOpen(false)}
+      />
+      <Button
+        variant="outlined"
+        color={'primary'}
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        {props.label}
+      </Button>
+    </Box>
+  );
+};


### PR DESCRIPTION

# Fix Autoincrementer settings buttons

## JIRA Ticket

None

## Description

When there is more than one auto incrementer field in a notebook, the settings button opened all
settings dialogs at once so only the last auto incrementer could be changed.

This PR fixes this by factoring out the button open/close status to a separate component.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
