### PR TITLE
feat: duplicate condition on split/add in condition editor

### DIFF
--- a/web/src/designer/components/condition/ConditionControl.tsx
+++ b/web/src/designer/components/condition/ConditionControl.tsx
@@ -129,10 +129,15 @@ const BooleanConditionControl = (props: ConditionProps) => {
   const addCondition = () => {
     if (condition) {
       const existing = condition.conditions || [];
-      // construct a condition with a new empty field condition
+      // Duplicate the first existing condition (or use empty condition if none)
+      const template =
+        existing.length > 0
+          ? JSON.parse(JSON.stringify(existing[0]))
+          : {...EMPTY_FIELD_CONDITION};
+
       const newCondition = {
         ...condition,
-        conditions: [...existing, EMPTY_FIELD_CONDITION],
+        conditions: [...existing, template],
       };
       updateCondition(newCondition);
     }
@@ -484,9 +489,10 @@ export const FieldConditionControl = (props: ConditionProps) => {
 
   const handleSplitCondition = () => {
     if (props.onChange) {
+      // turns the single condition into an AND group with a duplicate,
       props.onChange({
         operator: 'and',
-        conditions: [condition, {field: '', operator: 'equal', value: ''}],
+        conditions: [condition, JSON.parse(JSON.stringify(condition))],
       });
     }
   };


### PR DESCRIPTION
# feat: duplicate condition on split/add in condition editor

## Description

Improves the condition editor UX by duplicating the current condition when:
- a user splits a single condition into an `and/or` group (via the "Split" button),
- or adds a new condition to an existing `and/or` group.

This supports the common case where users want to define multiple values for the same (non multi select) field (e.g., `status = active OR status = pending`) without re-selecting the field and operator each time.

## Proposed Changes

- `BooleanConditionControl`:  
  `addCondition()` now duplicates the first existing condition (or uses `EMPTY_FIELD_CONDITION` if none).
- `FieldConditionControl`:  
  `handleSplitCondition()` now creates an AND group with two copies of the current condition.

## How to Test

1. In Designer, open the condition editor for a section or field.
2. Click the “Split” button:
   - Expected: the new group has two identical conditions.
3. Add a third condition using “Add another condition”:
   - Expected: new condition is a duplicate of the first in the group.
4. Modify one of the values:
   - Expected: only that condition updates; others remain unchanged.
5. Repeat with other target fields types.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.