### PR TITLE
Change notebook name when it is updated in designer

### DIFF
--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -390,12 +390,35 @@ export const updateNotebook = async (
     payload satisfies PouchDB.Core.PutDocument<EncodedProjectUIModel>
   );
 
-  // ensure that the name is in the metadata
-  // metadata.name = projectName.trim();
   await writeProjectMetadata(metaDB, metadata);
+
+  // update the name if required
+  await changeNotebookName({projectId, name: metadata.name});
 
   // no need to write design docs for existing projects
   return projectId;
+};
+
+/**
+ * Updates the notebook status to the targeted value
+ */
+export const changeNotebookName = async ({
+  projectId,
+  name,
+}: {
+  projectId: string;
+  name: string;
+}) => {
+  // get existing project record
+  const project = await getProjectById(projectId);
+
+  if (project.name !== name) {
+    // update name
+    const updated = {...project, name};
+
+    // write it back
+    await putProjectDoc(updated);
+  }
 };
 
 /**


### PR DESCRIPTION
# Change notebook name when it is updated in designer

## Ticket

#1628 

## Description

When the notebook name is changed in the designer, it doesn't change in the dashboard page or the app.

## Proposed Changes

Change the name in the project database if it has changed.

## How to Test

Change the name of a notebook in designer, note that it should update in dashboard.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
