### PR TITLE
Adds an error component to show a nicer page when we crash

### DIFF
--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,6 +1,37 @@
 import {AuthContext} from '@/context/auth-provider';
 import {Outlet, createRootRouteWithContext} from '@tanstack/react-router';
+import {Button} from '@/components/ui/button';
+import {LogoImage} from '@/components/logo';
+
+// Create a custom error component
+function CustomErrorComponent({error}: {error: Error}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full bg-white shadow-lg rounded-lg p-6">
+        <div className="flex items-center mb-4">
+          <div className="flex-shrink-0">
+            <img src="/assets/icons/icon-48.webp" />
+          </div>
+          <div className="ml-3">
+            <h3 className="text-lg font-medium text-gray-900">
+              Sorry, something went wrong
+            </h3>
+          </div>
+        </div>
+        {process.env.NODE_ENV === 'development' && (
+          <div className="text-sm text-gray-500 mb-4">
+            {error.message || 'An unexpected error occurred'}
+          </div>
+        )}
+        <Button variant="outline" onClick={() => (window.location.href = '/')}>
+          Return to Home Page
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 export const Route = createRootRouteWithContext<{auth: AuthContext}>()({
   component: () => <Outlet />,
+  errorComponent: CustomErrorComponent,
 });

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,7 +1,6 @@
 import {AuthContext} from '@/context/auth-provider';
 import {Outlet, createRootRouteWithContext} from '@tanstack/react-router';
 import {Button} from '@/components/ui/button';
-import {LogoImage} from '@/components/logo';
 
 // Create a custom error component
 function CustomErrorComponent({error}: {error: Error}) {


### PR DESCRIPTION

## Ticket

#1591 

## Description

Currently the control centre shows a generic error page when we crash with no user actions.

## Proposed Changes

Adds a custom error component with a link back to the home page which should resolve most problems.

<img width="996" height="580" alt="image" src="https://github.com/user-attachments/assets/96ff3200-d27e-4cd9-8074-3456756b6922" />

TODO: integrate bugsnag...

## How to Test

Create an error (add some random code) and see the page.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
