### PR TITLE
Improved Backup and Restore

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,8 @@
     "test": "env-cmd cross-env NODE_ENV=test TS_NODE_PROJECT='./tsconfig.json' mocha --exit",
     "test:watch": "env-cmd cross-env NODE_ENV=test TS_NODE_PROJECT='./tsconfig.json' mocha -w",
     "coverage": "nyc --reporter=html --reporter=lcov env-cmd cross-env NODE_ENV=test TS_NODE_PROJECT='./tsconfig.json' mocha",
-    "migrate": "env-cmd ts-node src/scripts/migrate.ts"
+    "migrate": "env-cmd ts-node src/scripts/migrate.ts",
+    "restore-backup": "env-cmd node --expose-gc --max-old-space-size=8000 -r ts-node/register src/scripts/restoreBackup.ts"
   },
   "dependencies": {
     "@faims3/data-model": "*",

--- a/api/src/couchdb/backupRestore.ts
+++ b/api/src/couchdb/backupRestore.ts
@@ -17,7 +17,7 @@
  * Description:
  *    Functions to backup and restore databases
  */
-import {safeWriteDocument} from '@faims3/data-model';
+import {batchWriteDocuments} from '@faims3/data-model';
 import {open} from 'node:fs/promises';
 import {initialiseDataDb, initialiseMetadataDb, localGetProjectsDb} from '.';
 
@@ -25,65 +25,147 @@ import {initialiseDataDb, initialiseMetadataDb, localGetProjectsDb} from '.';
  * restoreFromBackup - restore databases from a JSONL backup file
  * Backup file contains one line per document from the database
  * Each database starts with a JSONL line with the key `type="header"`
- * @param filename file containing JSONL backup of databases
+ * @param filename - file containing JSONL backup of databases
+ * @param pattern - optional regex pattern to filter databases to restore
+ * @param force - if true, overwrite existing documents if present, default is false
  */
-export const restoreFromBackup = async (filename: string) => {
+export const restoreFromBackup = async ({
+  filename,
+  pattern = '.*',
+  force = false,
+}: {
+  filename: string;
+  pattern?: string;
+  force?: boolean;
+}) => {
   const file = await open(filename);
 
-  let dbName;
-  let db;
+  let dbName: string;
+  let db: any;
   let line_number = 1;
+  let processedCount = 0;
+  const GC_INTERVAL = 1000; // Force GC every 1000 records
+  const BATCH_SIZE = 500; // Smaller batches
+  let batch: any[] = [];
+  let skipping = false;
 
-  for await (const line of file.readLines()) {
-    try {
-      const doc = JSON.parse(line);
-      if (doc.type === 'header') {
-        dbName = doc.database;
-
-        if (dbName.startsWith('projects')) {
-          // name will be eg. 'projects_default', where 'default' is the
-          // conductor instance id
-          // we'll put all projects into our projectsDB
-          db = localGetProjectsDb();
-        } else if (dbName.startsWith('metadata')) {
-          const projectName = dbName.split('||')[1];
-          // TODO: set up permissions for the databases
-          db = await initialiseMetadataDb({
-            projectId: projectName,
-            force: true,
+  try {
+    for await (const line of file.readLines()) {
+      if (processedCount % GC_INTERVAL === 0 && processedCount > 0) {
+        // Process batch before GC
+        if (batch.length > 0 && db) {
+          await batchWriteDocuments({
+            db,
+            documents: batch,
+            writeOnClash: true,
           });
-        } else if (dbName.startsWith('data')) {
-          const projectName = dbName.split('||')[1];
-          // TODO: set up permissions for the databases
-          db = await initialiseDataDb({
-            projectId: projectName,
-            force: true,
-          });
-        } else {
-          // don't try to restore anything we don't know about
-          db = undefined;
+          // console.log(
+          //   `Batch results: ${results.successful} successful, ${results.failed} failed`
+          // );
+          batch = []; // Clear batch
         }
-      } else if (!doc.id.startsWith('_design') && db) {
-        // don't try to restore design documents as these will have been
-        // created on the database initialisation
 
-        // delete the _rev attribute so that we can put it into an empty db
-        // if we were restoring into an existing db, we would need to be more
-        // careful and check whether this _rev is present in the db already
-        delete doc.doc._rev;
-        try {
-          // Safe write
-          await safeWriteDocument<any>({db, data: doc.doc, writeOnClash: true});
-        } catch (error) {
-          console.log('Error restoring document', doc.id);
+        if (global.gc) {
+          global.gc();
         }
+
+        // const memUsage = process.memoryUsage();
+        // console.log(
+        //   `Processed ${processedCount} records. Heap: ${Math.round(memUsage.heapUsed / 1024 / 1024)}MB`
+        // );
       }
-    } catch (e: any) {
-      console.error(
-        `error parsing JSON on line ${line_number} ${JSON.stringify(e, undefined, 2)} ${e.stack}`
-      );
-      return;
+
+      try {
+        let doc = JSON.parse(line);
+        if (doc.type === 'header') {
+          // write out any remaining documents to the previous db
+          if (batch.length > 0 && db) {
+            await batchWriteDocuments({
+              db,
+              documents: batch,
+              writeOnClash: force,
+            });
+            // console.log(
+            //   `Batch results: ${results.successful} successful, ${results.failed} failed`
+            // );
+            batch = [];
+          }
+          // update the database
+          dbName = doc.database;
+          skipping = dbName.match(pattern) === null;
+          if (skipping) {
+            console.log(`Skipping database ${dbName}`);
+          } else {
+            console.log(`Processing database ${dbName}`);
+          }
+          if (dbName.startsWith('projects')) {
+            // name will be eg. 'projects_default', where 'default' is the
+            // conductor instance id
+            // we'll put all projects into our projectsDB
+            db = localGetProjectsDb();
+          } else if (!skipping && dbName.startsWith('metadata')) {
+            const projectName = dbName.split('||')[1];
+            // TODO: set up permissions for the databases
+            db = await initialiseMetadataDb({
+              projectId: projectName,
+              force: true,
+            });
+          } else if (!skipping && dbName.startsWith('data')) {
+            const projectName = dbName.split('||')[1];
+            // TODO: set up permissions for the databases
+            db = await initialiseDataDb({
+              projectId: projectName,
+              force: true,
+            });
+          } else {
+            // don't try to restore anything we don't know about
+            db = undefined;
+          }
+        } else if (!skipping && !doc.id.startsWith('_design') && db) {
+          // don't try to restore design documents as these will have been
+          // created on the database initialisation
+          // Minimal document copy
+          const docToWrite = {
+            _id: doc.doc._id,
+            ...doc.doc,
+          };
+          // delete the _rev attribute so that we can put it into an empty db
+          // if we were restoring into an existing db, we would need to be more
+          // careful and check whether this _rev is present in the db already
+          delete docToWrite._rev;
+
+          batch.push(docToWrite);
+
+          if (batch.length >= BATCH_SIZE) {
+            await batchWriteDocuments({
+              db,
+              documents: batch,
+              writeOnClash: force,
+            });
+            // console.log(
+            //   `Batch results: ${results.successful} successful, ${results.failed} failed`
+            // );
+            batch = [];
+          }
+        }
+        processedCount += 1;
+        // Explicitly null out references to help GC
+        doc = null;
+      } catch (e: any) {
+        console.error(
+          `error parsing JSON on line ${line_number} ${JSON.stringify(e, undefined, 2)} ${e.stack}`
+        );
+        return;
+      }
+      line_number += 1;
     }
-    line_number += 1;
+    // Process final batch
+    if (batch.length > 0 && db) {
+      await batchWriteDocuments({db, documents: batch, writeOnClash: force});
+      batch = [];
+    }
+  } finally {
+    await file.close();
   }
+  console.log(`Restore completed. Total records processed: ${processedCount}`);
 };

--- a/api/src/scripts/restoreBackup.ts
+++ b/api/src/scripts/restoreBackup.ts
@@ -3,13 +3,20 @@
 import {restoreFromBackup} from '../couchdb/backupRestore';
 
 const main = async () => {
-  if (process.argv.length === 4) {
+  if (process.argv.length >= 4) {
     const filename = process.argv[2];
     const pattern = process.argv[3];
-    console.log(`Restoring from ${filename} with pattern ${pattern}`);
-    restoreFromBackup({filename, pattern});
+    const force = process.argv[4] === 'true';
+    console.log(
+      `Restoring from ${filename} with pattern ${pattern}, force=${force}`
+    );
+    restoreFromBackup({filename, pattern, force});
   } else {
-    console.log('Usage: node restoreBackup.ts <filename> <pattern>');
+    console.log('Usage: node restoreBackup.ts <filename> <pattern> ?<force>');
+    console.log(' * pattern is a regex pattern to filter databases to restore');
+    console.log(
+      ' * last argument is "true" to force overwrite of existing documents, default is false'
+    );
     process.exit(1);
   }
 };

--- a/api/src/scripts/restoreBackup.ts
+++ b/api/src/scripts/restoreBackup.ts
@@ -10,7 +10,14 @@ const main = async () => {
     console.log(
       `Restoring from ${filename} with pattern ${pattern}, force=${force}`
     );
-    restoreFromBackup({filename, pattern, force});
+    try {
+      await restoreFromBackup({filename, pattern, force});
+    } catch (err) {
+      console.error('Error restoring backup:', err);
+      process.exit(1);
+    }
+    console.log('Backup restore completed successfully.');
+    process.exit(0);
   } else {
     console.log('Usage: node restoreBackup.ts <filename> <pattern> ?<force>');
     console.log(' * pattern is a regex pattern to filter databases to restore');

--- a/api/src/scripts/restoreBackup.ts
+++ b/api/src/scripts/restoreBackup.ts
@@ -1,0 +1,17 @@
+/* eslint-disable n/no-process-exit */
+
+import {restoreFromBackup} from '../couchdb/backupRestore';
+
+const main = async () => {
+  if (process.argv.length === 4) {
+    const filename = process.argv[2];
+    const pattern = process.argv[3];
+    console.log(`Restoring from ${filename} with pattern ${pattern}`);
+    restoreFromBackup({filename, pattern});
+  } else {
+    console.log('Usage: node restoreBackup.ts <filename> <pattern>');
+    process.exit(1);
+  }
+};
+
+main();

--- a/api/src/scripts/restoreBackup.ts
+++ b/api/src/scripts/restoreBackup.ts
@@ -2,28 +2,104 @@
 
 import {restoreFromBackup} from '../couchdb/backupRestore';
 
+interface ParsedArgs {
+  filename?: string;
+  pattern?: string;
+  force: boolean;
+  help: boolean;
+}
+
+const parseArgs = (args: string[]): ParsedArgs => {
+  const parsed: ParsedArgs = {
+    force: false,
+    help: false
+  };
+
+  for (let i = 2; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--force' || arg === '-f') {
+      parsed.force = true;
+    } else if (arg === '--pattern' || arg === '-p') {
+      if (i + 1 < args.length) {
+        parsed.pattern = args[i + 1];
+        i++; // Skip next argument as it's the pattern value
+      } else {
+        throw new Error('--pattern requires a value');
+      }
+    } else if (!arg.startsWith('--') && !arg.startsWith('-')) {
+      // Assume it's the filename if no filename is set yet
+      if (!parsed.filename) {
+        parsed.filename = arg;
+      } else {
+        throw new Error(`Unexpected argument: ${arg}`);
+      }
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return parsed;
+};
+
+const showHelp = () => {
+  console.log('Usage: node restoreBackup.ts [options] <filename>');
+  console.log('');
+  console.log('Options:');
+  console.log(
+    '  -p, --pattern <pattern>  Regex pattern to filter databases to restore'
+  );
+  console.log(
+    '  -f, --force             Force overwrite of existing documents'
+  );
+  console.log('  -h, --help              Show this help message');
+  console.log('');
+  console.log('Examples:');
+  console.log('  node restoreBackup.ts backup.jsonl');
+  console.log('  node restoreBackup.ts --pattern "Foo.*" backup.jsonl');
+  console.log('  node restoreBackup.ts --pattern "Foo.*" --force backup.jsonl');
+};
+
 const main = async () => {
-  if (process.argv.length >= 4) {
-    const filename = process.argv[2];
-    const pattern = process.argv[3];
-    const force = process.argv[4] === 'true';
-    console.log(
-      `Restoring from ${filename} with pattern ${pattern}, force=${force}`
-    );
-    try {
-      await restoreFromBackup({filename, pattern, force});
-    } catch (err) {
-      console.error('Error restoring backup:', err);
+  try {
+    const args = parseArgs(process.argv);
+
+    if (args.help) {
+      showHelp();
+      process.exit(0);
+    }
+
+    if (!args.filename) {
+      console.error('Error: Missing required filename argument');
+      console.log('');
+      showHelp();
       process.exit(1);
     }
+
+    console.log(`Restoring from ${args.filename}`);
+    if (args.pattern) {
+      console.log(`Using pattern: ${args.pattern}`);
+    }
+    if (args.force) {
+      console.log('Force overwrite enabled');
+    }
+
+    await restoreFromBackup({
+      filename: args.filename,
+      pattern: args.pattern,
+      force: args.force,
+    });
+
     console.log('Backup restore completed successfully.');
     process.exit(0);
-  } else {
-    console.log('Usage: node restoreBackup.ts <filename> <pattern> ?<force>');
-    console.log(' * pattern is a regex pattern to filter databases to restore');
-    console.log(
-      ' * last argument is "true" to force overwrite of existing documents, default is false'
-    );
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error('Error:', err.message);
+    } else {
+      console.error('Error restoring backup:', err);
+    }
     process.exit(1);
   }
 };

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -603,7 +603,7 @@ describe('API tests', () => {
 
   it('can check sync status of records', async () => {
     // pull in some test data
-    await restoreFromBackup('test/backup.jsonl');
+    await restoreFromBackup({filename: 'test/backup.jsonl'});
     const projectId = '1693291182736-campus-survey-demo';
     const dataDb = await getDataDb(projectId);
     // get a list of record ids from the project
@@ -648,7 +648,7 @@ describe('API tests', () => {
 
   it('can download records as json', async () => {
     // pull in some test data
-    await restoreFromBackup('test/backup.jsonl');
+    await restoreFromBackup({filename: 'test/backup.jsonl'});
 
     const admin = await getExpressUserFromEmailOrUserId('admin');
     if (!admin) {
@@ -668,7 +668,7 @@ describe('API tests', () => {
 
   it('can download records as csv', async () => {
     // pull in some test data
-    await restoreFromBackup('test/backup.jsonl');
+    await restoreFromBackup({filename: 'test/backup.jsonl'});
 
     const url =
       '/api/notebooks/1693291182736-campus-survey-demo/records/FORM2.csv';
@@ -725,7 +725,7 @@ describe('API tests', () => {
 
   it('can download files as zip', async () => {
     // pull in some test data
-    await restoreFromBackup('test/backup.jsonl');
+    await restoreFromBackup({filename: 'test/backup.jsonl'});
 
     const adminUser = await getExpressUserFromEmailOrUserId('admin');
     if (adminUser) {

--- a/api/test/backup.test.ts
+++ b/api/test/backup.test.ts
@@ -52,7 +52,7 @@ describe('Backup and restore', () => {
     await cleanDataDBS();
     await initialiseDbAndKeys({});
 
-    await restoreFromBackup('test/backup.jsonl');
+    await restoreFromBackup({filename: 'test/backup.jsonl'});
 
     // should now have the notebooks from the backup defined
     const user = await getExpressUserFromEmailOrUserId('admin');

--- a/docs/developer/docs/source/markdown/Backup.md
+++ b/docs/developer/docs/source/markdown/Backup.md
@@ -1,0 +1,49 @@
+# On Device Backup of Data
+
+There is an option in the app to share a backup dump of the on-device databases.  This is
+intended as a safety measure. If a user is in the field and is concerned about data loss,
+they can create a local backup of data that could be recovered at a future time.
+We've also used this when devices have refused to sync data even though they have
+a network connection (due to an unknown bug).
+
+The backup option is available via the About Build screen in the app.  Clicking the
+backup button initiates a database dump. The dump file is then available to
+the device 'share' service which allows the user to save it as a local file or
+send it to a service (GDrive, email etc).
+
+## Dump Format
+
+The dump format is JSONL with one JSON line per record, interspersed with header
+lines.  At the start of each database dump the header line is as follows:
+
+```JSON
+{type: 'header', database: db.name, info: info}
+```
+
+Where `db.name` is the database name and `info` is the result of calling the `.info()`
+method on the database.
+
+Following lines are just raw documents from the database as single line JSON documents.
+No ordering is done on the documents, they are just the result of calling `allDocs()` on
+the database.
+
+Note that all databases, including local databases such as drafts etc. are dumped. This
+might be useful in diagnosing problems at some point.
+
+## Restoring the Dump
+
+The dump can only be restored on a server via a command line script:
+
+```shell
+npm run restore-backup fieldmark-backup-2025-06-19-1750363850254.jsonl pattern
+```
+
+This would restore records from the backup file to any databases matching the
+regular expression `pattern`.  
+
+By default, existing records will not be overwritten when the backup is restored.
+To overwrite existing records, add `true` to the end of the command line:
+
+```shell
+npm run restore-backup fieldmark-backup-2025-06-19-1750363850254.jsonl pattern true
+```

--- a/docs/developer/docs/source/markdown/Backup.md
+++ b/docs/developer/docs/source/markdown/Backup.md
@@ -35,15 +35,19 @@ might be useful in diagnosing problems at some point.
 The dump can only be restored on a server via a command line script:
 
 ```shell
-npm run restore-backup fieldmark-backup-2025-06-19-1750363850254.jsonl pattern
+npm run restore-backup fieldmark-backup-2025-06-19-1750363850254.jsonl
 ```
 
-This would restore records from the backup file to any databases matching the
-regular expression `pattern`.  
-
-By default, existing records will not be overwritten when the backup is restored.
-To overwrite existing records, add `true` to the end of the command line:
+This would restore records from the backup file to all databases.  To limit the
+databases restored to those matching the regular expression `mybackup.*`:
 
 ```shell
-npm run restore-backup fieldmark-backup-2025-06-19-1750363850254.jsonl pattern true
+npm run restore-backup -- --pattern 'mybackup.*' fieldmark-backup-2025-06-19-1750363850254.jsonl
+```
+
+By default, existing records will not be overwritten when the backup is restored.
+To overwrite existing records, add the `--force` flag to the command line:
+
+```shell
+npm run restore-backup -- --force fieldmark-backup-2025-06-19-1750363850254.jsonl
 ```

--- a/library/data-model/src/data_storage/dataDB/design.ts
+++ b/library/data-model/src/data_storage/dataDB/design.ts
@@ -237,20 +237,6 @@ export const recordAuditDocument = {
         }
       }),
     },
-    by_record_id_with_attachments: {
-      map: convertToCouchDBString(doc => {
-        // Emit all documents with record_id, including attachment status
-        if (doc.record_id) {
-          emit(
-            [doc.record_id, doc.attach_format_version ? 'attachment' : 'data'],
-            {
-              _id: doc._id,
-              _rev: doc._rev,
-            }
-          );
-        }
-      }),
-    },
   },
 };
 

--- a/library/data-model/src/data_storage/utils.ts
+++ b/library/data-model/src/data_storage/utils.ts
@@ -165,9 +165,6 @@ export async function batchWriteDocuments<T extends {}>({
       }
     }
 
-    // Clear chunk references
-    chunk.length = 0;
-
     // Allow garbage collection between chunks
     if (i % (CHUNK_SIZE * 10) === 0) {
       await new Promise(resolve => setTimeout(resolve, 1));

--- a/library/data-model/src/data_storage/utils.ts
+++ b/library/data-model/src/data_storage/utils.ts
@@ -95,9 +95,86 @@ export async function safeWriteDocument<T extends {}>({
       }
     } else {
       // Something else happened - unsure and throw
+      console.log(err);
       throw Error('Failed to update record - non 409 error' + err);
     }
   }
+}
+
+/**
+ * Efficiently writes multiple documents in a batch, handling conflicts
+ */
+export async function batchWriteDocuments<T extends {}>({
+  db,
+  documents,
+  writeOnClash = true,
+}: {
+  db: PouchDB.Database<T>;
+  documents: PouchDB.Core.ExistingDocument<T>[];
+  writeOnClash?: boolean;
+}): Promise<{successful: number; failed: number}> {
+  let successful = 0;
+  let failed = 0;
+
+  // Process in smaller chunks to avoid memory build-up
+  const CHUNK_SIZE = 10;
+
+  for (let i = 0; i < documents.length; i += CHUNK_SIZE) {
+    const chunk = documents.slice(i, i + CHUNK_SIZE);
+
+    try {
+      // Try bulk insert first
+      const results = await db.bulkDocs(chunk, {new_edits: true});
+
+      // Handle any conflicts in the results
+      for (let j = 0; j < results.length; j++) {
+        const result = results[j];
+        const doc = chunk[j];
+
+        if (
+          'error' in result &&
+          result.error &&
+          result.status === 409 &&
+          writeOnClash
+        ) {
+          // Handle conflict individually
+          try {
+            const existing = await db.get<T>(doc._id);
+            doc._rev = existing._rev;
+            await db.put(doc);
+            successful++;
+          } catch (conflictErr) {
+            console.warn(`Failed to resolve conflict for ${doc._id}`);
+            failed++;
+          }
+        } else if ('error' in result) {
+          failed++;
+        } else {
+          successful++;
+        }
+      }
+    } catch (bulkErr) {
+      // Fallback to individual writes for this chunk
+      for (const doc of chunk) {
+        try {
+          await safeWriteDocument({db, data: doc, writeOnClash});
+          successful++;
+        } catch (err) {
+          failed++;
+        }
+      }
+    }
+
+    // Clear chunk references
+    chunk.length = 0;
+
+    // Allow garbage collection between chunks
+    if (i % (CHUNK_SIZE * 10) === 0) {
+      await new Promise(resolve => setTimeout(resolve, 1));
+    }
+  }
+
+  return {successful, failed};
 }
 
 /**

--- a/library/data-model/tests/data_storage.test.ts
+++ b/library/data-model/tests/data_storage.test.ts
@@ -393,7 +393,8 @@ describe('record iterator', () => {
     const viewID = 'Test';
 
     // test below, at and above the batch size of the iterator
-    const sizes = [0, 50, 100, 220, 550];
+    // Reduced test sizes for CI performance, but still covering edge cases
+    const sizes = [0, 50, 100, 220];
     for (let i = 0; i < sizes.length; i++) {
       const n = sizes[i];
       await cleanDataDBS();
@@ -421,7 +422,7 @@ describe('record iterator', () => {
       // expect the sum of the first n integers from 0 to n-1
       expect(sumOfAges).toBe(Math.abs((n * (n - 1)) / 2));
     }
-  }, 25000);
+  }, 45000);
 });
 
 describe('record retrieval', () => {


### PR DESCRIPTION
# Improved Backup and Restore

## JIRA Ticket

None

## Description

Following a failure in trying to restore a large backup, this PR has some changes to improve both the backup and restore processes.

## Proposed Changes

Update the on-device backup process to use low-level methods to get the databases to dump containing records.  This prevents a problem we've seen recently where the backup failed because (we think) the internal data structures referencing databases were broken.  To avoid this in future, since this is an emergency procedure, we just look at the low level IDB database names to find dataDBs to back up.

For restoring backups, there was a memory leak that prevented large backups being restored.  I don't think it was a genuine leak but due to the rapid reading and writing of records, the GC did not catch  up and heap memory was exceeeded.  Here we add a batch write operation to write many documents at once to the database and use this to batch up writes from the restore process. 

Previous restore operation was via a special page on Conductor.  I've moved it to a package.json script which makes more sense for this operation.

I've also added the option to select which databases to restore from a backup file. 

Restoring a backup no longer overwrites existing documents by default.  This should mean that we can restore only the missing documents from a backup.

I added documentation about the backup format and process in the developer docs.

Successfully tested on a large (8G) backup from a device.  

## How to Test

Needs to be tested on device (can't save the backup on web).   Save a backup from a device having a bunch of records.   Try restoring this backup to a different server.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
