### PR TITLE
Assign a project to a new team in Control Center

### DIFF
--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -40,6 +40,7 @@ import {
   projectRoleToAction,
   ProjectUIModel,
   PutChangeNotebookStatusInputSchema,
+  PutChangeNotebookTeamInputSchema,
   PutUpdateNotebookInputSchema,
   PutUpdateNotebookResponse,
   removeProjectRole,
@@ -55,6 +56,7 @@ import {getDataDb} from '../couchdb';
 import {createManyRandomRecords} from '../couchdb/devtools';
 import {
   changeNotebookStatus,
+  changeNotebookTeam,
   countRecordsInNotebook,
   createNotebook,
   deleteNotebook,
@@ -317,6 +319,27 @@ api.put(
   }),
   async ({body: {status}, params: {projectId}}, res) => {
     await changeNotebookStatus({projectId, status});
+    res.sendStatus(200);
+    return;
+  }
+);
+
+// PUT change project team
+api.put(
+  '/:projectId/team',
+  requireAuthenticationAPI,
+  isAllowedToMiddleware({
+    action: Action.CHANGE_PROJECT_TEAM,
+    getResourceId(req) {
+      return req.params.projectId;
+    },
+  }),
+  processRequest({
+    params: z.object({projectId: z.string()}),
+    body: PutChangeNotebookTeamInputSchema,
+  }),
+  async ({body: {teamId}, params: {projectId}}, res) => {
+    await changeNotebookTeam({projectId, teamId});
     res.sendStatus(200);
     return;
   }

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -486,6 +486,26 @@ export const changeNotebookStatus = async ({
 };
 
 /**
+ * Updates the team associated with a notebook
+ */
+export const changeNotebookTeam = async ({
+  projectId,
+  teamId,
+}: {
+  projectId: string;
+  teamId: string;
+}) => {
+  // get existing project record
+  const project = await getProjectById(projectId);
+
+  // update team
+  const updated = {...project, ownedByTeamId: teamId};
+
+  // write it back
+  await putProjectDoc(updated);
+};
+
+/**
  * deleteNotebook - DANGER!! Delete a notebook and all its data
  * @param project_id - project identifier
  */

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -286,6 +286,15 @@ export type PutChangeNotebookStatusInput = z.infer<
   typeof PutChangeNotebookStatusInputSchema
 >;
 
+// PUT :/id change project team
+export const PutChangeNotebookTeamInputSchema = z.object({
+  teamId: z.string().min(1, 'Team ID is required'),
+});
+
+export type PutChangeNotebookTeamInput = z.infer<
+  typeof PutChangeNotebookTeamInputSchema
+>;
+
 // POST create new notebook from template response
 export const PostCreateNotebookResponseSchema = z.object({
   notebook: z.string(),

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -60,6 +60,9 @@ export enum Action {
   // Change open/closed status
   CHANGE_PROJECT_STATUS = 'CHANGE_PROJECT_STATUS',
 
+  // Change team of a project
+  CHANGE_PROJECT_TEAM = 'CHANGE_PROJECT_TEAM',
+
   // Delete the project
   DELETE_PROJECT = 'DELETE_PROJECT',
 
@@ -333,6 +336,12 @@ export const actionDetails: Record<Action, ActionDetails> = {
   [Action.CHANGE_PROJECT_STATUS]: {
     name: 'Change Project Status',
     description: 'Modify the open/closed status of a project',
+    resourceSpecific: true,
+    resource: Resource.PROJECT,
+  },
+  [Action.CHANGE_PROJECT_TEAM]: {
+    name: 'Change Project Team',
+    description: 'Change the team associated with a project',
     resourceSpecific: true,
     resource: Resource.PROJECT,
   },
@@ -991,6 +1000,7 @@ export const roleActions: Record<
       Action.UPDATE_PROJECT_DETAILS,
       Action.UPDATE_PROJECT_UISPEC,
       Action.CHANGE_PROJECT_STATUS,
+      Action.CHANGE_PROJECT_TEAM,
       Action.EXPORT_PROJECT_DATA,
 
       Action.VIEW_PROJECT_INVITES,

--- a/library/data-model/tests/permissionfunctions.test.ts
+++ b/library/data-model/tests/permissionfunctions.test.ts
@@ -225,6 +225,7 @@ describe('Authorization Helper Functions', () => {
               Action.UPDATE_PROJECT_DETAILS,
               Action.UPDATE_PROJECT_UISPEC,
               Action.CHANGE_PROJECT_STATUS,
+              Action.CHANGE_PROJECT_TEAM,
               Action.EXPORT_PROJECT_DATA,
 
               // Inherited from PROJECT_CONTRIBUTOR
@@ -245,6 +246,7 @@ describe('Authorization Helper Functions', () => {
       // Direct actions from PROJECT_MANAGER
       expect(actions).toContain(Action.UPDATE_PROJECT_DETAILS);
       expect(actions).toContain(Action.CHANGE_PROJECT_STATUS);
+      expect(actions).toContain(Action.CHANGE_PROJECT_TEAM);
 
       // Inherited from PROJECT_CONTRIBUTOR
       expect(actions).toContain(Action.READ_ALL_PROJECT_RECORDS);

--- a/web/src/components/dialogs/add-project-to-team-dialog.tsx
+++ b/web/src/components/dialogs/add-project-to-team-dialog.tsx
@@ -1,0 +1,47 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {Button} from '../ui/button';
+import {useState} from 'react';
+import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
+import {useAuth} from '@/context/auth-provider';
+import {ErrorComponent} from '@tanstack/react-router';
+import {AddProjectToTeamForm} from '../forms/add-project-to-team-form';
+
+export const AddProjectToTeamDialog = ({projectId}: {projectId: string}) => {
+  const [open, setOpen] = useState(false);
+
+  const {user} = useAuth();
+
+  if (!user) {
+    return <ErrorComponent error="Unauthenticated" />;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild className="w-fit">
+        <Button
+          variant="outline"
+          className="bg-primary text-primary-foreground"
+        >
+          Assign {NOTEBOOK_NAME_CAPITALIZED} to Team
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Assign {NOTEBOOK_NAME_CAPITALIZED} to Team</DialogTitle>
+          <DialogDescription>
+            Assign this {NOTEBOOK_NAME} to a different team. The notebook will
+            then be available to members of the new team.
+          </DialogDescription>
+        </DialogHeader>
+        <AddProjectToTeamForm setDialogOpen={setOpen} projectId={projectId} />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/components/forms/add-project-to-team-form.tsx
+++ b/web/src/components/forms/add-project-to-team-form.tsx
@@ -13,6 +13,10 @@ interface AddProjectToTeamFormProps {
 }
 
 /**
+ * A form component that allows assigning a project to a team.
+ *
+ * @param setDialogOpen - A function to control the dialog's open state.
+ * @param projectId - The ID of the project to be assigned to a team.
  */
 export function AddProjectToTeamForm({
   setDialogOpen,

--- a/web/src/components/forms/add-project-to-team-form.tsx
+++ b/web/src/components/forms/add-project-to-team-form.tsx
@@ -1,0 +1,85 @@
+import {Field, Form} from '@/components/form';
+import {useAuth} from '@/context/auth-provider';
+import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {modifyTeamForProject} from '@/hooks/project-hooks';
+import {useGetTeams} from '@/hooks/queries';
+import {Action} from '@faims3/data-model';
+import {useQueryClient} from '@tanstack/react-query';
+import {z} from 'zod';
+
+interface AddProjectToTeamFormProps {
+  setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  projectId: string;
+}
+
+/**
+ */
+export function AddProjectToTeamForm({
+  setDialogOpen,
+  projectId,
+}: AddProjectToTeamFormProps) {
+  const {user} = useAuth();
+  const QueryClient = useQueryClient();
+  const teams = useGetTeams(user);
+
+  // can we add a user to the team?
+  const canAddProjectToTeam = useIsAuthorisedTo({
+    action: Action.CHANGE_PROJECT_TEAM,
+    resourceId: projectId,
+  });
+
+  const teamsAvailable = teams.data?.teams;
+
+  if (!canAddProjectToTeam || !teamsAvailable) {
+    return <></>;
+  }
+
+  const fields: Field[] = [
+    {
+      name: 'teamId',
+      label: 'Team',
+      options: teamsAvailable.map(t => ({
+        label: t.name,
+        value: t._id,
+      })),
+      schema: z.string(),
+    },
+  ];
+
+  interface onSubmitProps {
+    teamId: string;
+  }
+
+  /**
+   * Handles the form submission
+   */
+  const onSubmit = async ({teamId}: onSubmitProps) => {
+    if (!user) return {type: 'submit', message: 'User not authenticated'};
+
+    const response = await modifyTeamForProject({
+      projectId,
+      teamId,
+      user,
+    });
+
+    if (!response.ok)
+      return {
+        type: 'submit',
+        message: 'Error adding project to team: ' + response.statusText,
+      };
+
+    QueryClient.invalidateQueries({
+      queryKey: ['projectsbyteam', user.token, teamId],
+    });
+
+    setDialogOpen(false);
+  };
+
+  return (
+    <Form
+      fields={fields}
+      onSubmit={onSubmit}
+      submitButtonText={'Assign to Team'}
+    />
+  );
+}

--- a/web/src/components/forms/export-project-form.tsx
+++ b/web/src/components/forms/export-project-form.tsx
@@ -3,6 +3,7 @@ import {Form} from '../form';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {useAuth} from '@/context/auth-provider';
 import {useGetProject} from '@/hooks/queries';
+import {ProjectUIViewsets, UISpecification} from '@faims3/data-model';
 
 /**
  * ExportProjectForm component renders a form for downloading a project's data.
@@ -15,6 +16,12 @@ const ExportProjectForm = ({type}: {type: 'zip' | 'csv'}) => {
   const {projectId} = Route.useParams();
   const {data} = useGetProject({user, projectId});
 
+  if (!data) {
+    return [];
+  }
+
+  const viewSets = data['ui-specification'].viewsets as ProjectUIViewsets;
+
   const fields = [
     {
       name: 'form',
@@ -22,8 +29,8 @@ const ExportProjectForm = ({type}: {type: 'zip' | 'csv'}) => {
       schema: z.string().nonempty(),
       options:
         data && data['ui-specification']?.viewsets
-          ? Object.keys(data['ui-specification']?.viewsets).map(name => ({
-              label: name,
+          ? Object.keys(viewSets).map(name => ({
+              label: viewSets[name].label || name,
               value: name,
             }))
           : [],

--- a/web/src/components/tabs/project/actions.tsx
+++ b/web/src/components/tabs/project/actions.tsx
@@ -22,6 +22,7 @@ import type {
 import {EditProjectDialog} from '@/components/dialogs/edit-project-dialog';
 import {generateTestRecordsForProject} from '@/hooks/project-hooks';
 import {Input} from '@mui/material';
+import {AddProjectToTeamDialog} from '@/components/dialogs/add-project-to-team-dialog';
 
 /**
  * ProjectActions component renders action cards for editing and closing a project.
@@ -92,6 +93,12 @@ const ProjectActions = (): JSX.Element => {
     resourceId: projectId,
   });
 
+  // can we change the project team?
+  const canAddProjectToTeam = useIsAuthorisedTo({
+    action: Action.CHANGE_PROJECT_TEAM,
+    resourceId: projectId,
+  });
+
   const handleCreateTestRecords = async () => {
     if (user)
       await generateTestRecordsForProject({
@@ -150,6 +157,21 @@ const ProjectActions = (): JSX.Element => {
           </List>
         </Card>
 
+        {canAddProjectToTeam && (
+          <Card className="flex-1">
+            <List className="flex flex-col gap-4">
+              <ListItem>
+                <ListLabel>Assign {NOTEBOOK_NAME} to a Team</ListLabel>
+                <ListDescription>
+                  Assign this {NOTEBOOK_NAME} to a team.
+                </ListDescription>
+              </ListItem>
+              <ListItem>
+                <AddProjectToTeamDialog projectId={projectId} />
+              </ListItem>
+            </List>
+          </Card>
+        )}
         <Card className="flex-1">
           <List className="flex flex-col gap-4">
             <ListItem>

--- a/web/src/hooks/project-hooks.ts
+++ b/web/src/hooks/project-hooks.ts
@@ -62,6 +62,27 @@ export const createProjectFromFile = async ({
   });
 };
 
+export const modifyTeamForProject = async ({
+  projectId,
+  teamId,
+  user,
+}: {
+  projectId: string;
+  teamId: string;
+  user: User;
+}) =>
+  await fetch(
+    `${import.meta.env.VITE_API_URL}/api/notebooks/${projectId}/team`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${user.token}`,
+      },
+      body: JSON.stringify({teamId}),
+    }
+  );
+
 export const removeInviteForProject = async ({
   inviteId,
   projectId,


### PR DESCRIPTION
# Assign a project to a new team in Control Center

## JIRA Ticket

None

## Description

As I migrate Fieldmark to the new version I need to assign existing notebooks to teams.  There is currently no
way to do this.

## Proposed Changes

Add an action in control center to assign a notebook to a different team. 

Also adds a quick fix - the drop-down for export was using viewset names rather than labels.

## How to Test

View  a notebook actions tab. If you have permission (project manager/admin) you will see the
new dialog. Teams shown in the drop down are those that you are a member of.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
