### PR TITLE
Make field name visible in AutoIncrementer

### DIFF
--- a/web/src/designer/components/Fields/BaseFieldEditor.tsx
+++ b/web/src/designer/components/Fields/BaseFieldEditor.tsx
@@ -50,6 +50,8 @@ import {
 
 type Props = {
   fieldName: string;
+  showExtraConfig?: boolean;
+  showHelperText?: boolean;
   children?: React.ReactNode;
 };
 
@@ -69,7 +71,12 @@ type StateType = {
   allowHiding: boolean;
 };
 
-export const BaseFieldEditor = ({fieldName, children}: Props) => {
+export const BaseFieldEditor = ({
+  fieldName,
+  showExtraConfig = true,
+  showHelperText = true,
+  children,
+}: Props) => {
   const field = useAppSelector(
     state => state.notebook['ui-specification'].present.fields[fieldName]
   );
@@ -265,74 +272,76 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
                 />
               </Box>
             </Grid>
-            <Grid item xs={12} md={8}>
-              <DebouncedTextField
-                fullWidth
-                label="Helper Text"
-                value={state.helperText}
-                multiline
-                rows={2}
-                onChange={e => updateProperty('helperText', e.target.value)}
-              />
-              {hasAdvancedSupport && (
-                <>
-                  <Box mt={2}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={showAdvanced}
-                          onChange={e => {
-                            setShowAdvanced(e.target.checked);
-                          }}
-                        />
-                      }
-                      label="Include advanced helper text"
-                    />
-                  </Box>
-
-                  {showAdvanced && (
-                    <Card variant="outlined" sx={{mt: 2, p: 2}}>
-                      <Box
-                        display="flex"
-                        alignItems="center"
-                        justifyContent="space-between"
-                      >
-                        <Typography variant="subtitle2" fontWeight="bold">
-                          Advanced Helper Text (Markdown)
-                        </Typography>
-                        <IconButton
-                          onClick={() => setExpanded(!expanded)}
-                          size="small"
-                          aria-label="Toggle advanced editor"
-                        >
-                          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                        </IconButton>
-                      </Box>
-
-                      <Collapse in={expanded}>
-                        <Box mt={2} sx={{maxHeight: 300, overflowY: 'auto'}}>
-                          <MdxEditor
-                            initialMarkdown={state.advancedHelperText}
-                            handleChange={debounce(
-                              markdown =>
-                                updateProperty('advancedHelperText', markdown),
-                              500,
-                              {leading: false, trailing: true}
-                            )}
-                            editorRef={mdxEditorRef}
+            {showHelperText && (
+              <Grid item xs={12} md={8}>
+                <DebouncedTextField
+                  fullWidth
+                  label="Helper Text"
+                  value={state.helperText}
+                  multiline
+                  rows={2}
+                  onChange={e => updateProperty('helperText', e.target.value)}
+                />
+                {hasAdvancedSupport && (
+                  <>
+                    <Box mt={2}>
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={showAdvanced}
+                            onChange={e => {
+                              setShowAdvanced(e.target.checked);
+                            }}
                           />
-                          <Alert severity="info" sx={{mt: 2}}>
-                            This markdown-based helper will appear in a dialog
-                            when users click the info icon next to the field
-                            label in the app.
-                          </Alert>
+                        }
+                        label="Include advanced helper text"
+                      />
+                    </Box>
+
+                    {showAdvanced && (
+                      <Card variant="outlined" sx={{mt: 2, p: 2}}>
+                        <Box
+                          display="flex"
+                          alignItems="center"
+                          justifyContent="space-between"
+                        >
+                          <Typography variant="subtitle2" fontWeight="bold">
+                            Advanced Helper Text (Markdown)
+                          </Typography>
+                          <IconButton
+                            onClick={() => setExpanded(!expanded)}
+                            size="small"
+                            aria-label="Toggle advanced editor"
+                          >
+                            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                          </IconButton>
                         </Box>
-                      </Collapse>
-                    </Card>
-                  )}
-                </>
-              )}
-            </Grid>
+
+                        <Collapse in={expanded}>
+                          <Box mt={2} sx={{maxHeight: 300, overflowY: 'auto'}}>
+                            <MdxEditor
+                              initialMarkdown={state.advancedHelperText}
+                              handleChange={debounce(
+                                markdown =>
+                                  updateProperty('advancedHelperText', markdown),
+                                500,
+                                {leading: false, trailing: true}
+                              )}
+                              editorRef={mdxEditorRef}
+                            />
+                            <Alert severity="info" sx={{mt: 2}}>
+                              This markdown-based helper will appear in a dialog
+                              when users click the info icon next to the field
+                              label in the app.
+                            </Alert>
+                          </Box>
+                        </Collapse>
+                      </Card>
+                    )}
+                  </>
+                )}
+              </Grid>
+            )}
 
             {children && (
               <Grid item xs={12}>
@@ -344,170 +353,172 @@ export const BaseFieldEditor = ({fieldName, children}: Props) => {
       </Grid>
 
       {/* --- REMAINDER OF THE FORM CONFIG --- */}
-      <Grid item xs={12}>
-        <Card variant="outlined" sx={{p: 2}}>
-          <Grid container spacing={2}>
-            {/* Row 1: Required, Annotation, Uncertainty, Condition */}
-            <Grid item xs={12} sm={3}>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={state.required}
-                    onChange={e => updateProperty('required', e.target.checked)}
-                  />
-                }
-                label="Required"
-              />
-            </Grid>
-            <Grid item xs={12} sm={3}>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={state.annotation}
-                    onChange={e =>
-                      updateProperty('annotation', e.target.checked)
-                    }
-                  />
-                }
-                label="Annotation"
-              />
-            </Grid>
-            <Grid item xs={12} sm={3}>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={state.uncertainty}
-                    onChange={e =>
-                      updateProperty('uncertainty', e.target.checked)
-                    }
-                  />
-                }
-                label="Uncertainty"
-              />
-            </Grid>
-            <Grid item xs={12} sm={3}>
-              <ConditionModal
-                label={state.condition ? 'Update Condition' : 'Add Condition'}
-                initial={state.condition}
-                onChange={conditionChanged}
-                field={fieldName}
-              />
-            </Grid>
-
-            {/* Row 2: Annotation and Uncertainty Labels */}
-            <Grid item container spacing={2}>
-              <Grid item xs={12} md={6}>
-                {state.annotation ? (
-                  <DebouncedTextField
-                    fullWidth
-                    label="Annotation Label"
-                    value={state.annotationLabel}
-                    onChange={e =>
-                      updateProperty('annotationLabel', e.target.value)
-                    }
-                  />
-                ) : (
-                  <div />
-                )}
-              </Grid>
-              <Grid item xs={12} md={6}>
-                {state.uncertainty ? (
-                  <DebouncedTextField
-                    fullWidth
-                    label="Uncertainty Label"
-                    value={state.uncertaintyLabel}
-                    onChange={e =>
-                      updateProperty('uncertaintyLabel', e.target.value)
-                    }
-                  />
-                ) : (
-                  <div />
-                )}
-              </Grid>
-            </Grid>
-
-            {/* Row 3: Condition Alert */}
-            <Grid item xs={12}>
-              {state.condition && (
-                <Alert severity="info">
-                  <strong>Field Condition:</strong> Show this field if&nbsp;
-                  <ConditionTranslation condition={state.condition} />
-                </Alert>
-              )}
-            </Grid>
-
-            {/* Row 4: Persistent, Display Parent, Protection, Allow Hiding */}
-            <Grid item xs={12} sm={3}>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={state.persistent}
-                    onChange={e =>
-                      updateProperty('persistent', e.target.checked)
-                    }
-                  />
-                }
-                label="Copy value to new records"
-              />
-            </Grid>
-            <Grid item xs={12} sm={3}>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={state.displayParent}
-                    onChange={e =>
-                      updateProperty('displayParent', e.target.checked)
-                    }
-                  />
-                }
-                label="Display in parent record"
-              />
-            </Grid>
-            {VITE_TEMPLATE_PROTECTIONS && (
-              <>
-                <Grid item xs={12} sm={3}>
-                  <Box display="flex" alignItems="center">
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={state.protection}
-                          onChange={e =>
-                            updateProperty('protection', e.target.checked)
-                          }
-                        />
-                      }
-                      label="Protected Field"
+      {showExtraConfig && (
+        <Grid item xs={12}>
+          <Card variant="outlined" sx={{p: 2}}>
+            <Grid container spacing={2}>
+              {/* Row 1: Required, Annotation, Uncertainty, Condition */}
+              <Grid item xs={12} sm={3}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={state.required}
+                      onChange={e => updateProperty('required', e.target.checked)}
                     />
-                    <Tooltip title="Enable protection to prevent users of this template (or derived templates) from editing or deleting this field.">
-                      <InfoOutlinedIcon
-                        fontSize="small"
-                        sx={{marginLeft: 0, color: '#757575'}}
-                      />
-                    </Tooltip>
-                  </Box>
-                </Grid>
-                <Grid item xs={12} sm={3}>
-                  {state.protection ? (
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={state.allowHiding}
-                          onChange={e =>
-                            updateProperty('allowHiding', e.target.checked)
-                          }
-                        />
+                  }
+                  label="Required"
+                />
+              </Grid>
+              <Grid item xs={12} sm={3}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={state.annotation}
+                      onChange={e =>
+                        updateProperty('annotation', e.target.checked)
                       }
-                      label="Allow Hiding"
+                    />
+                  }
+                  label="Annotation"
+                />
+              </Grid>
+              <Grid item xs={12} sm={3}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={state.uncertainty}
+                      onChange={e =>
+                        updateProperty('uncertainty', e.target.checked)
+                      }
+                    />
+                  }
+                  label="Uncertainty"
+                />
+              </Grid>
+              <Grid item xs={12} sm={3}>
+                <ConditionModal
+                  label={state.condition ? 'Update Condition' : 'Add Condition'}
+                  initial={state.condition}
+                  onChange={conditionChanged}
+                  field={fieldName}
+                />
+              </Grid>
+
+              {/* Row 2: Annotation and Uncertainty Labels */}
+              <Grid item container spacing={2}>
+                <Grid item xs={12} md={6}>
+                  {state.annotation ? (
+                    <DebouncedTextField
+                      fullWidth
+                      label="Annotation Label"
+                      value={state.annotationLabel}
+                      onChange={e =>
+                        updateProperty('annotationLabel', e.target.value)
+                      }
                     />
                   ) : (
                     <div />
                   )}
                 </Grid>
-              </>
-            )}
-          </Grid>
-        </Card>
-      </Grid>
+                <Grid item xs={12} md={6}>
+                  {state.uncertainty ? (
+                    <DebouncedTextField
+                      fullWidth
+                      label="Uncertainty Label"
+                      value={state.uncertaintyLabel}
+                      onChange={e =>
+                        updateProperty('uncertaintyLabel', e.target.value)
+                      }
+                    />
+                  ) : (
+                    <div />
+                  )}
+                </Grid>
+              </Grid>
+
+              {/* Row 3: Condition Alert */}
+              <Grid item xs={12}>
+                {state.condition && (
+                  <Alert severity="info">
+                    <strong>Field Condition:</strong> Show this field if&nbsp;
+                    <ConditionTranslation condition={state.condition} />
+                  </Alert>
+                )}
+              </Grid>
+
+              {/* Row 4: Persistent, Display Parent, Protection, Allow Hiding */}
+              <Grid item xs={12} sm={3}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={state.persistent}
+                      onChange={e =>
+                        updateProperty('persistent', e.target.checked)
+                      }
+                    />
+                  }
+                  label="Copy value to new records"
+                />
+              </Grid>
+              <Grid item xs={12} sm={3}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={state.displayParent}
+                      onChange={e =>
+                        updateProperty('displayParent', e.target.checked)
+                      }
+                    />
+                  }
+                  label="Display in parent record"
+                />
+              </Grid>
+              {VITE_TEMPLATE_PROTECTIONS && (
+                <>
+                  <Grid item xs={12} sm={3}>
+                    <Box display="flex" alignItems="center">
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={state.protection}
+                            onChange={e =>
+                              updateProperty('protection', e.target.checked)
+                            }
+                          />
+                        }
+                        label="Protected Field"
+                      />
+                      <Tooltip title="Enable protection to prevent users of this template (or derived templates) from editing or deleting this field.">
+                        <InfoOutlinedIcon
+                          fontSize="small"
+                          sx={{marginLeft: 0, color: '#757575'}}
+                        />
+                      </Tooltip>
+                    </Box>
+                  </Grid>
+                  <Grid item xs={12} sm={3}>
+                    {state.protection ? (
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={state.allowHiding}
+                            onChange={e =>
+                              updateProperty('allowHiding', e.target.checked)
+                            }
+                          />
+                        }
+                        label="Allow Hiding"
+                      />
+                    ) : (
+                      <div />
+                    )}
+                  </Grid>
+                </>
+              )}
+            </Grid>
+          </Card>
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/web/src/designer/components/Fields/BasicAutoIncrementer.tsx
+++ b/web/src/designer/components/Fields/BasicAutoIncrementer.tsx
@@ -1,7 +1,10 @@
-import {Grid, Card} from '@mui/material';
+import {Grid, Card, Typography} from '@mui/material';
 import {useAppDispatch, useAppSelector} from '../../state/hooks';
 import {FieldType} from '../../state/initial';
 import DebouncedTextField from '../debounced-text-field';
+import {getViewIDForField, slugify} from '@/designer/state/helpers/uiSpec-helpers';
+import {useState} from 'react';
+import {BaseFieldEditor} from './BaseFieldEditor';
 
 type PropType = {
   fieldName: string;
@@ -14,7 +17,6 @@ export const BasicAutoIncrementerEditor = ({fieldName, viewId}: PropType) => {
   );
   const dispatch = useAppDispatch();
 
-  const label = field['component-parameters'].label;
   const digits = field['component-parameters'].num_digits || 4;
 
   const updateDigits = (value: number) => {
@@ -27,45 +29,27 @@ export const BasicAutoIncrementerEditor = ({fieldName, viewId}: PropType) => {
       payload: {fieldName, newField},
     });
   };
-  const updateLabel = (value: string) => {
-    const newField = JSON.parse(JSON.stringify(field)) as FieldType; // deep copy
-    // ensure that the form_id in the field is set correctly
-    newField['component-parameters'].form_id = viewId;
-    newField['component-parameters'].label = value;
-    dispatch({
-      type: 'ui-specification/fieldUpdated',
-      payload: {fieldName, newField},
-    });
-  };
 
   return (
-    <Grid item sm={6} xs={12}>
-      <Card variant="outlined" sx={{display: 'flex'}}>
-        <Grid item xs={12} sx={{mx: 1.5, my: 2}}>
-          <DebouncedTextField
-            name="label"
-            variant="outlined"
-            label="Label"
-            fullWidth
-            value={label}
-            onChange={e => updateLabel(e.target.value)}
-            helperText="Enter a label for the field."
-          />
-        </Grid>
-      </Card>
-      <Card variant="outlined" sx={{display: 'flex'}}>
-        <Grid item xs={12} sx={{mx: 1.5, my: 2}}>
-          <DebouncedTextField
-            name="digits"
-            variant="outlined"
-            label="Number of digits in identifier"
-            type="number"
-            value={digits}
-            helperText="Identifier will be padded with zeros up to this many digits."
-            onChange={e => updateDigits(parseInt(e.target.value))}
-          />
-        </Grid>
-      </Card>
-    </Grid>
+    <BaseFieldEditor
+      fieldName={fieldName}
+      showExtraConfig={false}
+      showHelperText={false}
+    >
+      <Typography variant="body1" sx={{mb: 1}}>
+        This field provides a counter value that increments with each new
+        record. Users select a range of values for the counter on their device.
+        Often used as part of a Templated String Field.
+      </Typography>
+      <DebouncedTextField
+        name="digits"
+        variant="outlined"
+        label="Number of digits in identifier"
+        type="number"
+        value={digits}
+        helperText="Identifier will be padded with zeros up to this many digits."
+        onChange={e => updateDigits(parseInt(e.target.value))}
+      />
+    </BaseFieldEditor>
   );
 };


### PR DESCRIPTION
# Make field name visible in AutoIncrementer

## JIRA Ticket

[#1584](https://github.com/FAIMS/FAIMS3/issues/1584)

## Description

In the editor, an AutoIncrementer field displays only it's label which is not used anywhere, the ID is not visible. If a user changes the label they lose track of what the ID is if they want to add it to a templated field.


## Proposed Changes

Use the BaseFieldEditor for this field to allow label visibility and editing but configure it to hide the parts we don't need.

## How to Test

In the designer, create an AutoIncrementer field.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
