### PR TITLE
feat: Add Save/Cancel buttons to condition editor

### DIFF
--- a/web/src/designer/components/condition/ConditionModal.tsx
+++ b/web/src/designer/components/condition/ConditionModal.tsx
@@ -12,33 +12,88 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Button, Dialog} from '@mui/material';
-import {useState} from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Stack,
+} from '@mui/material';
+import {useCallback, useEffect, useState} from 'react';
 import {ConditionControl} from './ConditionControl';
-import {ConditionProps} from './types';
+import {ConditionProps, ConditionType} from './types';
 import QuizIcon from '@mui/icons-material/Quiz';
 
 export const ConditionModal = (props: ConditionProps & {label: string}) => {
   const [open, setOpen] = useState(false);
+  // Local draft copy
+  const [draft, setDraft] = useState<ConditionType | null>(
+    props.initial ?? null
+  );
+
+  // Reset the draft whenever the parent value changes while closed
+  // Doing it this way because the modal exists even when closed
+  useEffect(() => {
+    if (!open) setDraft(props.initial ?? null);
+  }, [props.initial, open]);
+
+  // Open the dialog and refresh draft from parent prop
+  const handleOpen = () => {
+    setDraft(props.initial ?? null);
+    setOpen(true);
+  };
+
+  const close = () => setOpen(false);
+
+  // Warn when cancelling
+  const handleCancel = useCallback(() => {
+    const changed =
+      JSON.stringify(draft) !== JSON.stringify(props.initial || null);
+    if (changed) {
+      const confirm = window.confirm(
+        'Discard unsaved changes to this condition?'
+      );
+      if (!confirm) return;
+    }
+    close();
+  }, [draft, props.initial]);
+
+  // Commit draft
+  const handleSave = () => {
+    if (props.onChange) props.onChange(draft);
+    close();
+  };
 
   return (
     <>
-      <Button
-        onClick={() => setOpen(true)}
-        size="small"
-        startIcon={<QuizIcon />}
-      >
+      <Button onClick={handleOpen} size="small" startIcon={<QuizIcon />}>
         {props.label}
       </Button>
-      <Dialog open={open} fullWidth={true} maxWidth="lg">
-        <ConditionControl
-          initial={props.initial}
-          onChange={props.onChange}
-          field={props.field}
-          view={props.view}
-        />
 
-        <Button onClick={() => setOpen(false)}>Close</Button>
+      <Dialog open={open} fullWidth={true} maxWidth="lg" onClose={handleCancel}>
+        <DialogContent>
+          <ConditionControl
+            initial={draft}
+            onChange={setDraft}
+            field={props.field}
+            view={props.view}
+          />
+        </DialogContent>
+
+        <DialogActions>
+          <Stack direction="row" spacing={2}>
+            <Button variant="outlined" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleSave}
+              disabled={draft === null}
+            >
+              Save
+            </Button>
+          </Stack>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/web/src/designer/state/uiSpec-reducer.ts
+++ b/web/src/designer/state/uiSpec-reducer.ts
@@ -23,6 +23,7 @@ import {
   removeFieldFromSummaryForViewset,
   replaceFieldInCondition,
 } from './helpers/uiSpec-helpers';
+import {v4 as uuidv4} from 'uuid';
 
 const uiSpecInitialState: NotebookUISpec =
   initialState.notebook['ui-specification'].present;


### PR DESCRIPTION
# feat: Add Save/Cancel buttons to condition editor

## Description

This PR adds **Save** and **Cancel** functionality to the condition editor modal.

Currently, any changes to conditions were applied immediately in redux. This could lead to accidental or partial edits being committed without confirmation. This change makes sure users can review changes and choose to either commit to them or discard them.

## Proposed Changes

- Refactored `ConditionModal` to:
  - Store a local `draft` of the condition
  - Only call `onChange` when the user clicks **Save**
  - Add **Cancel** button with confirmation if unsaved edits exist
- Updated modal layout to include `DialogActions` for buttons
- Minor tidy-up: removed now-unused state management logic

## How to Test

1. Open Designer
2. Click the button to create/edit a condition to open the modal.
3. Make some changes:
   - Click **Cancel** → verify you're prompted if edits were made.
   - Click **Save** → verify the changes are applied to the form.
4. Ensure that unmodified edits do not trigger unnecessary updates.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc-style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.