### PR TITLE
Control Centre Theming

### DIFF
--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -49,3 +49,8 @@ if test -f icons/icon-48.webp; then
   mkdir -p ./public/assets
   mv icons ./public/assets/icons
 fi
+
+## copy the icons over to web/ as well
+rm -rf ../web/public/assets/icons
+mkdir -p ../web/public/assets/
+cp -r ./public/assets/icons ../web/public/assets/icons

--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -50,7 +50,9 @@ if test -f icons/icon-48.webp; then
   mv icons ./public/assets/icons
 fi
 
-## copy the icons over to web/ as well
-rm -rf ../web/public/assets/icons
-mkdir -p ../web/public/assets/
-cp -r ./public/assets/icons ../web/public/assets/icons
+## copy the icons over to web/ as well (check they exist first)
+if test -f ./public/assets/icons/icon-48.webp; then
+  rm -rf ../web/public/assets/icons
+  mkdir -p ../web/public/assets/
+  cp -r ./public/assets/icons ../web/public/assets/icons
+fi

--- a/web/.env.dist
+++ b/web/.env.dist
@@ -3,3 +3,4 @@ VITE_APP_URL=http://localhost:3000
 VITE_API_URL=http://localhost:8080
 VITE_NOTEBOOK_NAME="project"
 VITE_WEBSITE_TITLE="Control Centre"
+VITE_THEME=bssTheme # or default

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -16,3 +16,6 @@ dist/
 .vscode/*
 !.vscode/extensions.json
 .idea
+
+# generated assets
+public

--- a/web/src/components/logo.tsx
+++ b/web/src/components/logo.tsx
@@ -1,5 +1,5 @@
+import {APP_NAME, WEBSITE_TITLE} from '@/constants';
 import {cn} from '@/lib/utils';
-import {Flame} from 'lucide-react';
 
 /**
  * Logo component renders a logo with the BSS name and version.
@@ -10,17 +10,12 @@ import {Flame} from 'lucide-react';
 export default function Logo({className}: {className?: string}) {
   return (
     <div className="flex gap-2">
-      <div
-        className={cn(
-          'flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground',
-          className
-        )}
-      >
-        <Flame className="size-4" />
+      <div>
+        <img src="/assets/icons/icon-48.webp" />
       </div>
-      <div className="grid flex-1 text-left text-sm leading-tight">
-        <span className="truncate font-semibold">BSS</span>
-        <span className="truncate text-xs">Bushfire Surveyor System</span>
+      <div className="flex flex-col text-left text-sm leading-none">
+        <span className="truncate font-semibold">{APP_NAME}</span>
+        <span className="truncate text-xs">{WEBSITE_TITLE}</span>
       </div>
     </div>
   );

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,27 +1,22 @@
 import {capitalize} from './lib/utils';
 
-export const NOTEBOOK_NAME = import.meta.env.VITE_NOTEBOOK_NAME || 'project';
 
+const getConfigValue = (key: string) => {
+  const value = (import.meta.env[key] as string | undefined) ?? '';
+  if (value === '') {
+    throw new Error(`Missing required env variable ${key}`);
+  }
+  return value;
+};
+
+export const NOTEBOOK_NAME = import.meta.env.VITE_NOTEBOOK_NAME || 'project';
 export const WEBSITE_TITLE =
   import.meta.env.VITE_WEBSITE_TITLE || 'Control Centre';
-
-export const WEB_URL =
-  (import.meta.env.VITE_WEB_URL as string | undefined) ?? '';
-if (WEB_URL === '') {
-  throw new Error('Missing required env variable VITE_WEB_URL');
-}
-
-export const API_URL =
-  (import.meta.env.VITE_API_URL as string | undefined) ?? '';
-if (API_URL === '') {
-  throw new Error('Missing required env variable VITE_API_URL');
-}
-
-export const APP_URL =
-  (import.meta.env.VITE_APP_URL as string | undefined) ?? '';
-if (APP_URL === '') {
-  throw new Error('Missing required env variable VITE_APP_URL');
-}
+export const APP_NAME = getConfigValue('VITE_APP_NAME');
+export const WEB_URL = getConfigValue('VITE_WEB_URL');
+export const API_URL = getConfigValue('VITE_API_URL');
+export const APP_URL = getConfigValue('VITE_APP_URL');
+export const APP_THEME = import.meta.env.VITE_APP_THEME || 'default';
 
 export const NOTEBOOK_NAME_CAPITALIZED = import.meta.env.VITE_NOTEBOOK_NAME
   ? capitalize(import.meta.env.VITE_NOTEBOOK_NAME)

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -54,11 +54,6 @@
     --secondary-foreground: 0 0% 98%;
   }
 
-  .theme-red {
-    --primary: 0 84% 60%;
-    --primary-foreground: 0 0% 98%;
-  }
-
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -14,10 +14,6 @@
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
@@ -41,6 +37,26 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%
+  }
+
+  :root,
+  :theme-default {
+    --primary: 83 80% 22%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+  }
+
+  .theme-bss {
+    --primary: 0 100% 0%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 173 58% 39%;
+    --secondary-foreground: 0 0% 98%;
+  }
+
+  .theme-red {
+    --primary: 0 84% 60%;
+    --primary-foreground: 0 0% 98%;
   }
 
   .dark {

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,13 @@
+export const THEME = import.meta.env.VITE_THEME || 'default';
+
+export const getThemeClass = () => {
+  switch (THEME) {
+    case 'bssTheme':
+      return 'theme-bss';
+    case 'red':
+      return 'theme-red';
+    case 'default':
+    default:
+      return 'theme-default';
+  }
+};

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -4,8 +4,6 @@ export const getThemeClass = () => {
   switch (THEME) {
     case 'bssTheme':
       return 'theme-bss';
-    case 'red':
-      return 'theme-red';
     case 'default':
     default:
       return 'theme-default';

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,6 +9,7 @@ import {AuthProvider, useAuth} from './context/auth-provider';
 import {BreadcrumbProvider} from './context/breadcrumb-provider';
 import './index.css';
 import {routeTree} from './routeTree.gen';
+import {getThemeClass} from './lib/theme';
 /**
  * App component renders the main application layout.
  * It includes the main navigation and the main content.
@@ -41,6 +42,7 @@ function App() {
   // Set the website title
   useEffect(() => {
     document.title = WEBSITE_TITLE ?? 'Control Centre';
+    document.documentElement.className = getThemeClass();
   }, []);
 
   return <RouterProvider router={router} context={{auth}} />;


### PR DESCRIPTION
# Control Centre Theming

## JIRA Ticket

[1516](https://github.com/FAIMS/FAIMS3/issues/1516)

## Description

Add theming for the control centre app.

## Proposed Changes

Theming selected by the same setting as the app, VITE_THEME is default (Fieldmark) or bssTheme.  

Currently minimal theming since there isn't much styling in the app.

## How to Test

Configure with:

VITE_THEME=bssTheme
VITE_THEME=default

Run build from the top level to generate the icon assets in the web folder.  Then run the control centre to see the new theme.  

BSS theme is the same but uses the same icon as the app.   Default theme uses the Fieldmark icon.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
