### PR TITLE
Fix template creation for admin user

### DIFF
--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -163,19 +163,24 @@ export function CreateTemplateForm({
     setDialogOpen(false);
   };
 
-  return (
-    <>
-      {possibleTeams?.length === 1 && (
-        <span>
-          <strong>Template will be owned by:</strong> {possibleTeams[0].name}
-        </span>
-      )}
-      <Form
-        fields={fields}
-        onSubmit={onSubmit}
-        submitButtonText="Create Template"
-        defaultValues={{team: defaultValues?.teamId}}
-      />
-    </>
-  );
+  if (possibleTeams.length === 0) {
+    // we shouldn't get here but just in case show a message
+    return <p>You do not have permission to create templates.</p>;
+  } else {
+    return (
+      <>
+        {possibleTeams?.length === 1 && (
+          <span>
+            <strong>Template will be owned by:</strong> {possibleTeams[0].name}
+          </span>
+        )}
+        <Form
+          fields={fields}
+          onSubmit={onSubmit}
+          submitButtonText="Create Template"
+          defaultValues={{team: defaultValues?.teamId}}
+        />
+      </>
+    );
+}
 }

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -39,17 +39,19 @@ export function CreateTemplateForm({
 
   // get the teams that we have permission to create
   // templates in
-  const teamsAvailable = getUserResourcesForAction({
-    decodedToken: user?.decodedToken,
-    action: Action.CREATE_TEMPLATE_IN_TEAM,
-  });
+  const teamsAvailable =
+    (canCreateGlobally
+      ? teams?.teams.map(t => t._id)
+      : getUserResourcesForAction({
+          decodedToken: user?.decodedToken,
+          action: Action.CREATE_TEMPLATE_IN_TEAM,
+        })) || [];
 
   // filter teams by those we can create templates in
-  const possibleTeams = teams?.teams.filter(team =>
-    teamsAvailable.includes(team._id)
-  );
+  const possibleTeams =
+    teams?.teams.filter(team => teamsAvailable.includes(team._id)) || [];
 
-  const justOneTeam = specifiedTeam || possibleTeams?.length === 1;
+  const justOneTeam = specifiedTeam || possibleTeams.length === 1;
 
   const fields: Field[] = [
     {
@@ -116,7 +118,7 @@ export function CreateTemplateForm({
     }
 
     let chosenTeamId = specifiedTeam;
-    if (justOneTeam && possibleTeams) {
+    if (justOneTeam && possibleTeams.length > 0) {
       chosenTeamId = possibleTeams[0]._id;
     } else if (team) {
       chosenTeamId = team;

--- a/web/src/routes/_protected/templates/index.tsx
+++ b/web/src/routes/_protected/templates/index.tsx
@@ -6,6 +6,8 @@ import {useGetTemplates} from '@/hooks/queries';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
 import {useMemo} from 'react';
+import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {Action, getUserResourcesForAction} from '@faims3/data-model';
 
 export const Route = createFileRoute('/_protected/templates/')({
   component: RouteComponent,
@@ -21,6 +23,17 @@ function RouteComponent() {
   const {user} = useAuth();
   const {isPending, data} = useGetTemplates(user);
   const navigate = useNavigate();
+
+  // can they create projects outside team?
+  const canCreateGlobally = useIsAuthorisedTo({
+    action: Action.CREATE_TEMPLATE,
+  });
+  // or in some team?
+  const canCreateInSomeTeam =
+    getUserResourcesForAction({
+      decodedToken: user?.decodedToken,
+      action: Action.CREATE_TEMPLATE_IN_TEAM,
+    }).length > 0;
 
   // breadcrumbs addition
   const paths = useMemo(
@@ -45,7 +58,9 @@ function RouteComponent() {
       data={data}
       loading={isPending}
       onRowClick={({_id}) => navigate({to: `/templates/${_id}`})}
-      button={<CreateTemplateDialog />}
+      button={
+        (canCreateGlobally || canCreateInSomeTeam) && <CreateTemplateDialog />
+      }
     />
   );
 }


### PR DESCRIPTION
# Fix template creation for admin user

## JIRA Ticket

None

## Description

There is a bug that prevents the admin user from creating templates.

## Proposed Changes

Bug is in the code that selects the teams that the template can be made in. Add all teams for the admin user.

Also drive-by fix - don't show the Create Template button for users who can't create templates.

## How to Test

Logged in as an admin user, try to create a template.

Logged in as a user who can't make templates (General User) you should not see the create template button.


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
