### PR TITLE
Offline maps tweaks and fixes

### DIFF
--- a/app/src/gui/components/map/map-download.tsx
+++ b/app/src/gui/components/map/map-download.tsx
@@ -18,6 +18,9 @@
  */
 
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Button,
   Card,
@@ -33,6 +36,7 @@ import {useEffect, useMemo, useState} from 'react';
 import ProgressBar from '../progress-bar';
 import {MapComponent} from './map-component';
 import {StoredTileSet, VectorTileStore} from './tile-source';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 /**
  * Map download component presents the UI for downloading offline maps.
@@ -164,7 +168,61 @@ export const MapDownloadComponent = () => {
               Estimate Download Size
             </Button>
           )}
+          {message && <Alert severity="error">{message}</Alert>}
         </Stack>
+      </Grid>
+
+      <Grid item xs={12} sm={4} md={3}>
+        <Accordion sx={{width: '100%'}}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{height: '2em'}}
+          >
+            <h3>Maps Downloaded</h3>
+          </AccordionSummary>
+          <AccordionDetails>
+            {tileSets.length === 0 && <p>No maps downloaded.</p>}
+            {tileSets.map((mapSet: StoredTileSet, idx: number) => (
+              <Card variant="outlined" key={idx}>
+                <CardContent>
+                  <Typography variant="h5" component="div">
+                    {mapSet.setName}
+                  </Typography>
+
+                  <Typography variant="body2" color="text.secondary">
+                    Size: {Math.round((100 * mapSet.size) / 1024 / 1024) / 100}{' '}
+                    MB
+                  </Typography>
+
+                  {mapSet.tileKeys.length !== mapSet.expectedTileCount && (
+                    <ProgressBar
+                      percentage={
+                        mapSet.tileKeys.length / mapSet.expectedTileCount
+                      }
+                    />
+                  )}
+                  <Typography variant="body2" color="text.secondary">
+                    Downloaded on: {mapSet.created.toLocaleDateString()}
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button
+                    variant="outlined"
+                    onClick={() => handleDeleteTileSet(mapSet.setName)}
+                  >
+                    Delete
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    onClick={() => handleShowExtent(mapSet)}
+                  >
+                    Show
+                  </Button>
+                </CardActions>
+              </Card>
+            ))}
+          </AccordionDetails>
+        </Accordion>
       </Grid>
 
       <Grid
@@ -180,51 +238,6 @@ export const MapDownloadComponent = () => {
         }}
       >
         <MapComponent parentSetMap={setMap} />
-      </Grid>
-
-      <Grid item xs={12} sm={4} md={3}>
-        <h3>Offline Maps</h3>
-
-        {message && <Alert severity="error">{message}</Alert>}
-
-        <h4>Maps Downloaded</h4>
-        {tileSets.length === 0 && <p>No maps downloaded.</p>}
-        {tileSets.map((mapSet: StoredTileSet, idx: number) => (
-          <Card variant="outlined" key={idx}>
-            <CardContent>
-              <Typography variant="h5" component="div">
-                {mapSet.setName}
-              </Typography>
-
-              <Typography variant="body2" color="text.secondary">
-                Size: {Math.round((100 * mapSet.size) / 1024 / 1024) / 100} MB
-              </Typography>
-
-              {mapSet.tileKeys.length !== mapSet.expectedTileCount && (
-                <ProgressBar
-                  percentage={mapSet.tileKeys.length / mapSet.expectedTileCount}
-                />
-              )}
-              <Typography variant="body2" color="text.secondary">
-                Downloaded on: {mapSet.created.toLocaleDateString()}
-              </Typography>
-            </CardContent>
-            <CardActions>
-              <Button
-                variant="outlined"
-                onClick={() => handleDeleteTileSet(mapSet.setName)}
-              >
-                Delete
-              </Button>
-              <Button
-                variant="outlined"
-                onClick={() => handleShowExtent(mapSet)}
-              >
-                Show
-              </Button>
-            </CardActions>
-          </Card>
-        ))}
       </Grid>
     </Grid>
   );

--- a/app/src/gui/components/map/map-download.tsx
+++ b/app/src/gui/components/map/map-download.tsx
@@ -37,6 +37,7 @@ import ProgressBar from '../progress-bar';
 import {MapComponent} from './map-component';
 import {StoredTileSet, VectorTileStore} from './tile-source';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {set} from 'lodash';
 
 /**
  * Map download component presents the UI for downloading offline maps.
@@ -48,6 +49,7 @@ export const MapDownloadComponent = () => {
   const [downloadSetName, setDownloadSetName] = useState('Default');
   const [message, setMessage] = useState('');
   const [tileSets, setTileSets] = useState<StoredTileSet[]>([]);
+  const [downloadListOpen, setDownloadListOpen] = useState(false);
 
   const tileStore = useMemo(() => new VectorTileStore(), []);
 
@@ -116,6 +118,8 @@ export const MapDownloadComponent = () => {
     if (map) {
       const extent = map.getView().calculateExtent();
       setMessage('');
+      setDownloadListOpen(true);
+      console.log('set downloadListOpen true');
       try {
         await tileStore.createTileSet(extent, downloadSetName);
         tileStore.downloadTileSet(downloadSetName);
@@ -173,7 +177,11 @@ export const MapDownloadComponent = () => {
       </Grid>
 
       <Grid item xs={12} sm={4} md={3}>
-        <Accordion sx={{width: '100%'}}>
+        <Accordion
+          sx={{width: '100%'}}
+          expanded={downloadListOpen}
+          onClick={() => setDownloadListOpen(!downloadListOpen)}
+        >
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             sx={{height: '2em'}}

--- a/app/src/gui/components/map/tile-source.ts
+++ b/app/src/gui/components/map/tile-source.ts
@@ -417,7 +417,7 @@ class TileStoreBase {
       const tileSets = await this.tileStore.tileSetDB.getAll();
       return tileSets
         ?.filter(ts => !ts.setName.startsWith('_'))
-        .toSorted((a, b) => b.created.getTime() - a.created.getTime());
+        .sort((a, b) => b.created.getTime() - a.created.getTime());
     } else {
       return [];
     }


### PR DESCRIPTION
# Offline maps tweaks and fixes

## JIRA Ticket

None

## Description

Two issues:

- bugsnag reports an error with toSorted in older browsers not being supported
- downloaded map list on mobile is below the map and offscreen so not visible


## Proposed Changes

- Use .sort to sort the list of maps downloaded. 
- Put the downloaded map list in an accordion, closed by default but above the map view so it is visible. Open it when downloading.

## How to Test

Check out the offline map component.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
