### PR TITLE
Add link to app in control centre

### DIFF
--- a/web/src/components/logo.tsx
+++ b/web/src/components/logo.tsx
@@ -5,14 +5,24 @@ import {APP_NAME, WEBSITE_TITLE} from '@/constants';
  */
 export default function Logo() {
   return (
-    <div className="flex gap-2">
+    <div className="flex items-center gap-2">
       <div>
-        <img src="/assets/icons/icon-48.webp" />
+        <LogoIcon size={48} />
       </div>
       <div className="flex flex-col text-left text-sm leading-none">
         <span className="truncate font-semibold">{APP_NAME}</span>
         <span className="truncate text-xs">{WEBSITE_TITLE}</span>
       </div>
     </div>
+  );
+}
+
+export function LogoIcon({size = 24}: {size?: number}) {
+  return (
+    <img
+      className="inline-block"
+      src="/assets/icons/icon-48.webp"
+      width={size}
+    />
   );
 }

--- a/web/src/routes/_protected.tsx
+++ b/web/src/routes/_protected.tsx
@@ -1,8 +1,10 @@
 import {VerificationAlertComponent} from '@/components/alerts/verification-alert';
 import Breadcrumbs from '@/components/breadcrumbs';
+import Logo, {LogoIcon} from '@/components/logo';
 import {ModeToggle} from '@/components/mode-toggle';
 import {SessionExpiredOverlay} from '@/components/session-expired-overlay';
 import {AppSidebar} from '@/components/side-bar/app-sidebar';
+import {Button} from '@/components/ui/button';
 import {Dialog} from '@/components/ui/dialog';
 import {Separator} from '@/components/ui/separator';
 import {
@@ -10,7 +12,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@/components/ui/sidebar';
-import {API_URL, SIGNIN_PATH} from '@/constants';
+import {API_URL, APP_NAME, APP_URL, SIGNIN_PATH} from '@/constants';
 import {useAuth} from '@/context/auth-provider';
 import {useRequestVerify} from '@/hooks/queries';
 import {
@@ -18,6 +20,7 @@ import {
   PostExchangeTokenResponseSchema,
 } from '@faims3/data-model';
 import {createFileRoute, Outlet} from '@tanstack/react-router';
+import {ExternalLinkIcon} from 'lucide-react';
 import {toast} from 'sonner';
 
 interface TokenParams {
@@ -145,7 +148,19 @@ function RouteComponent() {
                 <Separator orientation="vertical" className="mr-2 h-4" />
                 <Breadcrumbs />
               </div>
-              <ModeToggle />
+              <div className="flex">
+                <Button variant="outline">
+                  <a href={APP_URL} target="_blank">
+                    <span className="mr-2">
+                      <LogoIcon size={24} />
+                    </span>
+                    <span className="align-middle font-semibold">
+                      {APP_NAME} App
+                    </span>
+                  </a>
+                </Button>
+                <ModeToggle />
+              </div>
             </div>
           </header>
 

--- a/web/src/routes/_protected.tsx
+++ b/web/src/routes/_protected.tsx
@@ -144,8 +144,6 @@ function RouteComponent() {
           <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
             <div className="flex justify-between w-full px-4">
               <div className="flex items-center gap-2">
-                <SidebarTrigger className="-ml-1" />
-                <Separator orientation="vertical" className="mr-2 h-4" />
                 <Breadcrumbs />
               </div>
               <div className="flex">


### PR DESCRIPTION
# Add link to app in control centre

## JIRA Ticket

#1580 

## Description

There is no way to get to the app from the dashboard. 

## Proposed Changes

Add a button linking to the configured app in the toolbar. 

<img width="468" height="198" alt="image" src="https://github.com/user-attachments/assets/ab6f7ea1-f518-4cb5-8839-7a37a4a39554" />

Also removes the option to toggle the sidebar since this didn't work - the logo text overlaps the button when collapsed so you can't get it back.  Can't figure out how to fix that so disabled it - I don't think it's useful UX in this app.

## How to Test

View the control center, see the button!

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
