### PR TITLE
clean + fix old branch, enhancements for related record child record tables

### DIFF
--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -107,7 +107,7 @@ type GridColumnType = GridColDef<RecordMetadata>;
 // ============================================================================
 
 /** Maps column types to their display labels */
-const COLUMN_TO_LABEL_MAP: Map<ColumnType, string> = new Map([
+export const COLUMN_TO_LABEL_MAP: Map<ColumnType, string> = new Map([
   ['LAST_UPDATED', 'Last Updated'],
   ['LAST_UPDATED_BY', 'Last Updated By'],
   ['CONFLICTS', 'Conflicts'],
@@ -118,16 +118,16 @@ const COLUMN_TO_LABEL_MAP: Map<ColumnType, string> = new Map([
 ]);
 
 /** Columns that must always be shown */
-const MANDATORY_COLUMNS: ColumnType[] = ['CREATED', 'CREATED_BY'];
+export const MANDATORY_COLUMNS: ColumnType[] = ['CREATED', 'CREATED_BY'];
 
 /** Columns to show in large view */
-const LARGE_COLUMNS = MANDATORY_COLUMNS.concat([
+export const LARGE_COLUMNS = MANDATORY_COLUMNS.concat([
   'LAST_UPDATED',
   'LAST_UPDATED_BY',
 ]);
 
 /** Default values for text display and other constants */
-const CONSTANTS = {
+export const CONSTANTS = {
   MISSING_DATA_PLACEHOLDER: '-',
   HRID_COLUMN_LABEL: 'Field ID',
   VERTICAL_STACK_COLUMN_LABEL: 'Details',
@@ -203,7 +203,7 @@ function getDataForColumn({
  *
  * @returns {GridColumnType[]} Array of column definitions for the DataGrid
  */
-function buildColumnsFromSummaryFields({
+export function buildColumnsFromSummaryFields({
   summaryFields,
   uiSpecification,
 }: {
@@ -238,7 +238,7 @@ function buildColumnsFromSummaryFields({
  * @param columnType Type of column
  * @param uiSpecification The ui spec
  */
-function buildColumnFromSystemField({
+export function buildColumnFromSystemField({
   columnType,
   uiSpecification,
 }: {
@@ -444,7 +444,7 @@ function buildHridColumn(): GridColumnType {
  * @returns A single column definition which renders a vertical stack of key
  * value pairs nicely
  */
-function buildVerticalStackColumn({
+export function buildVerticalStackColumn({
   summaryFields,
   columnLabel,
   uiSpecification,

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -126,8 +126,8 @@ const LARGE_COLUMNS = MANDATORY_COLUMNS.concat([
   'LAST_UPDATED_BY',
 ]);
 
-/** Default values for text display and other constants */
-export const CONSTANTS = {
+/** Default values for text display , record grid labels */
+export const RECORD_GRID_LABELS = {
   MISSING_DATA_PLACEHOLDER: '-',
   HRID_COLUMN_LABEL: 'Field ID',
   VERTICAL_STACK_COLUMN_LABEL: 'Details',
@@ -225,7 +225,7 @@ export function buildColumnsFromSummaryFields({
       });
       return (
         <Typography>
-          {displayValue || CONSTANTS.MISSING_DATA_PLACEHOLDER}
+          {displayValue || RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER}
         </Typography>
       );
     },
@@ -274,7 +274,7 @@ export function buildColumnFromSystemField({
           });
           return (
             <Typography>
-              {value || CONSTANTS.MISSING_DATA_PLACEHOLDER}
+              {value || RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER}
             </Typography>
           );
         },
@@ -292,7 +292,7 @@ export function buildColumnFromSystemField({
           });
           return (
             <Typography>
-              {value || CONSTANTS.MISSING_DATA_PLACEHOLDER}
+              {value || RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER}
             </Typography>
           );
         },
@@ -328,7 +328,7 @@ export function buildColumnFromSystemField({
           });
           return (
             <Typography>
-              {value || CONSTANTS.MISSING_DATA_PLACEHOLDER}
+              {value || RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER}
             </Typography>
           );
         },
@@ -477,7 +477,7 @@ export function buildVerticalStackColumn({
           });
           // And a pretty key
           kvp[COLUMN_TO_LABEL_MAP.get('KIND') ?? 'Type'] =
-            val ?? CONSTANTS.MISSING_DATA_PLACEHOLDER;
+            val ?? RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER;
         }
 
         // Use the summary fields if present
@@ -490,12 +490,12 @@ export function buildVerticalStackColumn({
             });
             // And a pretty key
             const key = prettifyFieldName(summaryField);
-            kvp[key] = val ?? CONSTANTS.MISSING_DATA_PLACEHOLDER;
+            kvp[key] = val ?? RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER;
           }
         } else {
           // Add the HRID if available
-          kvp[CONSTANTS.HRID_COLUMN_LABEL] =
-            params.row.hrid ?? CONSTANTS.MISSING_DATA_PLACEHOLDER;
+          kvp[RECORD_GRID_LABELS.HRID_COLUMN_LABEL] =
+            params.row.hrid ?? RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER;
         }
 
         for (const mandatoryField of MANDATORY_COLUMNS) {
@@ -505,7 +505,7 @@ export function buildVerticalStackColumn({
               record: params.row,
               column: mandatoryField,
               uiSpecification,
-            }) ?? CONSTANTS.MISSING_DATA_PLACEHOLDER;
+            }) ?? RECORD_GRID_LABELS.MISSING_DATA_PLACEHOLDER;
         }
 
         // Add the conflict field if there is a conflict
@@ -596,7 +596,7 @@ function buildColumnDefinitions({
     // For small width, use vertical stack layout
     columnList.push(
       buildVerticalStackColumn({
-        columnLabel: CONSTANTS.VERTICAL_STACK_COLUMN_LABEL,
+        columnLabel: RECORD_GRID_LABELS.VERTICAL_STACK_COLUMN_LABEL,
         summaryFields,
         uiSpecification,
         includeKind,

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -118,10 +118,10 @@ const COLUMN_TO_LABEL_MAP: Map<ColumnType, string> = new Map([
 ]);
 
 /** Columns that must always be shown */
-export const MANDATORY_COLUMNS: ColumnType[] = ['CREATED', 'CREATED_BY'];
+const MANDATORY_COLUMNS: ColumnType[] = ['CREATED', 'CREATED_BY'];
 
 /** Columns to show in large view */
-export const LARGE_COLUMNS = MANDATORY_COLUMNS.concat([
+const LARGE_COLUMNS = MANDATORY_COLUMNS.concat([
   'LAST_UPDATED',
   'LAST_UPDATED_BY',
 ]);

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -129,7 +129,7 @@ const LARGE_COLUMNS = MANDATORY_COLUMNS.concat([
 /** Default values for text display , record grid labels */
 export const RECORD_GRID_LABELS = {
   MISSING_DATA_PLACEHOLDER: '-',
-  HRID_COLUMN_LABEL: 'Field ID',
+  HRID_COLUMN_LABEL: 'ID',
   VERTICAL_STACK_COLUMN_LABEL: 'Details',
 } as const;
 
@@ -706,7 +706,11 @@ function buildColumnDefinitions({
  * layout
  * @returns
  */
-const KeyValueTable = ({data}: {data: {[key: string]: string | ReactNode}}) => {
+export const KeyValueTable = ({
+  data,
+}: {
+  data: {[key: string]: string | ReactNode};
+}) => {
   return (
     <TableContainer>
       <Table size="small">
@@ -715,19 +719,21 @@ const KeyValueTable = ({data}: {data: {[key: string]: string | ReactNode}}) => {
             <TableRow key={key}>
               <TableCell
                 sx={{
-                  width: '40%',
+                  minWidth: '40%',
                   borderBottom: 'none',
                   padding: '4px 8px',
+                  textAlign: 'right',
                 }}
               >
                 {key}
               </TableCell>
               <TableCell
                 sx={{
-                  width: '60%',
+                  maxWidth: '60%',
                   borderBottom: 'none',
                   padding: '4px 8px',
                   fontWeight: 'bold',
+                  textAlign: 'left',
                 }}
               >
                 {val}
@@ -767,6 +773,7 @@ const useTableColumns = ({
     // Should the kind property be included?
     const includeKind = visibleTypes.length > 1;
     const viewsetId = visibleTypes.length === 1 ? visibleTypes[0] : '';
+
     return cols.concat(
       buildColumnDefinitions({
         uiSpecification: uiSpec,

--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -107,7 +107,7 @@ type GridColumnType = GridColDef<RecordMetadata>;
 // ============================================================================
 
 /** Maps column types to their display labels */
-export const COLUMN_TO_LABEL_MAP: Map<ColumnType, string> = new Map([
+const COLUMN_TO_LABEL_MAP: Map<ColumnType, string> = new Map([
   ['LAST_UPDATED', 'Last Updated'],
   ['LAST_UPDATED_BY', 'Last Updated By'],
   ['CONFLICTS', 'Conflicts'],

--- a/app/src/gui/components/record/conflict/conflictform.tsx
+++ b/app/src/gui/components/record/conflict/conflictform.tsx
@@ -48,7 +48,7 @@ import {useAppDispatch} from '../../../../context/store';
 import {logError} from '../../../../logging';
 import {theme} from '../../../themes';
 import {
-  addLinkedRecord,
+  getRelationshipDisplayData,
   check_if_record_relationship,
   update_child_records_conflict,
 } from '../relationships/RelatedInformation';
@@ -303,7 +303,7 @@ export default function ConflictForm(props: ConflictFormProps) {
       if (result !== null) {
         const type = result['type'];
         // get the parent and linked item
-        const newLinks: RecordLinkProps[] = await addLinkedRecord(
+        const newLinks: RecordLinkProps[] = await getRelationshipDisplayData(
           ui_specification,
           [],
           project_id,
@@ -315,7 +315,7 @@ export default function ConflictForm(props: ConflictFormProps) {
           serverId
         );
         setLinks(newLinks);
-        const newMergedLinks: RecordLinkProps[] = await addLinkedRecord(
+        const newMergedLinks: RecordLinkProps[] = await getRelationshipDisplayData(
           ui_specification,
           [],
           project_id,
@@ -352,7 +352,7 @@ export default function ConflictForm(props: ConflictFormProps) {
       if (comparedrevision.charAt(0) === '1') {
         //get the linksA for first loading
         if (linksA === null) {
-          const newLinks: RecordLinkProps[] = await addLinkedRecord(
+          const newLinks: RecordLinkProps[] = await getRelationshipDisplayData(
             ui_specification,
             [],
             project_id,
@@ -759,8 +759,6 @@ export default function ConflictForm(props: ConflictFormProps) {
     conflictfields.length > numResolved
       ? conflictfields.length - numResolved
       : 0;
-
-  console.log(conflictA);
 
   return (
     <React.Fragment>

--- a/app/src/gui/components/record/relationships/RelatedInformation.tsx
+++ b/app/src/gui/components/record/relationships/RelatedInformation.tsx
@@ -574,7 +574,24 @@ async function get_field_RelatedFields(
   return newfields;
 }
 
-export async function addLinkedRecord(
+/**
+ * Retrieves and processes relationship information from a record's parent and linked relationships,
+ * converting them into RecordLinkProps objects for UI display. This function examines the
+ * relationship structure of a record and creates display objects for each parent and linked
+ * relationship, including metadata like HRIDs, routes, and relationship types.
+ * 
+ * @param ui_specification - The UI specification for the project
+ * @param newfields - Existing array of RecordLinkProps to append to
+ * @param project_id - The project identifier
+ * @param parent - The relationship object containing parent and linked relationships
+ * @param record_id - The current record ID
+ * @param form_type - The form type/viewset name
+ * @param child_hrid - The HRID of the current record
+ * @param current_revision_id - The revision ID of the current record
+ * @param serverId - The server identifier for generating routes
+ * @returns Promise<Array<RecordLinkProps>> - Array of relationship display objects
+ */
+export async function getRelationshipDisplayData(
   ui_specification: ProjectUIModel,
   newfields: Array<RecordLinkProps>,
   project_id: string,
@@ -681,7 +698,6 @@ export async function addLinkedRecord(
       newfields.push(child);
     }
   }
-
   return newfields;
 }
 
@@ -860,7 +876,7 @@ export async function getDetailRelatedInformation(
       serverId
     );
     // get parent linked information
-    record_to_field_links = await addLinkedRecord(
+    record_to_field_links = await getRelationshipDisplayData(
       ui_specification,
       record_to_field_links,
       project_id,

--- a/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
+++ b/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
@@ -202,7 +202,7 @@ export function CreateRecordLink(props: CreateRecordLinkProps) {
           md={props.relation_type === 'Linked' ? 3 : 6}
           lg={props.relation_type === 'Linked' ? 3 : 6}
         >
-          <Field name={field_name + 'select'}>
+          <Field name={field_name + '-select'}>
             {({field, form}: any) => (
               <Autocomplete
                 size={'small'}

--- a/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
+++ b/app/src/gui/components/record/relationships/create_links/create_record_link.tsx
@@ -202,45 +202,58 @@ export function CreateRecordLink(props: CreateRecordLinkProps) {
           md={props.relation_type === 'Linked' ? 3 : 6}
           lg={props.relation_type === 'Linked' ? 3 : 6}
         >
-          <Field
-            size={'small'}
-            // multiple={multiple}
-            id={props.id ?? 'asynchronous-demo'}
-            name={field_name + 'select'}
-            component={Autocomplete}
-            isOptionEqualToValue={(
-              option: RecordReference,
-              value: RecordReference
-            ) =>
-              value !== undefined
-                ? option.project_id === value.project_id &&
-                  option.record_id === value.record_id
-                : false
-            }
-            getOptionLabel={(option: RecordReference) =>
-              option.record_label ?? ''
-            }
-            options={relatedRecords}
-            defaultValue={undefined}
-            disabled={disabled}
-            onChange={(event: any, values: any) => {
-              SetSelectedRecord(values);
-            }}
-            value={selectedRecord}
-            required={false}
-            noOptionsText={`No ${props.related_type_label ?? 'records'} available to link`}
-            renderInput={(params: any) => (
-              <TextField
-                {...params}
-                label={props.related_type_label}
-                error={props.form.errors[props.id] === undefined ? false : true}
-                variant="outlined"
-                InputProps={{
-                  ...params.InputProps,
+          <Field name={field_name + 'select'}>
+            {({field, form}: any) => (
+              <Autocomplete
+                size={'small'}
+                id={props.id ?? 'related-record'}
+                isOptionEqualToValue={(
+                  option: RecordReference,
+                  value: RecordReference
+                ) =>
+                  value !== undefined
+                    ? option.project_id === value.project_id &&
+                      option.record_id === value.record_id
+                    : false
+                }
+                getOptionLabel={(option: RecordReference) =>
+                  option.record_label ?? ''
+                }
+                // here we avoid spreading the 'key' option into the list as it
+                // triggers a warning, key isn't supposed to be there according to the
+                // type but it is passed in by the Autocomplete component
+                renderOption={(props, option) => {
+                  const {key, ...optionProps} = props as any;
+                  return (
+                    <li key={key} {...optionProps}>
+                      {option.record_label ?? ''}
+                    </li>
+                  );
                 }}
+                options={relatedRecords}
+                value={selectedRecord}
+                disabled={disabled}
+                onChange={(event: any, values: any) => {
+                  SetSelectedRecord(values);
+                  form.setFieldValue(field.name, values);
+                }}
+                noOptionsText={`No ${props.related_type_label ?? 'records'} available to link`}
+                renderInput={(params: any) => (
+                  <TextField
+                    {...params}
+                    label={props.related_type_label}
+                    error={
+                      props.form.errors[props.id] === undefined ? false : true
+                    }
+                    variant="outlined"
+                    InputProps={{
+                      ...params.InputProps,
+                    }}
+                  />
+                )}
               />
             )}
-          />
+          </Field>
         </Grid>
         {project_id !== undefined && disabled === false && (
           <Grid

--- a/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -205,13 +205,11 @@ export function DataGridFieldLinksComponent(
     valueGetter: (params: gridParamsDataType) => {
       const rel = params.row.relationship;
       if (rel.linked && rel.linked.length > 0) {
-        console.log('relationship', rel);
         // if the relationship has a linked record, return the type
         // find the link that is back to us
         const links_to_us = rel.linked.filter(
           (link: any) => link.record_id === params.id
         );
-        console.log('links_to_us', links_to_us);
         if (links_to_us && links_to_us.length > 0) {
           const rvp = links_to_us[0].relation_type_vocabPair;
           return (rvp && rvp.length > 0 && rvp[1]) || 'linked';

--- a/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -56,7 +56,7 @@ import {useDataGridStyles} from '../../../../../utils/useDataGridStyles';
 import {
   buildColumnFromSystemField,
   buildVerticalStackColumn,
-  CONSTANTS,
+  RECORD_GRID_LABELS,
 } from '../../../notebook/record_table';
 import {useScreenSize} from '../../../../../utils/useScreenSize';
 
@@ -311,7 +311,7 @@ export function DataGridFieldLinksComponent(
     uiSpec && (currentSize === 'xs' || currentSize === 'sm')
       ? buildVerticalStackColumn({
           summaryFields: [],
-          columnLabel: CONSTANTS.VERTICAL_STACK_COLUMN_LABEL,
+          columnLabel: RECORD_GRID_LABELS.VERTICAL_STACK_COLUMN_LABEL,
           uiSpecification: uiSpec,
           includeKind: false,
           hasConflict: false,

--- a/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -18,47 +18,48 @@
  *   TODO
  */
 
-import {RecordID, RecordMetadata, RecordReference} from '@faims3/data-model';
+import {RecordID, RecordMetadata} from '@faims3/data-model';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import {
   Alert,
   Box,
   Button,
   ButtonGroup,
-  CircularProgress,
   Modal,
   Paper,
-  Stack,
   Typography,
-  useTheme,
+  useTheme
 } from '@mui/material';
 import {
   DataGrid,
   GridActionsCellItem,
   GridCellParams,
   GridColDef,
+  GridEventListener,
   GridRow,
   GridRowParams,
 } from '@mui/x-data-grid';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 import {getExistingRecordRoute} from '../../../../../constants/routes';
+import {compiledSpecService} from '../../../../../context/slices/helpers/compiledSpecService';
 import {selectProjectById} from '../../../../../context/slices/projectSlice';
 import {useAppSelector} from '../../../../../context/store';
 import {
   getFieldLabel,
   getSummaryFieldInformation,
 } from '../../../../../uiSpecification';
-import RecordRouteDisplay from '../../../ui/record_link';
-import {gridParamsDataType} from '../record_links';
-import {RecordLinksToolbar} from '../toolbars';
-import {compiledSpecService} from '../../../../../context/slices/helpers/compiledSpecService';
 import {useDataGridStyles} from '../../../../../utils/useDataGridStyles';
+import {useScreenSize} from '../../../../../utils/useScreenSize';
 import {
   buildColumnFromSystemField,
   buildVerticalStackColumn,
+  KeyValueTable,
   RECORD_GRID_LABELS,
 } from '../../../notebook/record_table';
-import {useScreenSize} from '../../../../../utils/useScreenSize';
+import RecordRouteDisplay from '../../../ui/record_link';
+import {gridParamsDataType} from '../record_links';
+import {RecordLinksToolbar} from '../toolbars';
 
 type ColumnType = 'CREATED' | 'CREATED_BY' | 'LAST_UPDATED' | 'LAST_UPDATED_BY';
 
@@ -71,74 +72,6 @@ const style = {
   bgcolor: 'background.paper',
   p: 1,
 };
-
-// Unused component - referenced in RelatedRecordSelector and commented out
-// because it is unreachable (I think - SC)
-export function DataGridNoLink(props: {
-  links: RecordReference[];
-  relation_linked_vocab: string;
-  relation_type: string;
-}) {
-  const columns: any = [
-    {
-      field: 'relation_type_vocabPair',
-      headerName: 'Relationship',
-      headerClassName: 'faims-record-link--header',
-      minWidth: 200,
-      flex: 0.2,
-      valueGetter: (params: gridParamsDataType) =>
-        params.value !== undefined
-          ? params.value[0]
-          : props.relation_linked_vocab,
-    },
-    {
-      field: 'record_label',
-      headerName: 'Record',
-      headerClassName: 'faims-record-link--header',
-      minWidth: 200,
-      flex: 0.4,
-      valueGetter: (params: GridCellParams) =>
-        params.row.record_label ?? params.row.record_id,
-      renderCell: (params: GridCellParams) => (
-        <>
-          {params.value}
-          <CircularProgress size={12} thickness={5} />
-        </>
-      ),
-    },
-    {
-      field: 'record_id',
-      headerName: 'Updated',
-      headerClassName: 'faims-record-link--header',
-      minWidth: 100,
-      valueGetter: () => '',
-      flex: 0.4,
-    },
-  ];
-  // remove any invalid entries in links (due to a bug elsewhere)
-  const links = props.links.filter(link => link.record_id);
-
-  return props.links !== null && props.links.length > 0 ? (
-    <DataGrid
-      autoHeight
-      density={'compact'}
-      rowCount={5}
-      pageSizeOptions={[5, 10, 20]} // 100 here to disable an error thrown by MUI
-      disableRowSelectionOnClick
-      columns={columns}
-      initialState={{
-        sorting: {
-          sortModel: [{field: 'lastUpdatedBy', sort: 'desc'}],
-        },
-        pagination: {paginationModel: {pageSize: 5}},
-      }}
-      rows={links}
-      getRowId={r => r.record_id}
-    />
-  ) : (
-    <Box></Box>
-  );
-}
 
 interface DataGridLinksComponentProps {
   project_id: string;
@@ -173,7 +106,7 @@ export function DataGridFieldLinksComponent(
     selectProjectById(state, props.project_id)
   )?.uiSpecificationId;
   const uiSpec = uiSpecId ? compiledSpecService.getSpec(uiSpecId) : undefined;
-
+  const history = useNavigate();
   const theme = useTheme();
   const styles = useDataGridStyles(theme); // Add this
 
@@ -213,6 +146,20 @@ export function DataGridFieldLinksComponent(
       });
   }
 
+  const handleRowClick = useCallback<GridEventListener<'rowClick'>>(
+    params => {
+      history(
+        getExistingRecordRoute({
+          serverId: props.serverId,
+          projectId: props.project_id,
+          recordId: (params.row.record_id || '').toString(),
+          revisionId: (params.row.revision_id || '').toString(),
+        })
+      );
+    },
+    [history, props.serverId, props.project_id]
+  );
+
   function ChildRecordDisplay(props: {
     current_record_id: RecordID;
     child_record: RecordMetadata;
@@ -230,59 +177,41 @@ export function DataGridFieldLinksComponent(
       fn();
     }, [props.child_record]);
 
-    const route = getExistingRecordRoute({
-      serverId: props.serverId,
-      projectId: props.child_record.project_id,
-      recordId: props.child_record.record_id,
-      revisionId: props.child_record.revision_id,
-    });
-
     if (props.child_record.record_id === props.current_record_id) {
       return <RecordRouteDisplay>This record</RecordRouteDisplay>;
     } else {
-      return (
-        <Stack>
-          <Typography variant={'body2'} fontWeight={'bold'}>
-            <RecordRouteDisplay
-              link={props.child_record.deleted ? '' : route}
-              deleted={props.child_record.deleted}
-            >
-              {props.child_record.type + ': ' + props.child_record.hrid}
-            </RecordRouteDisplay>
-          </Typography>
-          {displayFields.map(fieldName => {
-            if (props.child_record.data) {
-              const value = props.child_record.data[fieldName];
-              if (typeof value === 'string')
-                return (
-                  <Typography key={fieldName} variant={'body2'}>
-                    {uiSpec ? getFieldLabel(uiSpec, fieldName) : fieldName}:{' '}
-                    {props.child_record.data
-                      ? props.child_record.data[fieldName]
-                      : ''}
-                  </Typography>
-                );
-            }
-            return <></>;
-          })}
-        </Stack>
-      );
+      const data: {[key: string]: string} = {
+        ID: props.child_record.hrid,
+      };
+      displayFields.forEach(fieldName => {
+        if (props.child_record.data) {
+          const value = props.child_record.data[fieldName];
+          if (typeof value === 'string') {
+            const label = uiSpec ? getFieldLabel(uiSpec, fieldName) : fieldName;
+            data[label] = value;
+          }
+        }
+      });
+
+      return <KeyValueTable data={data} />;
     }
   }
 
   const relation_column = {
     field: 'relation_type_vocabPair',
     headerName: 'Relationship',
-    headerClassName: 'faims-record-link--header',
-    minWidth: 200,
+    minWidth: 100,
     flex: 0.2,
     valueGetter: (params: gridParamsDataType) => {
       const rel = params.row.relationship;
       if (rel.linked && rel.linked.length > 0) {
+        console.log('relationship', rel);
+        // if the relationship has a linked record, return the type
         // find the link that is back to us
         const links_to_us = rel.linked.filter(
           (link: any) => link.record_id === params.id
         );
+        console.log('links_to_us', links_to_us);
         if (links_to_us && links_to_us.length > 0) {
           const rvp = links_to_us[0].relation_type_vocabPair;
           return (rvp && rvp.length > 0 && rvp[1]) || 'linked';
@@ -294,9 +223,9 @@ export function DataGridFieldLinksComponent(
 
   const record_column: GridColDef = {
     field: 'record',
-    headerName: 'Field Id',
-    minWidth: 140,
-    flex: 1,
+    headerName: 'Details',
+    minWidth: 200,
+    flex: 2,
     valueGetter: (params: GridCellParams) =>
       params.row.type + ' ' + params.row.hrid,
     renderCell: (params: GridCellParams) => (
@@ -309,7 +238,7 @@ export function DataGridFieldLinksComponent(
   };
 
   const smallScreenColumn: GridColDef | null =
-    uiSpec && (currentSize === 'xs' || currentSize === 'sm')
+    uiSpec && currentSize === 'xs'
       ? buildVerticalStackColumn({
           summaryFields: [],
           columnLabel: RECORD_GRID_LABELS.VERTICAL_STACK_COLUMN_LABEL,
@@ -319,28 +248,21 @@ export function DataGridFieldLinksComponent(
         })
       : null;
 
+  /** Columns that must always be shown */
+  const SYSTEM_COLUMNS: ColumnType[] = ['CREATED', 'CREATED_BY'];
+
+  /** Columns to show in large view */
+  if (currentSize === 'lg') {
+    SYSTEM_COLUMNS.push('LAST_UPDATED');
+    SYSTEM_COLUMNS.push('LAST_UPDATED_BY');
+  }
+
   // System fields for medium+ screens
   const systemColumns: GridColDef[] = uiSpec
-    ? (
-        [
-          'CREATED',
-          'CREATED_BY',
-          'LAST_UPDATED',
-          'LAST_UPDATED_BY',
-        ] as ColumnType[]
-      ).map(c =>
+    ? SYSTEM_COLUMNS.map(c =>
         buildColumnFromSystemField({columnType: c, uiSpecification: uiSpec!})
       )
     : [];
-
-  const updated_by_column = {
-    field: 'lastUpdatedBy',
-    headerName: 'Updated',
-    headerClassName: 'faims-record-link--header',
-    minWidth: 150,
-    flex: 0.2,
-    valueGetter: (params: GridCellParams) => params.row.updated_by,
-  };
 
   const columns: GridColDef[] = [];
 
@@ -448,6 +370,7 @@ export function DataGridFieldLinksComponent(
             density={'compact'}
             pageSizeOptions={[5, 10, 20]}
             disableRowSelectionOnClick
+            onRowClick={handleRowClick}
             slots={{
               footer: RecordLinksToolbar,
             }}

--- a/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
+++ b/app/src/gui/components/record/relationships/field_level_links/datagrid.tsx
@@ -200,7 +200,7 @@ export function DataGridFieldLinksComponent(
   const relation_column = {
     field: 'relation_type_vocabPair',
     headerName: 'Relationship',
-    minWidth: 100,
+    minWidth: 150,
     flex: 0.2,
     valueGetter: (params: gridParamsDataType) => {
       const rel = params.row.relationship;
@@ -208,7 +208,7 @@ export function DataGridFieldLinksComponent(
         // if the relationship has a linked record, return the type
         // find the link that is back to us
         const links_to_us = rel.linked.filter(
-          (link: any) => link.record_id === params.id
+          (link: any) => link.record_id === props.record_id
         );
         if (links_to_us && links_to_us.length > 0) {
           const rvp = links_to_us[0].relation_type_vocabPair;
@@ -273,8 +273,8 @@ export function DataGridFieldLinksComponent(
           {/*  relationship above the stacked details */}
           {props.relation_type !== 'Child' && (
             <Typography variant="body2" sx={{mb: 1}}>
-              <strong>Relationship:</strong>{' '}
-              {relation_column.valueGetter!(params as any)}
+              Relationship:{' '}
+              <strong>{relation_column.valueGetter!(params as any)}</strong>
             </Typography>
           )}
           {/* vertical-stack cell under  */}

--- a/app/src/gui/fields/RelatedRecordSelector.tsx
+++ b/app/src/gui/fields/RelatedRecordSelector.tsx
@@ -158,6 +158,10 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
     return <p>Error... could not find ui specification.</p>;
   }
 
+  // State containing the list of available records that can be linked to the current record.
+  // This list excludes any records that are already linked (for single-value fields) or
+  // already present in the current field value (for multi-value fields). Used to populate
+  // the dropdown/selector for choosing which record to link to.
   const [relatedRecords, setRelatedRecords] = React.useState<RecordReference[]>(
     []
   );
@@ -351,6 +355,7 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
       else newValue = [new_child_record];
     } else newValue = new_child_record;
     props.form.setFieldValue(props.field.name, newValue, true);
+    console.log('set field value', props.field.name, newValue);
     return new_record_id;
   };
 
@@ -368,7 +373,11 @@ export function RelatedRecordSelector(props: RelatedRecordSelectorProps) {
     else newValue = selectedRecord;
 
     props.form.setFieldValue(props.field.name, newValue, true);
-    props.form.submitForm();
+
+    if (record_id !== selectedRecord.record_id) {
+      props.form.submitForm(); // this will update the record currently being edited
+    }
+
     const current_record = {
       record_id: record_id,
       field_id: field_name,

--- a/app/src/gui/pages/record.tsx
+++ b/app/src/gui/pages/record.tsx
@@ -113,7 +113,8 @@ export default function Record() {
   const history = useNavigate();
 
   if (!serverId) return <></>;
-  const [value, setValue] = React.useState('1');
+  const [tabValue, setTabValue] = React.useState('1');
+
   if (!projectId) return <></>;
   const project = useAppSelector(state => selectProjectById(state, projectId));
   if (!project) return <></>;
@@ -144,7 +145,7 @@ export default function Record() {
   const not_xs = useMediaQuery(theme.breakpoints.up('sm'));
   const mq_above_md = useMediaQuery(theme.breakpoints.up('md'));
   const [open, setOpen] = React.useState(false);
-  const [pressedvalue, setpressedvalue] = useState(value);
+  const [pressedvalue, setpressedvalue] = useState(tabValue);
   const [relatedRecords, setRelatedRecords] = useState([] as RecordLinkProps[]);
   const [parentLinks, setParentLinks] = useState([] as ParentLinkProps[]);
   const [is_link_ready, setIs_link_ready] = useState(false);
@@ -160,6 +161,16 @@ export default function Record() {
     ROUTES.INDIVIDUAL_NOTEBOOK_ROUTE + serverId + '/' + projectId;
   const [backLink, setBackLink] = useState<string>(projectLink);
   const [backIsParent, setBackIsParent] = useState(false);
+
+  // if there are no conflicts and the tab value is 4 then default back to tab 1
+  useEffect(() => {
+    if (
+      conflicts === null ||
+      conflicts['available_heads'] === undefined ||
+      Object.keys(conflicts['available_heads']).length === 1
+    )
+      setTabValue('1');
+  }, [conflicts]);
 
   useEffect(() => {
     const getIni = async () => {
@@ -195,7 +206,7 @@ export default function Record() {
         setBackIsParent(false);
         setUpdatedRevisionId(revisionId);
         setselectedRevision(revisionId!);
-        setValue('1');
+        setTabValue('1');
       });
     };
 
@@ -356,14 +367,14 @@ export default function Record() {
 
   const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {
     if (
-      value === '4' &&
+      tabValue === '4' &&
       conflicts !== null &&
       conflicts['available_heads'] !== undefined &&
       Object.keys(conflicts['available_heads']).length > 1
     ) {
       setOpen(true);
       setpressedvalue(newValue);
-    } else setValue(newValue);
+    } else setTabValue(newValue);
   };
 
   const handleUnlink = (
@@ -418,7 +429,7 @@ export default function Record() {
   };
 
   const handleConfirm = () => {
-    setValue(pressedvalue);
+    setTabValue(pressedvalue);
     setOpen(false);
   };
 
@@ -532,7 +543,7 @@ export default function Record() {
           )}
       </Box>
       <Paper square elevation={0} variant={'outlined'}>
-        <TabContext value={value}>
+        <TabContext value={tabValue}>
           <AppBar
             position="static"
             sx={{


### PR DESCRIPTION
## JIRA Ticket

[BSS-973
](https://jira.csiro.au/browse/BSS-973)

## Description

This PR revives the old feature/child-records-table branch, rebases it onto the latest develop, and resolves all conflicts, then realigns the child-record DataGrid with the styling and behaviour of the main RecordsTable. 
Have kep the vehicle record id included in field id for better reference, rest all is aligned with main records table, have additional actions column  as before that allows "remove link".

The column set is now identical—Record is renamed Field Id, date/user metadata columns are in the same order, and the shared helpers buildColumnFromSystemField and buildVerticalStackColumn are reused to eliminate duplicate logic.



## How to Test

Create a parent record which includes related record selector like  - Structure and Assets 
Attached test survey for reference.

[1750999411809-related-record-selector.json](https://github.com/user-attachments/files/20967735/1750999411809-related-record-selector.json)

Add child records to that parent record and view the table behaviour, it is now more easy to read, more responsive and aligned with main records table in terms of content and usability.,

please save the parent record and view the newly added child records under related record structure step.

Related record table BEFORE: 
![image](https://github.com/user-attachments/assets/eae9ab94-716f-4894-bf26-9a7bbcbee011)

Related record table AFTER: 
please refer to the screenshots: 

![image](https://github.com/user-attachments/assets/23365633-64e9-4f8c-ba67-7cdf8bdb1ae0)

  
![localhost_3000_surveys_development-faims-server_1750823726118-relation-sampler_records_rec-305ab975-74b2-4470-b499-5a5236b996ad_revision_frev-8af4db4c-898c-47c0-95ad-018905d3c026(iPhone SE)](https://github.com/user-attachments/assets/676f6e36-bcdd-403c-863d-93ac3f8f9d7f)

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
