### PR TITLE
Fix control center infinite loop in Firefox

### DIFF
--- a/web/src/components/dialogs/create-project-invite.tsx
+++ b/web/src/components/dialogs/create-project-invite.tsx
@@ -20,6 +20,9 @@ export const CreateProjectInvite = () => {
   const [open, setOpen] = useState(false);
 
   return (
+    // modal is false here because of a bug in radix-ui that leads to
+    // an infinite recursion in Firefox when the select control in the form
+    // is clicked.
     <Dialog open={open} onOpenChange={setOpen} modal={false}>
       <DialogTrigger asChild className="w-fit">
         <Button

--- a/web/src/components/dialogs/create-project-invite.tsx
+++ b/web/src/components/dialogs/create-project-invite.tsx
@@ -20,7 +20,7 @@ export const CreateProjectInvite = () => {
   const [open, setOpen] = useState(false);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={setOpen} modal={false}>
       <DialogTrigger asChild className="w-fit">
         <Button
           variant="outline"

--- a/web/src/components/dialogs/teams/create-team-invite.tsx
+++ b/web/src/components/dialogs/teams/create-team-invite.tsx
@@ -19,6 +19,9 @@ export const CreateTeamInvite = ({teamId}: {teamId: string}) => {
   const [open, setOpen] = useState(false);
 
   return (
+    // modal is false here because of a bug in radix-ui that leads to
+    // an infinite recursion in Firefox when the select control in the form
+    // is clicked.
     <Dialog open={open} onOpenChange={setOpen} modal={false}>
       <DialogTrigger asChild className="w-fit">
         <Button

--- a/web/src/components/dialogs/teams/create-team-invite.tsx
+++ b/web/src/components/dialogs/teams/create-team-invite.tsx
@@ -19,7 +19,7 @@ export const CreateTeamInvite = ({teamId}: {teamId: string}) => {
   const [open, setOpen] = useState(false);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={setOpen} modal={false}>
       <DialogTrigger asChild className="w-fit">
         <Button
           variant="outline"


### PR DESCRIPTION
Signed-off-by: Steve Cassidy <steve.cassidy@mq.edu.au>

# Fix control center infinite loop in Firefox

## JIRA Ticket

None

## Description

Firefox enters an infinite loop when you click the 'Role' select control while making a
team or notebook invite. 

## Proposed Changes

Seems to be due to a bug in radix-ui with focus inside dialog modals.   Solution is to make
the invite form non-modal. 

## How to Test

In Firefox, make an invite. 


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
