### PR TITLE
Remove logerror when user closes camera app etc.

### DIFF
--- a/app/src/gui/fields/TakePhoto.tsx
+++ b/app/src/gui/fields/TakePhoto.tsx
@@ -407,7 +407,9 @@ export const TakePhoto: React.FC<
             : [image];
         props.form.setFieldValue(props.field.name, newImages, true);
       } catch (err: any) {
-        logError(err);
+        // we don't log this because it will be the result of user action
+        // cancelling the camera or denying access - set the field error
+        // so they can see the problem
         props.form.setFieldError(props.field.name, err.message);
       }
     } else {


### PR DESCRIPTION
# Remove logerror when user closes camera app etc.

## Ticket

#1631

## Description

Various user actions were being logged to BugSnag that we don't need to know about when the user cancelled the camera app or denied location permissions. 

## Proposed Changes

Don't log these 'errors'.  User will still be notified.

## How to Test

Cancel the camera app in a take-photo field.


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
