### PR TITLE
Add new role 'TEAM_MEMBER_CREATOR'

### DIFF
--- a/api/src/api/teams.ts
+++ b/api/src/api/teams.ts
@@ -316,6 +316,7 @@ api.post(
         )
       );
     }
+    console.log('Required actions:', requiredActions);
 
     for (const actionToCheck of requiredActions) {
       if (

--- a/library/data-model/src/permission/functions.ts
+++ b/library/data-model/src/permission/functions.ts
@@ -287,12 +287,15 @@ export function teamInviteToAction({
  * @returns The corresponding permission action
  */
 export function getTeamMembershipAction(role: Role, add: boolean): Action {
+  console.log('getTeamMembershipAction', role, add);
   switch (role) {
     case Role.TEAM_ADMIN:
       return add ? Action.ADD_ADMIN_TO_TEAM : Action.REMOVE_ADMIN_FROM_TEAM;
     case Role.TEAM_MANAGER:
       return add ? Action.ADD_MANAGER_TO_TEAM : Action.REMOVE_MANAGER_FROM_TEAM;
     case Role.TEAM_MEMBER:
+      return add ? Action.ADD_MEMBER_TO_TEAM : Action.REMOVE_MEMBER_FROM_TEAM;
+    case Role.TEAM_MEMBER_CREATOR:
       return add ? Action.ADD_MEMBER_TO_TEAM : Action.REMOVE_MEMBER_FROM_TEAM;
     default:
       throw new Error(`Invalid team role: ${role}`);

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -836,6 +836,7 @@ export enum Role {
   // TEAM ROLES
   // ================
   TEAM_MEMBER = 'TEAM_MEMBER',
+  TEAM_MEMBER_CREATOR = 'TEAM_MEMBER_CREATOR',
   TEAM_MANAGER = 'TEAM_MANAGER',
   TEAM_ADMIN = 'TEAM_ADMIN',
 }
@@ -937,8 +938,14 @@ export const roleDetails: Record<Role, RoleDetails> = {
     resource: Resource.TEAM,
   },
   [Role.TEAM_MEMBER]: {
-    name: 'Team Member',
-    description: 'Basic membership in a team with standard access privileges',
+    name: 'Team Member (Contributor)',
+    description: 'Can contribute data to all projects within a team',
+    scope: RoleScope.RESOURCE_SPECIFIC,
+    resource: Resource.TEAM,
+  },
+  [Role.TEAM_MEMBER_CREATOR]: {
+    name: 'Team Member (Creator)',
+    description: 'Can create new projects within a team',
     scope: RoleScope.RESOURCE_SPECIFIC,
     resource: Resource.TEAM,
   },
@@ -1108,6 +1115,20 @@ export const roleActions: Record<
     virtualRoles: new Map([
       // Projects owned by team -> contributor
       [Resource.PROJECT, [Role.PROJECT_CONTRIBUTOR]],
+      // Template owned by team -> guest
+      [Resource.TEMPLATE, [Role.TEMPLATE_GUEST]],
+    ]),
+  },
+
+  // Modified team member to allow project creation but not
+  // access to all projects in the team
+  [Role.TEAM_MEMBER_CREATOR]: {
+    actions: [
+      Action.VIEW_TEAM_DETAILS,
+      Action.VIEW_TEAM_MEMBERS,
+      Action.CREATE_PROJECT_IN_TEAM,
+    ],
+    virtualRoles: new Map([
       // Template owned by team -> guest
       [Resource.TEMPLATE, [Role.TEMPLATE_GUEST]],
     ]),

--- a/web/src/components/forms/teams/add-user-to-team-form.tsx
+++ b/web/src/components/forms/teams/add-user-to-team-form.tsx
@@ -37,6 +37,7 @@ export function AddUserToTeamForm({
   const rolesAvailable: Role[] = [];
   if (canAddMemberToTeam) {
     rolesAvailable.push(Role.TEAM_MEMBER);
+    rolesAvailable.push(Role.TEAM_MEMBER_CREATOR);
   }
   if (canAddManagerToTeam) {
     rolesAvailable.push(Role.TEAM_MANAGER);
@@ -58,7 +59,12 @@ export function AddUserToTeamForm({
         label: roleDetails[r].name,
         value: r,
       })),
-      schema: z.enum(['TEAM_MEMBER', 'TEAM_MANAGER', 'TEAM_ADMIN']),
+      schema: z.enum([
+        Role.TEAM_MEMBER,
+        Role.TEAM_MEMBER_CREATOR,
+        Role.TEAM_MANAGER,
+        Role.TEAM_ADMIN,
+      ]),
     },
   ];
 

--- a/web/src/components/tables/team-users.tsx
+++ b/web/src/components/tables/team-users.tsx
@@ -57,6 +57,7 @@ export const useGetColumns = ({
   const rolesAvailable: Role[] = [];
   if (canAddMemberToTeam) {
     rolesAvailable.push(Role.TEAM_MEMBER);
+    rolesAvailable.push(Role.TEAM_MEMBER_CREATOR);
   }
   if (canAddManagerToTeam) {
     rolesAvailable.push(Role.TEAM_MANAGER);
@@ -79,6 +80,9 @@ export const useGetColumns = ({
       return canRemoveManager;
     }
     if (hasRoles.includes(Role.TEAM_MEMBER)) {
+      return canRemoveMember;
+    }
+    if (hasRoles.includes(Role.TEAM_MEMBER_CREATOR)) {
       return canRemoveMember;
     }
 
@@ -111,6 +115,7 @@ export const useGetColumns = ({
           original: {roles, username},
         },
       }) => {
+        console.log('roles for ', username, roles);
         return (
           <div
             className="flex flex-wrap gap-1 items-center"

--- a/web/src/components/tabs/teams/team-users.tsx
+++ b/web/src/components/tabs/teams/team-users.tsx
@@ -37,6 +37,8 @@ const TeamUsers = ({teamId}: {teamId: string}) => {
 
   const columns = useGetColumns({teamId});
 
+  console.log('team data', data);
+
   return (
     <div>
       {isLoading ? (


### PR DESCRIPTION

# feat/fix/chore: pr title

## Ticket

#1622

## Description

Currently we only have 'Member' and 'Manager' within a team, we need a role that can create notebooks in the team and administer their own notebooks but not manage users or other aspects of the team. Ideally, they should only be able to see their own notebook and data (this is for students in a course who each make their own notebook).

## Proposed Changes

Add a new role TEAM_MEMBER_CREATOR that can make notebooks but not contribute to other notebooks.   

Permissions to create these roles are the same as for the other member role. 

## How to Test

Test in the control centre/


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
