### PR TITLE
BUG: Adding the first autoincrementer field to a notebook breaks it

### DIFF
--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -252,52 +252,6 @@ const generateProjectID = (projectName: string): ProjectID => {
   return `${Date.now().toFixed()}-${slugify(projectName)}`;
 };
 
-type AutoIncReference = {
-  form_id: string;
-  field_id: string;
-  label: string;
-};
-
-type AutoIncrementObject = {
-  _id: string;
-  references: AutoIncReference[];
-};
-
-/**
- * Derive an autoincrementers object from a UI Spec
- *   find all of the autoincrement fields in the UISpec and create an
- *   entry for each of them.
- * @param uiSpec a project UI Model
- * @returns an autoincrementers object suitable for insertion into the db or
- *          undefined if there are no such fields
- */
-const getAutoIncrementers = (uiSpec: EncodedProjectUIModel) => {
-  // Note that this relies on the name 'local-autoincrementers' being the same as that
-  // used in the front-end code (LOCAL_AUTOINCREMENTERS_NAME in src/local-data/autoincrementers.ts)
-  const autoinc: AutoIncrementObject = {
-    _id: 'local-autoincrementers',
-    references: [],
-  };
-
-  const fields = uiSpec.fields;
-  for (const field in fields) {
-    // TODO are there other names?
-    if (fields[field]['component-name'] === 'BasicAutoIncrementer') {
-      autoinc.references.push({
-        form_id: fields[field]['component-parameters'].form_id,
-        field_id: fields[field]['component-parameters'].name,
-        label: fields[field]['component-parameters'].label,
-      });
-    }
-  }
-
-  if (autoinc.references.length > 0) {
-    return autoinc;
-  } else {
-    return undefined;
-  }
-};
-
 /**
  * validateDatabases - check that all notebook databases are set up
  *  properly, add design documents if they are missing
@@ -382,11 +336,6 @@ export const createNotebook = async (
     force: true,
   });
 
-  // derive autoincrementers from uispec
-  const autoIncrementers = getAutoIncrementers(uispec);
-  if (autoIncrementers) {
-    await metaDB.put(autoIncrementers);
-  }
   const payload = {_id: 'ui-specification', ...uispec};
   await metaDB.put(
     payload satisfies PouchDB.Core.PutDocument<EncodedProjectUIModel>
@@ -427,21 +376,6 @@ export const updateNotebook = async (
     force: true,
   });
 
-  // derive autoincrementers from uispec
-  const autoIncrementers = getAutoIncrementers(uispec);
-  if (autoIncrementers) {
-    // need to update any existing autoincrementer document
-    // this should have the _rev property so that our update will work
-    const existingAutoInc = (await metaDB.get(
-      'local-autoincrementers'
-    )) as AutoIncrementObject;
-    if (existingAutoInc) {
-      existingAutoInc.references = autoIncrementers.references;
-      await metaDB.put(existingAutoInc);
-    } else {
-      await metaDB.put(autoIncrementers);
-    }
-  }
 
   // update the existing uispec document
   // need the revision id of the existing one to do this...

--- a/api/test/couchdb.test.ts
+++ b/api/test/couchdb.test.ts
@@ -265,16 +265,6 @@ describe('notebook api', () => {
 
       const notebooks = await getUserProjectsDetailed(user);
       expect(notebooks.length).to.equal(1);
-      const db = await getMetadataDb(projectID);
-      if (db) {
-        try {
-          const autoInc = (await db.get('local-autoincrementers')) as any;
-          expect(autoInc.references.length).to.equal(2);
-          expect(autoInc.references[0].form_id).to.equal('FORM1SECTION1');
-        } catch (err) {
-          fail('could not get autoincrementers' + err);
-        }
-      }
     }
   });
 
@@ -436,11 +426,6 @@ describe('notebook api', () => {
       if (newMetadata) {
         expect(newMetadata['name']).to.equal('Updated Test Notebook');
         expect(newMetadata['project_lead']).to.equal('Bob Bobalooba');
-      }
-      const metaDB = await getMetadataDb(projectID);
-      if (metaDB) {
-        const autoInc = (await metaDB.get('local-autoincrementers')) as any;
-        expect(autoInc.references.length).to.equal(3);
       }
     }
   });

--- a/web/src/designer/DesignerWidget.tsx
+++ b/web/src/designer/DesignerWidget.tsx
@@ -82,13 +82,14 @@ export function DesignerWidget({
 }: DesignerWidgetProps) {
   // 1. Migrate + inject designerIdentifiers + reset undo history on each new notebook
   const processedNotebook = useMemo<NotebookWithHistory | undefined>(() => {
-    if (!notebook) return undefined;
+    // check that we have an actual notebook
+    if (!notebook?.metadata) return undefined;
 
     const flat: Notebook = {
       metadata: notebook.metadata,
       'ui-specification': notebook['ui-specification'].present,
     };
-
+    // migrate the notebook - update any out of date fields or structures
     const migrated: Notebook = migrateNotebook(flat);
 
     // Inject in-memory designerIdentifier if missing


### PR DESCRIPTION
# BUG: Adding the first autoincrementer field to a notebook breaks it

## JIRA Ticket

[#1581](https://github.com/FAIMS/FAIMS3/issues/1581)

## Description

If there is no existing auto incrementer in a notebook then adding one triggers a bug - in api/src/couchdb/notebooks.ts it tries to get the existing local-autoincrementer document but that doesn't exist, the crash results in a 404 error to the request.

We don't use that document ever, just remove this bit of code.

## Proposed Changes

Removes the code that checks for auto incrementers and creates the document in the metadata db.   This document was never read so this is no loss.

Also fix a bug in the redraw of the DesignerWidget that caused a crash when I saved my new notebook, check for 'empty' notebook was incorrect.

## How to Test

Create a notebook from scratch and then add an Auto Incrementer field.  Previously it would crash when you tried to save the notebook.  Now it won't.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
