### PR TITLE
Include annotation and uncertainty in csv export where enabled

### DIFF
--- a/api/notebooks/sample_notebook.json
+++ b/api/notebooks/sample_notebook.json
@@ -2,7 +2,11 @@
   "metadata": {
     "project_status": "New",
     "test_key": "test_value",
-    "accesses": ["admin", "moderator", "team"],
+    "accesses": [
+      "admin",
+      "moderator",
+      "team"
+    ],
     "forms": {
       "FORM1": {
         "submitActionFORM1": "Save and New",
@@ -26,12 +30,17 @@
         "visibleFORM3": true
       }
     },
-    "sections": {},
     "meta": {},
     "access": {
-      "accessFORM1": ["admin"],
-      "accessFORM2": ["admin"],
-      "accessFORM3": ["admin"]
+      "accessFORM1": [
+        "admin"
+      ],
+      "accessFORM2": [
+        "admin"
+      ],
+      "accessFORM3": [
+        "admin"
+      ]
     },
     "ispublic": false,
     "isrequest": false,
@@ -56,15 +65,36 @@
           "id": "take-photo",
           "helperText": "Take a photo",
           "variant": "outlined",
-          "label": "Take Photo",
-          "helpertext": "Take an overview photo"
+          "label": "Take Photo"
         },
-        "validationSchema": [["yup.object"], ["yup.nullable"]],
+        "validationSchema": [
+          [
+            "yup.array"
+          ],
+          [
+            "yup.of",
+            [
+              [
+                "yup.object"
+              ],
+              [
+                "yup.nullable"
+              ]
+            ]
+          ],
+          [
+            "yup.nullable"
+          ]
+        ],
         "initialValue": null,
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -83,12 +113,23 @@
           "variant": "outlined",
           "label": "Take GPS Point"
         },
-        "validationSchema": [["yup.object"], ["yup.nullable"]],
+        "validationSchema": [
+          [
+            "yup.object"
+          ],
+          [
+            "yup.nullable"
+          ]
+        ],
         "initialValue": null,
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -135,18 +176,24 @@
               }
             ]
           },
-          "InputLabelProps": {
-            "label": "Feature Type"
-          },
           "id": "feature-type",
-          "name": "feature-type"
+          "name": "feature-type",
+          "label": "Feature Type"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -168,19 +215,24 @@
             "rows": 4
           },
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Feature Description"
-          },
-          "FormHelperTextProps": {},
           "id": "feature-description",
-          "name": "feature-description"
+          "name": "feature-description",
+          "label": "Feature Description"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -203,19 +255,24 @@
           },
           "multiple": true,
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Artefacts"
-          },
-          "FormHelperTextProps": {},
           "id": "artefacts",
-          "name": "artefacts"
+          "name": "artefacts",
+          "label": "Artefacts"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": [],
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -238,19 +295,24 @@
           },
           "multiple": false,
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Measurements"
-          },
-          "FormHelperTextProps": {},
           "id": "measurements",
-          "name": "measurements"
+          "name": "measurements",
+          "label": "Measurements"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -313,18 +375,27 @@
               }
             ]
           },
-          "InputLabelProps": {
-            "label": "Dimension"
-          },
           "id": "dimension",
-          "name": "dimension"
+          "name": "dimension",
+          "label": "Dimension"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": true,
             "label": "uncertainty"
@@ -344,19 +415,28 @@
             "type": "number"
           },
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Measurement"
-          },
-          "FormHelperTextProps": {},
           "id": "measurement",
-          "name": "measurement"
+          "name": "measurement",
+          "label": "Measurement"
         },
-        "validationSchema": [["yup.number"], ["yup.min", 1]],
+        "validationSchema": [
+          [
+            "yup.number"
+          ],
+          [
+            "yup.min",
+            1
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -403,18 +483,24 @@
               }
             ]
           },
-          "InputLabelProps": {
-            "label": "Material"
-          },
           "id": "material",
-          "name": "material"
+          "name": "material",
+          "label": "Material"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -433,12 +519,34 @@
           "variant": "outlined",
           "label": "Take Photo"
         },
-        "validationSchema": [["yup.object"], ["yup.nullable"]],
+        "validationSchema": [
+          [
+            "yup.array"
+          ],
+          [
+            "yup.of",
+            [
+              [
+                "yup.object"
+              ],
+              [
+                "yup.nullable"
+              ]
+            ]
+          ],
+          [
+            "yup.nullable"
+          ]
+        ],
         "initialValue": null,
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -461,20 +569,28 @@
             "type": "text",
             "readOnly": true
           },
-          "InputLabelProps": {
-            "label": "ArtefactID"
-          },
-          "hrid": true,
           "fieldselect10": "html-text",
           "numberfield": 2,
-          "fieldselect11": "artefactid-counter"
+          "fieldselect11": "artefactid-counter",
+          "label": "ArtefactID"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -497,21 +613,29 @@
             "type": "text",
             "readOnly": true
           },
-          "InputLabelProps": {
-            "label": "ArtefactID"
-          },
-          "hrid": true,
           "linked": "artefactid",
           "fieldselect10": "html-text",
           "numberfield": 2,
-          "fieldselect11": "artefactid-counter"
+          "fieldselect11": "artefactid-counter",
+          "label": "ArtefactID"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -533,19 +657,24 @@
             "rows": 4
           },
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Interpretation"
-          },
-          "FormHelperTextProps": {},
           "id": "interpretation",
-          "name": "interpretation"
+          "name": "interpretation",
+          "label": "Interpretation"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -567,19 +696,24 @@
             "rows": 4
           },
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Comments"
-          },
-          "FormHelperTextProps": {},
           "id": "comments",
-          "name": "comments"
+          "name": "comments",
+          "label": "Comments"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -599,12 +733,23 @@
           "form_id": "FORM1SECTION1",
           "label": "FeatureIDincrementor"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
-        "initialValue": null,
-        "access": ["admin"],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
+        "initialValue": "",
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -624,12 +769,23 @@
           "form_id": "FORM2SECTION1",
           "label": "ArtefactID_counter"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
-        "initialValue": null,
-        "access": ["admin"],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
+        "initialValue": "",
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -652,20 +808,28 @@
             "type": "text",
             "readOnly": true
           },
-          "InputLabelProps": {
-            "label": "FeatureID"
-          },
-          "hrid": true,
           "numberfield": 2,
           "fieldselect10": "feature-type",
-          "fieldselect11": "featureidincrementor"
+          "fieldselect11": "featureidincrementor",
+          "label": "FeatureID"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -688,21 +852,29 @@
             "type": "text",
             "readOnly": true
           },
-          "InputLabelProps": {
-            "label": "FeatureID"
-          },
-          "hrid": true,
           "linked": "featureid",
           "numberfield": 2,
           "fieldselect10": "feature-type",
-          "fieldselect11": "featureidincrementor"
+          "fieldselect11": "featureidincrementor",
+          "label": "FeatureID"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -723,12 +895,20 @@
           "id": "html-text",
           "name": "html-text"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -754,17 +934,28 @@
           "InputLabelProps": {
             "label": ""
           },
-          "hrid": true,
           "numberfield": 2,
           "fieldselect10": "measurement",
-          "fieldselect11": "dimension"
+          "fieldselect11": "dimension",
+          "label": "templatedstringfield"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -790,18 +981,29 @@
           "InputLabelProps": {
             "label": ""
           },
-          "hrid": true,
           "linked": "templatedstringfield",
           "numberfield": 2,
           "fieldselect10": "measurement",
-          "fieldselect11": "dimension"
+          "fieldselect11": "dimension",
+          "label": "hridFORM3"
         },
-        "validationSchema": [["yup.string"], ["yup.required"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ],
+          [
+            "yup.required"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -823,19 +1025,24 @@
             "rows": 4
           },
           "SelectProps": {},
-          "InputLabelProps": {
-            "label": "Artefact Comment"
-          },
-          "FormHelperTextProps": {},
           "id": "artefact-comment",
-          "name": "artefact-comment"
+          "name": "artefact-comment",
+          "label": "Artefact Comment"
         },
-        "validationSchema": [["yup.string"]],
+        "validationSchema": [
+          [
+            "yup.string"
+          ]
+        ],
         "initialValue": "",
-        "access": ["admin"],
+        "access": [
+          "admin"
+        ],
         "meta": {
-          "annotation_label": "annotation",
-          "annotation": true,
+          "annotation": {
+            "include": true,
+            "label": "annotation"
+          },
           "uncertainty": {
             "include": false,
             "label": "uncertainty"
@@ -861,7 +1068,11 @@
         "label": "SECTION1"
       },
       "FORM3SECTION1": {
-        "fields": ["hridFORM3", "dimension", "measurement"],
+        "fields": [
+          "hridFORM3",
+          "dimension",
+          "measurement"
+        ],
         "uidesign": "form",
         "label": "Dimension"
       },
@@ -880,18 +1091,31 @@
     },
     "viewsets": {
       "FORM1": {
-        "views": ["FORM1SECTION1"],
-        "label": "Feature"
+        "views": [
+          "FORM1SECTION1"
+        ],
+        "label": "Feature",
+        "hridField": "hridFORM1"
       },
       "FORM2": {
-        "views": ["FORM2SECTION1"],
-        "label": "Artefact"
+        "views": [
+          "FORM2SECTION1"
+        ],
+        "label": "Artefact",
+        "hridField": "hridFORM2"
       },
       "FORM3": {
-        "views": ["FORM3SECTION1"],
-        "label": "Measurements"
+        "views": [
+          "FORM3SECTION1"
+        ],
+        "label": "Measurements",
+        "hridField": "hridFORM3"
       }
     },
-    "visible_types": ["FORM1", "FORM2", "FORM3"]
+    "visible_types": [
+      "FORM1",
+      "FORM2",
+      "FORM3"
+    ]
   }
 }

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -764,6 +764,9 @@ type FieldSummary = {
   uncertainty?: string;
 };
 
+/**
+ * Convert annotations on a field to a format suitable for CSV export
+ */
 const csvFormatAnnotation = (
   field: FieldSummary,
   {annotation, uncertainty}: Annotations
@@ -778,8 +781,13 @@ const csvFormatAnnotation = (
   return result;
 };
 
+/**
+ * Format the data for a single record for CSV export
+ *
+ * @returns a map of column headings to values
+ */
 const convertDataForOutput = (
-  fields: {name: string; type: string}[],
+  fields: FieldSummary[],
   data: any,
   annotations: {[name: string]: Annotations},
   hrid: string,
@@ -797,7 +805,7 @@ const convertDataForOutput = (
       );
       const formattedAnnotation = csvFormatAnnotation(
         field,
-        annotations[field.name]
+        annotations[field.name] || {}
       );
       result = {...result, ...formattedValue, ...formattedAnnotation};
     } else {
@@ -807,6 +815,14 @@ const convertDataForOutput = (
   return result;
 };
 
+/**
+ * Get a list of fields for a notebook with relevant information
+ * on each for the export
+ *
+ * @param project_id Project ID
+ * @param viewID View ID
+ * @returns an array of FieldSummary objects
+ */
 const getNotebookFieldTypes = async (project_id: ProjectID, viewID: string) => {
   const uiSpec = await getEncodedNotebookUISpec(project_id);
   if (!uiSpec) {
@@ -835,6 +851,13 @@ const getNotebookFieldTypes = async (project_id: ProjectID, viewID: string) => {
   return fields;
 };
 
+/**
+ * Stream the records in a notebook as a CSV file
+ *
+ * @param projectId Project ID
+ * @param viewID View ID
+ * @param res writeable stream
+ */
 export const streamNotebookRecordsAsCSV = async (
   projectId: ProjectID,
   viewID: string,

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -772,7 +772,9 @@ const csvFormatAnnotation = (
   if (field.annotation !== '')
     result[field.name + '_' + field.annotation] = annotation;
   if (field.uncertainty !== '')
-    result[field.name + '_' + field.uncertainty] = uncertainty;
+    result[field.name + '_' + field.uncertainty] = uncertainty
+      ? 'true'
+      : 'false';
   return result;
 };
 
@@ -822,10 +824,10 @@ const getNotebookFieldTypes = async (project_id: ProjectID, viewID: string) => {
         name: field,
         type: fieldInfo['type-returned'],
         annotation: fieldInfo.meta.annotation.include
-          ? fieldInfo.meta.annotation.label
+          ? slugify(fieldInfo.meta.annotation.label)
           : '',
         uncertainty: fieldInfo.meta.uncertainty.include
-          ? fieldInfo.meta.uncertainty.label
+          ? slugify(fieldInfo.meta.uncertainty.label)
           : '',
       });
     });

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -648,9 +648,9 @@ describe('API tests', () => {
             expect(response.text).to.contain('identifier');
             expect(response.text).to.contain('take-photo');
             // uncertainty label on asset number
-            expect(response.text).to.contain('asset-number_Questionable');
+            expect(response.text).to.contain('asset-number_questionable');
             // annotation label for asset number
-            expect(response.text).to.contain('asset-number_Difficulties');
+            expect(response.text).to.contain('asset-number_difficulties');
 
             const lines = response.text.split('\n');
             lines.forEach(line => {

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -646,6 +646,12 @@ describe('API tests', () => {
           .expect(response => {
             // response body should be csv data
             expect(response.text).to.contain('identifier');
+            expect(response.text).to.contain('take-photo');
+            // uncertainty label on asset number
+            expect(response.text).to.contain('asset-number_Questionable');
+            // annotation label for asset number
+            expect(response.text).to.contain('asset-number_Difficulties');
+
             const lines = response.text.split('\n');
             lines.forEach(line => {
               if (line !== '' && !line.startsWith('identifier')) {
@@ -659,6 +665,14 @@ describe('API tests', () => {
           });
     }
   });
+
+  //identifier,record_id,revision_id,type,created_by,created,updated_by,updated,
+  // hridFORM2,hridFORM2_uncertainty,autoincrementer,autoincrementer_uncertainty,
+  // asset-number,asset-number_Questionable,element-type,
+  // take-gps-point,take-gps-point_latitude,take-gps-point_longitude,take-gps-point_accuracy,
+  // nearest-building,nearest-building_Uncertain,
+  // checkbox,condition,
+  // take-photo,element-notes,element-notes_uncertainty
 
   it('can download files as zip', async () => {
     // pull in some test data


### PR DESCRIPTION
# Include annotation and uncertainty in csv export where enabled

## Ticket

[FAIMS1515](https://github.com/FAIMS/FAIMS3/issues/1515)

## Description

Current CSV export ignores annotation and uncertainty on fields.  This PR includes them in the export.

## Proposed Changes

Any field with annotation or uncertainty enabled will get an extra column in the CSV export called FFFF_AAAA  where FFFF is the field id and AAAA is the defined annotation (or uncertainty) label.  The content will be the value of the annotation or uncertainty on that field.

## How to Test

Export data from a notebook that has annotation and uncertainty added. 


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
