### PR TITLE
Node version in engines should be a plain version number 

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "main": "build/src/index.js",
   "packageManager": "npm@10.7.0",
   "engines": {
-    "node": "^22.18.0"
+    "node": "22.18.0"
   },
   "scripts": {
     "lint": "gts lint",

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "engines": {
-    "node": "^22.18.0"
+    "node": "22.18.0"
   },
   "scripts": {
     "prestart": "npm run runconfig",

--- a/infrastructure/aws-cdk/package.json
+++ b/infrastructure/aws-cdk/package.json
@@ -6,7 +6,7 @@
     "@faims3/infra-aws-cdk": "bin/@faims3/infra-aws-cdk.js"
   },
   "engines": {
-    "node": "^22.18.0"
+    "node": "22.18.0"
   },
   "scripts": {
     "build": "tsc",

--- a/library/data-model/package.json
+++ b/library/data-model/package.json
@@ -7,7 +7,7 @@
   "module": "./build/esm/index.js",
   "types": "build/src/index.d.ts",
   "engines": {
-    "node": "^22.18.0"
+    "node": "22.18.0"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.0",
   "main": "index.js",
   "engines": {
-    "node": "^22.18.0"
+    "node": "22.18.0"
   },
   "workspaces": [
     "api",

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.3",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "22.18.0"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "dev": "vite --port=3001",


### PR DESCRIPTION
# Node version in engines should be a plain version number 

## JIRA Ticket

None

## Description

App build is breaking on Digital Ocean because it can't work out what version of Node we want.  It wants a specific version rather than ^version.

## Proposed Changes

Change to specific version in all package.json files.  Add engines stanza to web/package.json.


## How to Test

Build on DO


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
