### PR TITLE
Facilitate migration from v1.0

### DIFF
--- a/api/src/auth/authRoutes.ts
+++ b/api/src/auth/authRoutes.ts
@@ -89,6 +89,15 @@ export const DEFAULT_REDIRECT_URL = WEBAPP_PUBLIC_URL + '/auth-return';
  * @param socialProviders an array of login provider identifiers
  */
 export function addAuthRoutes(app: Router, socialProviders: AuthProvider[]) {
+
+  // For legacy versions of the app, we provide a message on /auth to
+  // let them know they need to upgrade to the latest version
+  app.get('/auth', (req, res) => {
+    res.render('auth-legacy', {
+      socialProviders,
+    });
+  });
+
   /**
    * Handle local login OR register request with username and password
    */

--- a/api/views/auth-legacy.handlebars
+++ b/api/views/auth-legacy.handlebars
@@ -1,0 +1,13 @@
+{{#if messages.message}}
+  <div class='alert alert-warning'>{{messages.message}}</div>
+{{/if}}
+{{#if messages.success}}
+  <div class='alert alert-success'>{{messages.success}}</div>
+{{/if}}
+<div class='auth-header'>
+  <h2>Please Update</h2>
+  <p>You are using an older version of the app. Please visit 
+    your app store and update to the latest version to continue using the app.
+  </p>
+  <button class='btn btn-primary' onclick="window.history.back()">Return to the App</button>
+</div>

--- a/api/views/auth-legacy.handlebars
+++ b/api/views/auth-legacy.handlebars
@@ -9,5 +9,5 @@
   <p>You are using an older version of the app. Please visit 
     your app store and update to the latest version to continue using the app.
   </p>
-  <button class='btn btn-primary' onclick="window.history.back()">Return to the App</button>
+  <button class='btn btn-primary' type="button" onclick="window.history.back()">Return to the App</button>
 </div>

--- a/app/.env.dist
+++ b/app/.env.dist
@@ -58,4 +58,6 @@ VITE_APP_PRIVACY_POLICY_URL=https://fieldnote.au/privacy
 # Contact link, if missing, no contact link will be shown
 VITE_APP_CONTACT_URL=https://fieldnote.au/contact
 # Should the app use breadcrumbs for navigation, 'breadcrumbs' or 'none'
-VITE_NAVIGATION=breadcrumbs 
+VITE_NAVIGATION=breadcrumbs
+# Should we migrate old v1.0 style databases on startup?  'true' for yes, anything else is no
+VITE_MIGRATE_OLD_DATABASES=false

--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -453,12 +453,8 @@ function showRecordLinks(): boolean {
  */
 function migrateOldDatabases(): boolean {
   const migrateOldDatabases = import.meta.env.VITE_MIGRATE_OLD_DATABASES;
-  if (migrateOldDatabases === '' || migrateOldDatabases === undefined) {
-    return false; // default to false
-  }
-  return migrateOldDatabases.toLowerCase() === 'true';
+  return TRUTHY_STRINGS.includes(migrateOldDatabases.toLowerCase());
 }
-
 
 // this should disappear once we have listing activation set up
 export const AUTOACTIVATE_LISTINGS = true;

--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -447,6 +447,19 @@ function showRecordLinks(): boolean {
   return import.meta.env.VITE_SHOW_RECORD_LINKS === 'true';
 }
 
+
+/**
+ * Should we automatically migrate old v1.0 style databases on startup?
+ */
+function migrateOldDatabases(): boolean {
+  const migrateOldDatabases = import.meta.env.VITE_MIGRATE_OLD_DATABASES;
+  if (migrateOldDatabases === '' || migrateOldDatabases === undefined) {
+    return false; // default to false
+  }
+  return migrateOldDatabases.toLowerCase() === 'true';
+}
+
+
 // this should disappear once we have listing activation set up
 export const AUTOACTIVATE_LISTINGS = true;
 export const CONDUCTOR_URLS = get_conductor_urls();
@@ -480,3 +493,4 @@ export const SHOW_RECORD_LINKS = showRecordLinks();
 export const SUPPORT_EMAIL = get_support_email();
 export const PRIVACY_POLICY_URL = get_app_privacy_policy_url();
 export const CONTACT_URL = get_app_contact_url();
+export const MIGRATE_OLD_DATABASES = migrateOldDatabases();


### PR DESCRIPTION
# Facilitate migration from v1.0

## JIRA Ticket

None

## Description

Users of the v1.0 app would need to reset devices to use the new app and would lose any data on device that was not synced.

## Proposed Changes

Adds a placeholder page at /auth on conductor with a message about updating the app, this should catch any existing users who try to login with the old app.

Adds a migration in the app to rename any existing dataDbs to use the new name format.   The old database is then deleted.  This means that when the user re-activates the notebook, they will see whatever data was present before the update without having to sync.  This should include any data on device that had not been synced before.

## How to Test

Complex to test.   Set up a v1.0.0 server and create a notebook, create some records, activate the notebook in the app and sync.   

Shut down the v1.0.0 server. Run migrate from current main, run the api server, run the app.  On refreshing the app page in the browser, the migration should happen.  Note the messages in the console.

Tested in browser but not on device as it would be too complex to establish the same sequence.  Hoping that it would work as expected!


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
