### PR TITLE
Render markdown in select fields and in the value of multiselect

### DIFF
--- a/app/src/gui/fields/multiselect.tsx
+++ b/app/src/gui/fields/multiselect.tsx
@@ -211,7 +211,13 @@ export const MuiMultiSelect = ({
         multiple
         onChange={handleChange}
         value={value}
-        renderValue={selected => selected.join(', ')}
+        renderValue={selected => (
+          <span
+            dangerouslySetInnerHTML={{
+              __html: contentToSanitizedHtml(selected.join(', ')),
+            }}
+          />
+        )}
         MenuProps={{
           PaperProps: {
             style: {

--- a/app/src/gui/fields/select.tsx
+++ b/app/src/gui/fields/select.tsx
@@ -60,6 +60,7 @@ interface Props {
 
 import {useTheme} from '@mui/material/styles';
 import FieldWrapper from './fieldWrapper';
+import {contentToSanitizedHtml} from '../../utils/DomPurifier';
 
 /**
  * Select Component - A reusable dropdown select field with Formik integration.
@@ -102,7 +103,21 @@ export const Select = (props: Props & TextFieldProps) => {
                 wordWrap: 'break-word',
               }}
             >
-              <ListItemText primary={option.label} />
+              <ListItemText
+                primary={
+                  <span
+                    style={{
+                      display: 'contents',
+                      whiteSpace: 'normal',
+                      wordBreak: 'break-word',
+                      lineHeight: '0.1rem',
+                    }}
+                    dangerouslySetInnerHTML={{
+                      __html: contentToSanitizedHtml(option.label),
+                    }}
+                  />
+                }
+              />
             </MenuItem>
           ))}
         </MuiSelect>


### PR DESCRIPTION
# Render markdown in select fields and in the value of multiselect

## JIRA Ticket

[1576](https://github.com/FAIMS/FAIMS3/issues/1576)

## Description

We support markdown text in multiselect but not in select fields. Also when you select an item with
markdown formatting in a multi-select it is not rendered properly in the field.

## Proposed Changes

Adds formatting in the right places.

## How to Test

Create a select and multi-select with formatting and note the presentation of the labels.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
