### PR TITLE
better alignment of formatted text in radio group

### DIFF
--- a/app/src/gui/fields/radio.tsx
+++ b/app/src/gui/fields/radio.tsx
@@ -122,14 +122,15 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
                   />
                 }
                 label={
-                  <span
+                  <div
                     style={{
-                      display: 'contents',
+                      display: 'block',
                       whiteSpace: 'normal',
                       wordBreak: 'break-word',
                       lineHeight: '1.5',
-                      paddingTop: '2px',
+                      paddingTop: '6px',
                       paddingLeft: '0px',
+                      marginTop: '0px',
                     }}
                     dangerouslySetInnerHTML={{
                       __html: contentToSanitizedHtml(option.label),
@@ -143,7 +144,21 @@ export class RadioGroup extends React.Component<RadioGroupProps & Props> {
                   marginBottom: 1,
                   '& .MuiFormControlLabel-label': {
                     display: 'block',
-                    marginTop: '5px',
+                    marginTop: '0px',
+                    alignSelf: 'flex-start',
+                    // markdown formatted text will be wrapped in a <p> tag
+                    // so we need to remove the default margin
+                    // and padding from the <p> tag
+                    '& p': {
+                      margin: 0,
+                      padding: 0,
+                    },
+                    '& p:first-child': {
+                      marginTop: 0,
+                    },
+                    '& p:last-child': {
+                      marginBottom: 0,
+                    },
                   },
                 }}
               />


### PR DESCRIPTION
# Better alignment of formatted text in radio group

## JIRA Ticket

None

## Description

Alignment of text labels with radio buttons was broken.

## Proposed Changes

Since we're inserting markdown formatted text it is wrapped in a paragraph tag. 
Needed to strip margins from the embedded paragraphs to fix the alignment.
![localhost_3000_surveys_development-faims-server_1750823726118-relation-sampler_records_rec-305ab975-74b2-4470-b499-5a5236b996ad_revision_frev-8af4db4c-898c-47c0-95ad-018905d3c026](https://github.com/user-attachments/assets/12b32656-6bb1-4205-b824-d5de6e4c85fe)

## How to Test

View a notebook with radio buttons.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
