### PR TITLE
Improve Dashboard actions on templates

### DIFF
--- a/library/data-model/src/permission/functions.ts
+++ b/library/data-model/src/permission/functions.ts
@@ -113,6 +113,32 @@ export function isAuthorized({
 }
 
 /**
+ * What resources does this user have permission for with a resource-specific
+ * action?
+ */
+export function getUserResourcesForAction({
+  decodedToken,
+  action,
+}: {
+  decodedToken: DecodedTokenPermissions;
+  action: Action;
+}): Array<string> {
+  const authorizedResources: Array<string> = [];
+
+  // Check resource-specific roles for access
+  for (const resourceRole of decodedToken.resourceRoles) {
+    if (
+      resourceRole.resourceId &&
+      roleGrantsAction({roles: [resourceRole.role], action})
+    ) {
+      authorizedResources.push(resourceRole.resourceId);
+    }
+  }
+
+  return authorizedResources;
+}
+
+/**
  * Maps a add/remove role operation to the corresponding action needed
  * @param add Whether this is an add operation (true) or remove operation (false)
  * @param role The role being added or removed

--- a/library/data-model/src/permission/functions.ts
+++ b/library/data-model/src/permission/functions.ts
@@ -120,10 +120,13 @@ export function getUserResourcesForAction({
   decodedToken,
   action,
 }: {
-  decodedToken: DecodedTokenPermissions;
+  decodedToken?: DecodedTokenPermissions | null;
   action: Action;
 }): Array<string> {
   const authorizedResources: Array<string> = [];
+
+  // if token is not there, we can't access any resources
+  if (!decodedToken) return authorizedResources;
 
   // Check resource-specific roles for access
   for (const resourceRole of decodedToken.resourceRoles) {

--- a/library/data-model/tests/permissionfunctions.test.ts
+++ b/library/data-model/tests/permissionfunctions.test.ts
@@ -429,6 +429,15 @@ describe('getUserResourcesForAction', () => {
 
     expect(resources).toHaveLength(0);
   });
+
+  it('returns an empty array if token is undefined', () => {
+    const resources = getUserResourcesForAction({
+      decodedToken: undefined,
+      action: Action.UPDATE_PROJECT_DETAILS,
+    });
+
+    expect(resources).toHaveLength(0);
+  });
 });
 
 describe('isAuthorized', () => {

--- a/library/data-model/tests/permissionfunctions.test.ts
+++ b/library/data-model/tests/permissionfunctions.test.ts
@@ -1,6 +1,7 @@
 import {
   extendTokenWithVirtualRoles,
   generateVirtualResourceRoles,
+  getUserResourcesForAction,
   isTokenAuthorized,
   necessaryActionToCouchRoleList,
   ResourceAssociation,
@@ -393,6 +394,40 @@ describe('Authorization Helper Functions', () => {
         })
       ).toBe(false);
     });
+  });
+});
+
+describe('getUserResourcesForAction', () => {
+  it('returns an array of resource IDs for a given action', () => {
+    const token: DecodedTokenPermissions = {
+      resourceRoles: [
+        {resourceId: 'template123', role: Role.TEAM_MANAGER},
+        {resourceId: 'project123', role: Role.PROJECT_MANAGER},
+      ],
+      globalRoles: [],
+    };
+
+    const resources = getUserResourcesForAction({
+      decodedToken: token,
+      action: Action.UPDATE_PROJECT_DETAILS,
+    });
+
+    expect(resources).toContain('project123');
+    expect(resources).not.toContain('template123');
+  });
+
+  it('returns an empty array if no resources are authorized', () => {
+    const token: DecodedTokenPermissions = {
+      resourceRoles: [{resourceId: 'template123', role: Role.TEAM_MANAGER}],
+      globalRoles: [],
+    };
+
+    const resources = getUserResourcesForAction({
+      decodedToken: token,
+      action: Action.UPDATE_PROJECT_DETAILS,
+    });
+
+    expect(resources).toHaveLength(0);
   });
 });
 

--- a/web/src/components/dialogs/add-template-to-team-dialog.tsx
+++ b/web/src/components/dialogs/add-template-to-team-dialog.tsx
@@ -1,0 +1,48 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {Button} from '../ui/button';
+import {useState} from 'react';
+import {useAuth} from '@/context/auth-provider';
+import {ErrorComponent} from '@tanstack/react-router';
+
+export const AddTemplateToTeamDialog = ({templateId}: {templateId: string}) => {
+  const [open, setOpen] = useState(false);
+
+  const {user} = useAuth();
+
+  if (!user) {
+    return <ErrorComponent error="Unauthenticated" />;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild className="w-fit">
+        <Button
+          variant="outline"
+          className="bg-primary text-primary-foreground"
+        >
+          Assign Template to Team
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Assign Template to Team</DialogTitle>
+          <DialogDescription>
+            Assign this template to a different team. The template will then be
+            available to members of the new team.
+          </DialogDescription>
+        </DialogHeader>
+        <AddTemplateToTeamForm
+          setDialogOpen={setOpen}
+          templateId={templateId}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/components/dialogs/archive-template-dialog.tsx
+++ b/web/src/components/dialogs/archive-template-dialog.tsx
@@ -77,7 +77,7 @@ export const ArchiveTemplateDialog = ({archived}: {archived: boolean}) => {
           <DialogTitle>Archive Template</DialogTitle>
           <DialogDescription>
             Archive the current template. This make the template read-only and
-            prevent {NOTEBOOK_NAME} from being created from it.
+            prevent new {NOTEBOOK_NAME}s from being created from it.
           </DialogDescription>
         </DialogHeader>
         <Button variant="destructive" className="w-full" onClick={onClick}>

--- a/web/src/components/dialogs/create-tempalate-from-project-dialog.tsx
+++ b/web/src/components/dialogs/create-tempalate-from-project-dialog.tsx
@@ -1,0 +1,66 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {Button} from '../ui/button';
+import {useState} from 'react';
+import {Plus} from 'lucide-react';
+import {useGetTeam} from '@/hooks/queries';
+import {useAuth} from '@/context/auth-provider';
+import {ErrorComponent} from '@tanstack/react-router';
+import {CreateTemplateFromProjectForm} from '../forms/create-template-from-project';
+
+export const CreateTemplateFromProjectDialog = ({
+  defaultValues,
+  projectId,
+  specifiedTeam = undefined,
+}: {
+  defaultValues?: {teamId?: string};
+  projectId: string;
+  specifiedTeam?: string;
+}) => {
+  const [open, setOpen] = useState(false);
+  const {user} = useAuth();
+  if (!user) {
+    return <ErrorComponent error="Unauthenticated" />;
+  }
+
+  const {data: team} = useGetTeam(user, specifiedTeam);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild className="w-fit">
+        <Button
+          variant="outline"
+          className="flex items-center space-x-2 bg-primary text-primary-foreground"
+        >
+          <Plus size={16} />
+          <span>Create Template</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg space-y-6">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-medium">
+            Create Template
+            {specifiedTeam && <> in “{team?.name ?? 'Team'}”</>}
+          </DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">
+            Upload a JSON file to pre-populate, or leave blank to start from
+            scratch.
+          </DialogDescription>
+        </DialogHeader>
+
+        <CreateTemplateFromProjectForm
+          setDialogOpen={setOpen}
+          defaultValues={defaultValues}
+          specifiedTeam={specifiedTeam}
+          projectId={projectId}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/components/dialogs/edit-template.tsx
+++ b/web/src/components/dialogs/edit-template.tsx
@@ -19,6 +19,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '../ui/tooltip';
+import {Pencil} from 'lucide-react';
 
 /**
  * EditTemplateDialog component renders a dialog for editing a template.
@@ -29,7 +30,7 @@ import {
 export const EditTemplateDialog = () => {
   const {user} = useAuth();
   const {templateId} = Route.useParams();
-  const {data, isLoading} = useGetTemplate(user, templateId);
+  const {data} = useGetTemplate(user, templateId);
   const [open, setOpen] = useState(false);
 
   return (
@@ -39,7 +40,8 @@ export const EditTemplateDialog = () => {
           <Tooltip>
             <TooltipTrigger className="w-fit">
               <Button variant="outline" disabled={true}>
-                Edit Template
+                Replace Template JSON
+                <Pencil />
               </Button>
             </TooltipTrigger>
             <TooltipContent className="w-32 text-balance">
@@ -50,49 +52,20 @@ export const EditTemplateDialog = () => {
       ) : (
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild className="w-fit">
-            <Button variant="outline">Edit Template</Button>
+            <Button variant="outline">
+              Replace Template JSON
+              <Pencil />
+            </Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Edit Template</DialogTitle>
+              <DialogTitle>Replace Template JSON</DialogTitle>
               <DialogDescription>
-                Follow the following steps to edit the current template.
+                Upload a new template JSON file to replace the current one. new
+                file must be a valid JSON file.
               </DialogDescription>
             </DialogHeader>
-            <List>
-              <ListItem className="space-y-2">
-                <ListDescription>
-                  1. Download the template file.
-                </ListDescription>
-                <Button variant="outline" disabled={isLoading}>
-                  <a
-                    href={`data:text/json;charset=utf-8,${encodeURIComponent(
-                      JSON.stringify({
-                        metadata: data?.metadata,
-                        'ui-specification': data?.['ui-specification'],
-                      })
-                    )}`}
-                    download={`${templateId}.json`}
-                  >
-                    Download
-                  </a>
-                </Button>
-              </ListItem>
-              <ListItem>
-                {
-                  //TODO Update this view to link directly into designer
-                }
-                <ListDescription>
-                  2. Edit the template using Designer.
-                </ListDescription>
-              </ListItem>
-              <ListItem className="space-y-2">
-                <ListDescription>
-                  3. Upload the edited template file.
-                </ListDescription>
-                <UpdateTemplateForm setDialogOpen={setOpen} />
-              </ListItem>
-            </List>
+            <UpdateTemplateForm setDialogOpen={setOpen} />
           </DialogContent>
         </Dialog>
       )}

--- a/web/src/components/forms/add-template-to-team-form.tsx
+++ b/web/src/components/forms/add-template-to-team-form.tsx
@@ -1,0 +1,89 @@
+import {Field, Form} from '@/components/form';
+import {useAuth} from '@/context/auth-provider';
+import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {modifyTeamForProject} from '@/hooks/project-hooks';
+import {useGetTeams} from '@/hooks/queries';
+import {Action} from '@faims3/data-model';
+import {useQueryClient} from '@tanstack/react-query';
+import {z} from 'zod';
+
+interface AddTemplateToTeamFormProps {
+  setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  templateId: string;
+}
+
+/**
+ * A form component that allows assigning a project to a team.
+ *
+ * @param setDialogOpen - A function to control the dialog's open state.
+ * @param projectId - The ID of the project to be assigned to a team.
+ */
+export function AddTemplateToTeamForm({
+  setDialogOpen,
+  templateId,
+}: AddTemplateToTeamFormProps) {
+  const {user} = useAuth();
+  const QueryClient = useQueryClient();
+  const teams = useGetTeams(user);
+
+  // can we add a user to the team?
+  const canAddTemplateToTeam = useIsAuthorisedTo({
+    action: Action.CHANGE_TEMPLATE_STATUS,
+    resourceId: templateId,
+  });
+
+  const teamsAvailable = teams.data?.teams;
+
+  if (!canAddTemplateToTeam || !teamsAvailable) {
+    return <></>;
+  }
+
+  const fields: Field[] = [
+    {
+      name: 'teamId',
+      label: 'Team',
+      options: teamsAvailable.map(t => ({
+        label: t.name,
+        value: t._id,
+      })),
+      schema: z.string(),
+    },
+  ];
+
+  interface onSubmitProps {
+    teamId: string;
+  }
+
+  /**
+   * Handles the form submission
+   */
+  const onSubmit = async ({teamId}: onSubmitProps) => {
+    if (!user) return {type: 'submit', message: 'User not authenticated'};
+
+    const response = await modifyTeamForProject({
+      projectId,
+      teamId,
+      user,
+    });
+
+    if (!response.ok)
+      return {
+        type: 'submit',
+        message: 'Error adding project to team: ' + response.statusText,
+      };
+
+    QueryClient.invalidateQueries({
+      queryKey: ['projectsbyteam', user.token, teamId],
+    });
+
+    setDialogOpen(false);
+  };
+
+  return (
+    <Form
+      fields={fields}
+      onSubmit={onSubmit}
+      submitButtonText={'Assign to Team'}
+    />
+  );
+}

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -5,7 +5,7 @@ import {z} from 'zod';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetTeams} from '@/hooks/queries';
 import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
-import {Action} from '@faims3/data-model';
+import {Action, getUserResourcesForAction} from '@faims3/data-model';
 
 import blankNotebook from '../../../notebooks/blank-notebook.json';
 import {NOTEBOOK_NAME} from '@/constants';
@@ -37,17 +37,17 @@ export function CreateTemplateForm({
     action: Action.CREATE_TEMPLATE,
   });
 
-  // filter teams by those we can create templates in
-  const possibleTeams = teams?.teams.filter(team => {
-    return (
-      user &&
-      userCanDo({
-        user,
-        action: Action.CREATE_TEMPLATE_IN_TEAM,
-        resourceId: team._id,
-      })
-    );
+  // get the teams that we have permission to create
+  // templates in
+  const teamsAvailable = getUserResourcesForAction({
+    decodedToken: user?.decodedToken,
+    action: Action.CREATE_TEMPLATE_IN_TEAM,
   });
+
+  // filter teams by those we can create templates in
+  const possibleTeams = teams?.teams.filter(team =>
+    teamsAvailable.includes(team._id)
+  );
 
   const justOneTeam = specifiedTeam || possibleTeams?.length === 1;
 

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -4,7 +4,7 @@ import {readFileAsText} from '@/lib/utils';
 import {z} from 'zod';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetTeams} from '@/hooks/queries';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
 import {Action} from '@faims3/data-model';
 
 import blankNotebook from '../../../notebooks/blank-notebook.json';
@@ -37,6 +37,20 @@ export function CreateTemplateForm({
     action: Action.CREATE_TEMPLATE,
   });
 
+  // filter teams by those we can create templates in
+  const possibleTeams = teams?.teams.filter(team => {
+    return (
+      user &&
+      userCanDo({
+        user,
+        action: Action.CREATE_TEMPLATE_IN_TEAM,
+        resourceId: team._id,
+      })
+    );
+  });
+
+  const justOneTeam = specifiedTeam || possibleTeams?.length === 1;
+
   const fields: Field[] = [
     {
       name: 'name',
@@ -60,11 +74,11 @@ export function CreateTemplateForm({
     },
   ];
 
-  if (!specifiedTeam) {
+  if (!justOneTeam) {
     fields.push({
       name: 'team',
       label: `Team${canCreateGlobally ? ' (optional)' : ''}`,
-      options: teams?.teams.map(({_id, name}) => ({
+      options: possibleTeams?.map(({_id, name}) => ({
         label: name,
         value: _id,
       })),
@@ -101,6 +115,13 @@ export function CreateTemplateForm({
       };
     }
 
+    let chosenTeamId = specifiedTeam;
+    if (justOneTeam && possibleTeams) {
+      chosenTeamId = possibleTeams[0]._id;
+    } else if (team) {
+      chosenTeamId = team;
+    }
+
     try {
       const res = await fetch(
         `${import.meta.env.VITE_API_URL}/api/templates/`,
@@ -111,7 +132,7 @@ export function CreateTemplateForm({
             Authorization: `Bearer ${user.token}`,
           },
           body: JSON.stringify({
-            teamId: team ?? specifiedTeam,
+            teamId: chosenTeamId,
             name,
             ...jsonPayload,
           }),
@@ -141,11 +162,18 @@ export function CreateTemplateForm({
   };
 
   return (
-    <Form
-      fields={fields}
-      onSubmit={onSubmit}
-      submitButtonText="Create Template"
-      defaultValues={{team: defaultValues?.teamId}}
-    />
+    <>
+      {possibleTeams?.length === 1 && (
+        <span>
+          <strong>Template will be owned by:</strong> {possibleTeams[0].name}
+        </span>
+      )}
+      <Form
+        fields={fields}
+        onSubmit={onSubmit}
+        submitButtonText="Create Template"
+        defaultValues={{team: defaultValues?.teamId}}
+      />
+    </>
   );
 }

--- a/web/src/components/forms/create-template-from-project.tsx
+++ b/web/src/components/forms/create-template-from-project.tsx
@@ -1,0 +1,140 @@
+import {useAuth} from '@/context/auth-provider';
+import {Field, Form} from '@/components/form';
+import {readFileAsText} from '@/lib/utils';
+import {z} from 'zod';
+import {useQueryClient} from '@tanstack/react-query';
+import {useGetProject, useGetTeams} from '@/hooks/queries';
+import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
+import {Action} from '@faims3/data-model';
+
+import blankNotebook from '../../../notebooks/blank-notebook.json';
+import {NOTEBOOK_NAME} from '@/constants';
+
+interface CreateTemplateFromProjectForm {
+  setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  defaultValues?: {teamId?: string};
+  projectId: string;
+  specifiedTeam?: string;
+}
+
+/**
+ * CreateTemplateForm component renders a form for creating a template.
+ * It provides a button to open the dialog and a form to create the template.
+ *
+ * @param {CreateTemplateFromProjectForm} props - The props for the form.
+ * @returns {JSX.Element} The rendered CreateTemplateForm component.
+ */
+export function CreateTemplateFromProjectForm({
+  setDialogOpen,
+  defaultValues,
+  projectId,
+  specifiedTeam = undefined,
+}: CreateTemplateFromProjectForm) {
+  const {user, refreshToken} = useAuth();
+  const queryClient = useQueryClient();
+  const {data: teams} = useGetTeams(user);
+  const {data: projectData} = useGetProject({user, projectId});
+
+  // can they create projects outside team?
+  const canCreateGlobally = useIsAuthorisedTo({
+    action: Action.CREATE_TEMPLATE,
+  });
+
+  // filter teams by those we can create templates in
+  const possibleTeams = teams?.teams.filter(team => {
+    return (
+      user &&
+      userCanDo({
+        user,
+        action: Action.CREATE_TEMPLATE_IN_TEAM,
+        resourceId: team._id,
+      })
+    );
+  });
+
+  const fields: Field[] = [
+    {
+      name: 'name',
+      label: 'Template Name',
+      description: 'A short display name for the template',
+      schema: z.string().min(5, {
+        message: 'Template name must be at least 5 characters.',
+      }),
+    },
+  ];
+
+  if (!specifiedTeam) {
+    fields.push({
+      name: 'team',
+      label: `Team${canCreateGlobally ? ' (optional)' : ''}`,
+      options: possibleTeams?.map(({_id, name}) => ({
+        label: name,
+        value: _id,
+      })),
+      schema: canCreateGlobally ? z.string().optional() : z.string(),
+    });
+  }
+
+  const onSubmit = async (values: {
+    name: string;
+    file?: File;
+    team?: string;
+  }) => {
+    if (!user) return {type: 'submit', message: 'Not authenticated'};
+
+    const {name, team} = values;
+
+    console.log('request body', {
+      ...projectData,
+      teamId: team ?? specifiedTeam,
+      name,
+    });
+
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/templates/`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${user.token}`,
+          },
+          body: JSON.stringify({
+            ...projectData,
+            teamId: team ?? specifiedTeam,
+            name,
+          }),
+        }
+      );
+      if (!res.ok) throw new Error(res.statusText);
+      // need to refresh our auth token to get permissions on this new template
+      const {message, status} = await refreshToken();
+      if (status === 'error') {
+        return {
+          type: 'submit',
+          message: `template created but failed to refresh user token: ${message}`,
+        };
+      }
+    } catch {
+      return {type: 'submit', message: 'Failed to create template'};
+    }
+
+    // query invalidations
+    if (specifiedTeam || team) {
+      await queryClient.invalidateQueries({
+        queryKey: ['templatesbyteam', specifiedTeam || team],
+      });
+    }
+    await queryClient.invalidateQueries({queryKey: ['templates', undefined]});
+    setDialogOpen(false);
+  };
+
+  return (
+    <Form
+      fields={fields}
+      onSubmit={onSubmit}
+      submitButtonText="Create Template"
+      defaultValues={{team: defaultValues?.teamId}}
+    />
+  );
+}

--- a/web/src/components/forms/create-template-from-project.tsx
+++ b/web/src/components/forms/create-template-from-project.tsx
@@ -1,14 +1,10 @@
 import {useAuth} from '@/context/auth-provider';
 import {Field, Form} from '@/components/form';
-import {readFileAsText} from '@/lib/utils';
 import {z} from 'zod';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetProject, useGetTeams} from '@/hooks/queries';
 import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
 import {Action} from '@faims3/data-model';
-
-import blankNotebook from '../../../notebooks/blank-notebook.json';
-import {NOTEBOOK_NAME} from '@/constants';
 
 interface CreateTemplateFromProjectForm {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -51,6 +47,7 @@ export function CreateTemplateFromProjectForm({
       })
     );
   });
+  const justOneTeam = specifiedTeam || possibleTeams?.length === 1;
 
   const fields: Field[] = [
     {
@@ -63,7 +60,7 @@ export function CreateTemplateFromProjectForm({
     },
   ];
 
-  if (!specifiedTeam) {
+  if (!justOneTeam) {
     fields.push({
       name: 'team',
       label: `Team${canCreateGlobally ? ' (optional)' : ''}`,
@@ -83,12 +80,6 @@ export function CreateTemplateFromProjectForm({
     if (!user) return {type: 'submit', message: 'Not authenticated'};
 
     const {name, team} = values;
-
-    console.log('request body', {
-      ...projectData,
-      teamId: team ?? specifiedTeam,
-      name,
-    });
 
     try {
       const res = await fetch(
@@ -130,11 +121,18 @@ export function CreateTemplateFromProjectForm({
   };
 
   return (
-    <Form
-      fields={fields}
-      onSubmit={onSubmit}
-      submitButtonText="Create Template"
-      defaultValues={{team: defaultValues?.teamId}}
-    />
+    <>
+      {possibleTeams?.length === 1 && (
+        <span>
+          <strong>Template will be owned by:</strong> {possibleTeams[0].name}
+        </span>
+      )}
+      <Form
+        fields={fields}
+        onSubmit={onSubmit}
+        submitButtonText="Create Template"
+        defaultValues={{team: defaultValues?.teamId}}
+      />
+    </>
   );
 }

--- a/web/src/components/forms/update-template-form.tsx
+++ b/web/src/components/forms/update-template-form.tsx
@@ -56,9 +56,9 @@ export function UpdateTemplateForm({setDialogOpen}: UpdateTemplateFormProps) {
     <Form
       fields={fields}
       onSubmit={onSubmit}
-      submitButtonText="Update Template"
+      submitButtonText="Upload Template JSON"
       submitButtonVariant="destructive"
-      warningMessage={`Editing the template may result in inconsistencies between the ${NOTEBOOK_NAME} created from it.`}
+      warningMessage={`Editing the template does not change any of the ${NOTEBOOK_NAME}s created from it.  This may create inconsistencies in your data.`}
     />
   );
 }

--- a/web/src/components/tabs/project/actions.tsx
+++ b/web/src/components/tabs/project/actions.tsx
@@ -12,7 +12,7 @@ import {useGetProject} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {ProjectStatusDialog} from '@/components/dialogs/change-project-status-dialog';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
-import {Action} from '@faims3/data-model';
+import {Action, getUserResourcesForAction} from '@faims3/data-model';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {DesignerDialog} from '@/components/dialogs/designer-dialog';
 import type {
@@ -89,6 +89,11 @@ const ProjectActions = (): JSX.Element => {
     setEditorOpen(false);
   };
 
+  const canEditProject = useIsAuthorisedTo({
+    action: Action.UPDATE_PROJECT_UISPEC,
+    resourceId: projectId,
+  });
+
   const canChangeProjectStatus = useIsAuthorisedTo({
     action: Action.CHANGE_PROJECT_STATUS,
     resourceId: projectId,
@@ -99,6 +104,12 @@ const ProjectActions = (): JSX.Element => {
     action: Action.CHANGE_PROJECT_TEAM,
     resourceId: projectId,
   });
+
+  const canCreateTemplateInTeam =
+    getUserResourcesForAction({
+      decodedToken: user?.decodedToken,
+      action: Action.CREATE_TEMPLATE_IN_TEAM,
+    }).length > 0;
 
   const handleCreateTestRecords = async () => {
     if (user)
@@ -138,25 +149,28 @@ const ProjectActions = (): JSX.Element => {
             </List>
           </Card>
         )}
-        <Card className="flex-1">
-          <List className="flex flex-col gap-4">
-            <ListItem>
-              <ListLabel>Edit {NOTEBOOK_NAME_CAPITALIZED}</ListLabel>
-              <ListDescription>
-                Edit this {NOTEBOOK_NAME} in the Notebook Editor.
-              </ListDescription>
-            </ListItem>
-            <ListItem>
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => setEditorOpen(true)}
-              >
-                Open in Editor
-              </Button>
-            </ListItem>
-          </List>
-        </Card>
+
+        {canEditProject && (
+          <Card className="flex-1">
+            <List className="flex flex-col gap-4">
+              <ListItem>
+                <ListLabel>Edit {NOTEBOOK_NAME_CAPITALIZED}</ListLabel>
+                <ListDescription>
+                  Edit this {NOTEBOOK_NAME} in the Notebook Editor.
+                </ListDescription>
+              </ListItem>
+              <ListItem>
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => setEditorOpen(true)}
+                >
+                  Open in Editor
+                </Button>
+              </ListItem>
+            </List>
+          </Card>
+        )}
 
         {canAddProjectToTeam && (
           <Card className="flex-1">
@@ -173,6 +187,7 @@ const ProjectActions = (): JSX.Element => {
             </List>
           </Card>
         )}
+
         <Card className="flex-1">
           <List className="flex flex-col gap-4">
             <ListItem>
@@ -199,39 +214,43 @@ const ProjectActions = (): JSX.Element => {
           </List>
         </Card>
 
-        <Card className="flex-1">
-          <List className="flex flex-col gap-4">
-            <ListItem>
-              <ListLabel>
-                Replace {NOTEBOOK_NAME_CAPITALIZED} JSON File
-              </ListLabel>
-              <ListDescription>
-                Replace the {NOTEBOOK_NAME} JSON file.
-              </ListDescription>
-            </ListItem>
-            <ListItem>
-              <EditProjectDialog />
-            </ListItem>
-          </List>
-        </Card>
+        {canEditProject && (
+          <Card className="flex-1">
+            <List className="flex flex-col gap-4">
+              <ListItem>
+                <ListLabel>
+                  Replace {NOTEBOOK_NAME_CAPITALIZED} JSON File
+                </ListLabel>
+                <ListDescription>
+                  Replace the {NOTEBOOK_NAME} JSON file.
+                </ListDescription>
+              </ListItem>
+              <ListItem>
+                <EditProjectDialog />
+              </ListItem>
+            </List>
+          </Card>
+        )}
 
-        <Card className="flex-1">
-          <List className="flex flex-col gap-4">
-            <ListItem>
-              <ListLabel>
-                Create Template from this {NOTEBOOK_NAME_CAPITALIZED}
-              </ListLabel>
-              <ListDescription>
-                Create a new template from the current {NOTEBOOK_NAME}.  You will
-                then be able to create copies of this {NOTEBOOK_NAME} from the
-                template.
-              </ListDescription>
-            </ListItem>
-            <ListItem>
-              <CreateTemplateFromProjectDialog projectId={projectId} />
-            </ListItem>
-          </List>
-        </Card>
+        {canCreateTemplateInTeam && (
+          <Card className="flex-1">
+            <List className="flex flex-col gap-4">
+              <ListItem>
+                <ListLabel>
+                  Create Template from this {NOTEBOOK_NAME_CAPITALIZED}
+                </ListLabel>
+                <ListDescription>
+                  Create a new template from the current {NOTEBOOK_NAME}. You
+                  will then be able to create copies of this {NOTEBOOK_NAME}{' '}
+                  from the template.
+                </ListDescription>
+              </ListItem>
+              <ListItem>
+                <CreateTemplateFromProjectDialog projectId={projectId} />
+              </ListItem>
+            </List>
+          </Card>
+        )}
 
         {canChangeProjectStatus && (
           <Card className="flex-1">

--- a/web/src/components/tabs/project/actions.tsx
+++ b/web/src/components/tabs/project/actions.tsx
@@ -23,6 +23,7 @@ import {EditProjectDialog} from '@/components/dialogs/edit-project-dialog';
 import {generateTestRecordsForProject} from '@/hooks/project-hooks';
 import {Input} from '@mui/material';
 import {AddProjectToTeamDialog} from '@/components/dialogs/add-project-to-team-dialog';
+import {CreateTemplateFromProjectDialog} from '@/components/dialogs/create-tempalate-from-project-dialog';
 
 /**
  * ProjectActions component renders action cards for editing and closing a project.
@@ -210,6 +211,24 @@ const ProjectActions = (): JSX.Element => {
             </ListItem>
             <ListItem>
               <EditProjectDialog />
+            </ListItem>
+          </List>
+        </Card>
+
+        <Card className="flex-1">
+          <List className="flex flex-col gap-4">
+            <ListItem>
+              <ListLabel>
+                Create Template from this {NOTEBOOK_NAME_CAPITALIZED}
+              </ListLabel>
+              <ListDescription>
+                Create a new template from the current {NOTEBOOK_NAME}.  You will
+                then be able to create copies of this {NOTEBOOK_NAME} from the
+                template.
+              </ListDescription>
+            </ListItem>
+            <ListItem>
+              <CreateTemplateFromProjectDialog projectId={projectId} />
             </ListItem>
           </List>
         </Card>

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -14,6 +14,7 @@ import type {
   NotebookWithHistory,
   NotebookUISpec,
 } from '@/designer/state/initial';
+import {EditTemplateDialog} from '@/components/dialogs/edit-template';
 
 /**
  * TemplateActions component renders action cards for creating a project from a template,
@@ -121,6 +122,18 @@ const TemplateActions = () => {
             </ListItem>
           </List>
         </Card>
+        <Card className="flex-1">
+          <List className="flex flex-col gap-4">
+            <ListItem>
+              <ListLabel>Replace Template JSON File</ListLabel>
+              <ListDescription>Replace the template JSON file.</ListDescription>
+            </ListItem>
+            <ListItem>
+              <EditTemplateDialog />
+            </ListItem>
+          </List>
+        </Card>
+
         <Card>
           <List>
             <ListItem>

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -15,6 +15,8 @@ import type {
   NotebookUISpec,
 } from '@/designer/state/initial';
 import {EditTemplateDialog} from '@/components/dialogs/edit-template';
+import {Action, getUserResourcesForAction} from '@faims3/data-model';
+import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 
 /**
  * TemplateActions component renders action cards for creating a project from a template,
@@ -75,28 +77,45 @@ const TemplateActions = () => {
     setEditorOpen(false);
   };
 
+  const canEditTemplate = useIsAuthorisedTo({
+    action: Action.UPDATE_TEMPLATE_UISPEC,
+    resourceId: templateId,
+  });
+
+  const canCreateProject = useIsAuthorisedTo({
+    action: Action.CREATE_PROJECT,
+  });
+
+  const canCreateProjectInTeam =
+    getUserResourcesForAction({
+      decodedToken: user?.decodedToken,
+      action: Action.CREATE_PROJECT_IN_TEAM,
+    }).length > 0;
+
   return (
     <>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        <Card>
-          <List>
-            <ListItem>
-              <ListLabel>Edit Template</ListLabel>
-              <ListDescription>
-                Edit this template in the Notebook Editor.
-              </ListDescription>
-            </ListItem>
-            <ListItem>
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => setEditorOpen(true)}
-              >
-                Open in Editor
-              </Button>
-            </ListItem>
-          </List>
-        </Card>
+        {canEditTemplate && (
+          <Card>
+            <List>
+              <ListItem>
+                <ListLabel>Edit Template</ListLabel>
+                <ListDescription>
+                  Edit this template in the Notebook Editor.
+                </ListDescription>
+              </ListItem>
+              <ListItem>
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => setEditorOpen(true)}
+                >
+                  Open in Editor
+                </Button>
+              </ListItem>
+            </List>
+          </Card>
+        )}
         <Card>
           <List>
             <ListItem>
@@ -122,31 +141,34 @@ const TemplateActions = () => {
             </ListItem>
           </List>
         </Card>
-        <Card className="flex-1">
-          <List className="flex flex-col gap-4">
-            <ListItem>
-              <ListLabel>Replace Template JSON File</ListLabel>
-              <ListDescription>Replace the template JSON file.</ListDescription>
-            </ListItem>
-            <ListItem>
-              <EditTemplateDialog />
-            </ListItem>
-          </List>
-        </Card>
-
-        <Card>
-          <List>
-            <ListItem>
-              <ListLabel>Create {NOTEBOOK_NAME_CAPITALIZED}</ListLabel>
-              <ListDescription>
-                Create a new {NOTEBOOK_NAME} based on this template.
-              </ListDescription>
-            </ListItem>
-            <ListItem>
-              <ProjectFromTemplateDialog />
-            </ListItem>
-          </List>
-        </Card>
+        {canEditTemplate && (
+          <Card className="flex-1">
+            <List className="flex flex-col gap-4">
+              <ListItem>
+                <ListLabel>Replace Template JSON File</ListLabel>
+                <ListDescription>Replace the template JSON file.</ListDescription>
+              </ListItem>
+              <ListItem>
+                <EditTemplateDialog />
+              </ListItem>
+            </List>
+          </Card>
+        )}
+        {(canCreateProject || canCreateProjectInTeam) && (
+          <Card>
+            <List>
+              <ListItem>
+                <ListLabel>Create {NOTEBOOK_NAME_CAPITALIZED}</ListLabel>
+                <ListDescription>
+                  Create a new {NOTEBOOK_NAME} based on this template.
+                </ListDescription>
+              </ListItem>
+              <ListItem>
+                <ProjectFromTemplateDialog />
+              </ListItem>
+            </List>
+          </Card>
+        )}
         <Card>
           <List>
             {data?.metadata.project_status === 'archived' ? (

--- a/web/src/routes/_protected/profile/index.tsx
+++ b/web/src/routes/_protected/profile/index.tsx
@@ -123,33 +123,6 @@ function RouteComponent() {
           </Button>
         </ListItem>
       </Card>
-
-      <Card className="flex-1">
-        <ListItem className="flex flex-col gap-2">
-          <ListLabel className="flex items-center gap-2">
-            <ShieldAlert size={18} />
-            <span>Bearer Token</span>
-          </ListLabel>
-          <ListDescription>
-            Click below to copy the token that can be used to authenticate in
-            scripts that use the API.
-          </ListDescription>
-          <Button
-            variant="outline"
-            onClick={async () => {
-              try {
-                await navigator.clipboard.writeText(user?.token || '');
-                toast('Bearer token copied to clipboard successfully! 🎉');
-              } catch (error) {
-                toast.error('Failed to copy bearer token to clipboard');
-              }
-            }}
-            className="mt-2"
-          >
-            Copy Bearer Token to Clipboard
-          </Button>
-        </ListItem>
-      </Card>
       <Card className="flex-1">
         <ListItem className="flex flex-col gap-2">
           <ListLabel className="flex items-center gap-2">


### PR DESCRIPTION
# Improve Dashboard actions on templates

## Ticket

#1599 #1578 #1611 

## Description

Some improvements to the actions available in the dashboard relating to templates and a few other drive-by tweaks.

## Proposed Changes

- removes 'Copy Bearer Token' from the user actions since it is superceeded by the long-lived token
- add an action to update the JSON for a template, similar to that for notebooks
- add an action to create a template from a notebook
- ensure that user is allowed to make templates in teams, only show teams they have permissions in and if there is only one team, don't offer a choice
- adds a utility function getUserResourcesForAction in data-model to get the resources (eg. teams) that a user has permission to carry out a particular action on
- hide some actions if the user doesn't have permission to use them: notebook and template editing, uploading JSON should not be visible as actions if they won't work

## How to Test

Login to the dashboard/control centre with accounts having various roles - team member, team manager, project contributor and note the visibility of actions on notebooks and templates.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
