### PR TITLE
Initialise safe-area plugin in code rather than in config

### DIFF
--- a/app/capacitor.config.dist.json
+++ b/app/capacitor.config.dist.json
@@ -14,15 +14,6 @@
     },
     "CapacitorHttp": {
       "enabled": false
-    },
-    "SafeArea": {
-      "enabled": true,
-      "customColorsForSystemBars": true,
-      "statusBarColor": "#FAFAFB",
-      "statusBarContent": "dark",
-      "navigationBarColor": "#FAFAFB",
-      "navigationBarContent": "dark",
-      "offset": 0
     }
   },
   "server": {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -51,6 +51,19 @@ import {AppUrlListener} from './native_hooks';
 import {MapDownloadComponent} from './gui/components/map/map-download';
 import {OFFLINE_MAPS} from './buildconfig';
 
+import {SafeArea} from '@capacitor-community/safe-area';
+
+SafeArea.enable({
+  config: {
+    customColorsForSystemBars: true,
+    statusBarColor: '#FAFAFB', // transparent
+    statusBarContent: 'dark',
+    navigationBarColor: '#FAFAFB', // transparent
+    navigationBarContent: 'dark',
+    offset: 0,
+  },
+});
+
 // type AppProps = {};
 
 // type AppState = {


### PR DESCRIPTION
# Fix safe-area overlap on mobile app

## JIRA Ticket

None

## Description

In the mobile app, the display is still overlapping the safe-area at the top of the screen unless you turn the device sideways and back again.

## Proposed Changes

Initialise the safe-area plugin in code rather than in config seems to fix the problem.

## How to Test

Build for IOS/Android, open the app. You should see that the app does not overlap the safe area.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
