### PR TITLE
Fix record sort and filter

### DIFF
--- a/library/data-model/src/data_storage/queries.ts
+++ b/library/data-model/src/data_storage/queries.ts
@@ -99,13 +99,13 @@ export async function getAllRecordsWithRegex({
   let count = 0;
   const record_ids = [] as RecordID[];
 
-  // need to delete in batches since find requires a limit argument
-  // however we should only ever be deleting one draft
+  // need to query in batches since find requires a limit argument
   do {
     res = await dataDb.find({
       selector: {
         avp_format_version: 1,
-        data: {$regex: regex},
+        // need an or query here to handle values that are arrays
+        $or: [{data: {$regex: regex}}, {data: {$elemMatch: {$regex: regex}}}],
       },
       limit: BATCH_SIZE,
       skip: skip,


### PR DESCRIPTION
# Fix record sort and filter

## Ticket

#1635 

## Description

Filtering and sorting is broken for 'summary fields' in the records table and search only sometimes works.  

## Proposed Changes

The problem was with the way that summary field values in the table were generated, we used renderCell which meant that the value that was being sorted/filtered was not what was shown.   Replace this with valueGetter to return a string value.   This then re-enables sort and filter in the table. 

Search didn't work on values that were arrays. Modified the query to use a regex within arrays as well as for plain values.

## How to Test

In the record table for a notebook with configured summary fields, click on a table header to sort. Use filters via the table header. Search via the search box.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
