### PR TITLE
Add wrapper around PouchDB in the app to intercept connection failures

### DIFF
--- a/api/src/couchdb/emailReset.ts
+++ b/api/src/couchdb/emailReset.ts
@@ -384,7 +384,7 @@ export const deleteEmailCode = async (
   }
 
   try {
-    await authDB.remove(codeDoc!._id, codeDoc!._rev);
+    if (codeDoc) await authDB.remove(codeDoc);
   } catch (error) {
     throw new Error(`Failed to delete email code: ${(error as Error).message}`);
   }

--- a/api/src/couchdb/index.ts
+++ b/api/src/couchdb/index.ts
@@ -27,6 +27,7 @@ import {
   AuthDatabase,
   couchInitialiser,
   DATABASE_TYPE,
+  DatabaseInterface,
   DatabaseType,
   initAuthDB,
   initDataDB,
@@ -72,8 +73,8 @@ const MIGRATIONS_DB_NAME = 'migrations';
 const INVITE_DB_NAME = 'invites';
 const TEAMS_DB_NAME = 'teams';
 
-let _directoryDB: PouchDB.Database | undefined;
-let _projectsDB: PouchDB.Database<ProjectDocument> | undefined;
+let _directoryDB: DatabaseInterface | undefined;
+let _projectsDB: DatabaseInterface<ProjectDocument> | undefined;
 let _templatesDb: TemplateDB | undefined;
 let _authDB: AuthDatabase | undefined;
 let _usersDB: PeopleDB | undefined;
@@ -161,7 +162,7 @@ export const verifyCouchDBConnection = async () => {
   return result;
 };
 
-export const getDirectoryDB = (): PouchDB.Database => {
+export const getDirectoryDB = (): DatabaseInterface => {
   if (!_directoryDB) {
     const pouch_options = pouchOptions();
 
@@ -208,7 +209,7 @@ export const getUsersDB = (): PeopleDB => {
   return _usersDB;
 };
 
-export const localGetProjectsDb = (): PouchDB.Database<ProjectDocument> => {
+export const localGetProjectsDb = (): DatabaseInterface<ProjectDocument> => {
   if (!_projectsDB) {
     const pouch_options = pouchOptions();
     const dbName = COUCHDB_INTERNAL_URL + '/' + PROJECTS_DB_NAME;
@@ -253,7 +254,7 @@ export const getMigrationDb = (): MigrationsDB => {
   return _migrationsDB;
 };
 
-export const getInvitesDB = (): PouchDB.Database => {
+export const getInvitesDB = (): DatabaseInterface => {
   if (!_invitesDB) {
     const pouch_options = pouchOptions();
     const dbName = COUCHDB_INTERNAL_URL + '/' + INVITE_DB_NAME;
@@ -290,7 +291,7 @@ export const getTeamsDB = (): TeamsDB => {
  */
 export const getMetadataDb = async (
   projectID: ProjectID
-): Promise<PouchDB.Database<ProjectMetaObject>> => {
+): Promise<DatabaseInterface<ProjectMetaObject>> => {
   // Gets the projects DB
   const projectsDB = localGetProjectsDb();
   if (!projectsDB) {
@@ -343,7 +344,7 @@ export const getMetadataDb = async (
  */
 export const getDataDb = async (
   projectID: ProjectID
-): Promise<PouchDB.Database<ProjectDataObject>> => {
+): Promise<DatabaseInterface<ProjectDataObject>> => {
   // Get the projects DB
   const projectsDB = localGetProjectsDb();
   if (!projectsDB) {
@@ -394,7 +395,7 @@ export const initialiseMetadataDb = async ({
 }: {
   projectId: string;
   force?: boolean;
-}): Promise<PouchDB.Database<ProjectMetaObject>> => {
+}): Promise<DatabaseInterface<ProjectMetaObject>> => {
   // Are we in a testing environment?
   const isTesting = process.env.NODE_ENV === 'test';
 
@@ -426,7 +427,7 @@ export const initialiseDataDb = async ({
 }: {
   projectId: string;
   force?: boolean;
-}): Promise<PouchDB.Database<ProjectDataObject>> => {
+}): Promise<DatabaseInterface<ProjectDataObject>> => {
   // Are we in a testing environment?
   const isTesting = process.env.NODE_ENV === 'test';
 
@@ -660,7 +661,7 @@ export const initialiseAndMigrateDBs = async ({
 }) => {
   await initialiseDbAndKeys({force, pushKeys});
 
-  let dbs: {dbType: DATABASE_TYPE; dbName: string; db: PouchDB.Database}[] = [
+  let dbs: {dbType: DATABASE_TYPE; dbName: string; db: DatabaseInterface}[] = [
     {db: getAuthDB(), dbType: DatabaseType.AUTH, dbName: AUTH_DB_NAME},
     {
       db: getDirectoryDB(),
@@ -692,8 +693,8 @@ export const initialiseAndMigrateDBs = async ({
   for (const project of projects) {
     // Project ID
     const projectId = project._id;
-    const dataDb = (await getDataDb(projectId)) as PouchDB.Database;
-    const metadataDb = (await getMetadataDb(projectId)) as PouchDB.Database;
+    const dataDb = (await getDataDb(projectId)) as DatabaseInterface;
+    const metadataDb = (await getMetadataDb(projectId)) as DatabaseInterface;
     dbs.concat([
       {
         db: dataDb,

--- a/api/src/couchdb/longLivedTokens.ts
+++ b/api/src/couchdb/longLivedTokens.ts
@@ -375,7 +375,7 @@ export const deleteLongLivedToken = async (
   }
 
   try {
-    await authDB.remove(tokenDoc!._id, tokenDoc!._rev);
+    if (tokenDoc) await authDB.remove(tokenDoc);
   } catch (error) {
     throw new Error(
       `Failed to delete long-lived token: ${(error as Error).message}`

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -45,6 +45,7 @@ import {
   userHasProjectRole,
   PROJECT_METADATA_PREFIX,
   Annotations,
+  DatabaseInterface,
 } from '@faims3/data-model';
 import archiver from 'archiver';
 import {Stream} from 'stream';
@@ -498,7 +499,7 @@ export const deleteNotebook = async (project_id: string) => {
 };
 
 export const writeProjectMetadata = async (
-  metaDB: PouchDB.Database,
+  metaDB: DatabaseInterface,
   metadata: any
 ) => {
   // add metadata, one document per attribute value pair

--- a/api/src/couchdb/refreshTokens.ts
+++ b/api/src/couchdb/refreshTokens.ts
@@ -452,7 +452,7 @@ export const deleteRefreshToken = async (
 
   // If we've reached this point, we have a valid tokenDoc
   try {
-    await authDB.remove(tokenDoc._id, tokenDoc._rev);
+    await authDB.remove(tokenDoc);
   } catch (error) {
     throw new Error(
       `Failed to delete refresh token: ${(error as Error).message}`

--- a/api/test/mocks.ts
+++ b/api/test/mocks.ts
@@ -3,7 +3,7 @@ import PouchDBFind from 'pouchdb-find';
 PouchDB.plugin(require('pouchdb-adapter-memory')); // enable memory adapter for testing
 PouchDB.plugin(PouchDBFind);
 
-import {DBCallbackObject, ProjectID} from '@faims3/data-model';
+import {DatabaseInterface, DBCallbackObject, ProjectID} from '@faims3/data-model';
 import {COUCHDB_INTERNAL_URL} from '../src/buildconfig';
 import {
   getAuthDB,
@@ -38,7 +38,7 @@ const mockShouldDisplayRecord = async () => {
   return true;
 };
 
-const clearDB = async (db: PouchDB.Database) => {
+const clearDB = async (db: DatabaseInterface) => {
   const docs = await db.allDocs();
   for (let index = 0; index < docs.rows.length; index++) {
     const doc = docs.rows[index];
@@ -75,7 +75,7 @@ export const resetDatabases = async () => {
 };
 
 export const cleanDataDBS = async () => {
-  let db: PouchDB.Database;
+  let db: DatabaseInterface;
   for (const name in databaseList) {
     db = databaseList[name];
     delete databaseList[name];

--- a/app/src/context/slices/helpers/databaseHelpers.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../buildconfig';
 import {compileUiSpecConditionals} from '../../../uiSpecification';
 import {DatabaseConnectionConfig, ProjectIdentity} from '../projectSlice';
+import {PouchDBWrapper} from './pouchDBWrapper';
 
 type DBReplicateOptions =
   | PouchDB.Replication.ReplicateOptions
@@ -109,12 +110,12 @@ export function createLocalPouchDatabase<Content extends {}>({
   id,
 }: {
   id: string;
-}): PouchDB.Database<Content> {
-  return new PouchDB<Content>(id, LOCAL_POUCH_OPTIONS);
+}): PouchDBWrapper<Content> {
+  return new PouchDBWrapper<Content>(id);
 }
 
 /**
- * Creates a PouchDB.Database used to access a remote Couch/Pouch instance
+ * Creates a PouchDBWrapper used to access a remote Couch/Pouch instance
  *
  * @param jwtToken The token to authorise with
  * @param couchUrl The couch URL e.g. https://couch.domain.com:443
@@ -143,7 +144,7 @@ export function createRemotePouchDbFromConnectionInfo<Content extends {}>({
     return PouchDB.fetch(url, opts);
   };
 
-  // Derivce the connection string (includes port if needed)
+  // Derive the connection string (includes port if needed)
   const dbConnectionString = couchUrl.endsWith('/')
     ? couchUrl + databaseName
     : couchUrl + '/' + databaseName;
@@ -276,7 +277,7 @@ export function createPouchDbSync<Content extends {}>({
   eventHandlers = DEFAULT_SYNC_HANDLERS,
 }: {
   attachmentDownload: boolean;
-  localDb: PouchDB.Database<Content>;
+  localDb: PouchDBWrapper<Content>;
   remoteDb: PouchDB.Database<Content>;
   eventHandlers?: SyncEventHandlers;
 }) {
@@ -303,7 +304,7 @@ export function createPouchDbSync<Content extends {}>({
   };
 
   // Create the sync object
-  let sync = PouchDB.sync(localDb, remoteDb, options);
+  let sync = PouchDB.sync(localDb.db, remoteDb, options);
 
   // Attach all provided event handlers These types provided in the library are
   // completely wrong - e.g. see the docs here https://pouchdb.com/api.html#sync

--- a/app/src/context/slices/helpers/pouchDBWrapper.ts
+++ b/app/src/context/slices/helpers/pouchDBWrapper.ts
@@ -18,6 +18,16 @@
  * and mitigate the indexedDB failure that occurs on IOS devices
  */
 
+/*
+ * This wrapper should have the same interface as PouchDB.Database
+ * so that it can be used as a drop-in replacement.  All operations
+ * then go through the withRetry() method which will try to re-connect
+ * to the database if one of the known errors occurs.
+ *
+ * This should have no performance impact apart from the additional
+ * function call overhead.
+ */
+
 import {DatabaseInterface} from '@faims3/data-model';
 import {RUNNING_UNDER_TEST} from '../../../buildconfig';
 import {logError} from '../../../logging';
@@ -139,7 +149,6 @@ export class PouchDBWrapper<T extends {}> implements DatabaseInterface<T> {
     doc: PouchDB.Core.PutDocument<T & Model>,
     options?: any
   ) {
-    console.log('db.pub', doc, options);
     if (options)
       return this.withRetry(() => this.db.put<Model>(doc, options), 'put');
     else return this.withRetry(() => this.db.put<Model>(doc), 'put');

--- a/app/src/context/slices/helpers/pouchDBWrapper.ts
+++ b/app/src/context/slices/helpers/pouchDBWrapper.ts
@@ -184,6 +184,8 @@ export class PouchDBWrapper<T extends {}> implements DatabaseInterface<T> {
     return this.withRetry(() => this.db.query(fun, opts), 'query');
   }
 
+  // security is not implemented for local browser based databases but we need
+  // to include the method to match the interface
   async security() {}
 
   async destroy() {

--- a/app/src/context/slices/helpers/pouchDBWrapper.ts
+++ b/app/src/context/slices/helpers/pouchDBWrapper.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Description:
+ *   Defines a wrapper around the PouchDB API so that we can catch
+ * and mitigate the indexedDB failure that occurs on IOS devices
+ */
+
+import {DatabaseInterface} from '@faims3/data-model';
+import {RUNNING_UNDER_TEST} from '../../../buildconfig';
+import {logError} from '../../../logging';
+import PouchDB from 'pouchdb-browser';
+
+// This is the PouchDB type which provides options for instantiating a database
+type LocalDatabaseOptions = PouchDB.Configuration.DatabaseConfiguration;
+
+// Default local options is none
+export const LOCAL_POUCH_OPTIONS: LocalDatabaseOptions = {};
+
+// enable memory adapter for testing
+if (RUNNING_UNDER_TEST) {
+  LOCAL_POUCH_OPTIONS['adapter'] = 'memory';
+}
+
+// Error types that indicate we should recreate the database connection
+const RECREATION_ERROR_NAMES = [
+  'InvalidStateError',
+  'AbortError',
+  'TransactionInactiveError',
+  'NotFoundError',
+  'DataError',
+  'VersionError',
+];
+
+export class PouchDBWrapper<T extends {}> implements DatabaseInterface<T> {
+  db: PouchDB.Database<T>;
+  name: string;
+  private recreationCount = 0;
+  private maxRecreations = 3;
+
+  constructor(name: string) {
+    // create a new database with this name and the standard options
+    this.name = name;
+    this.db = new PouchDB<T>(name, LOCAL_POUCH_OPTIONS);
+  }
+
+  private shouldRecreate(error: any): boolean {
+    // Check if this is an error type that indicates connection issues
+    return RECREATION_ERROR_NAMES.some(
+      errorName =>
+        error.name === errorName || error.message?.includes(errorName)
+    );
+  }
+
+  private async _recreate(): Promise<void> {
+    this.recreationCount++;
+    logError(
+      `PouchDB connection error, recreating (attempt ${this.recreationCount}) ${this.name}`
+    );
+
+    try {
+      // Destroy the old database instance
+      await this.db.close?.();
+    } catch (e) {
+      // Ignore errors when closing
+    }
+
+    // Create new instance
+    this.db = new PouchDB(this.name, LOCAL_POUCH_OPTIONS);
+  }
+
+  // Execute an operation with retry on certain errors
+  private async withRetry<R>(
+    operation: () => Promise<R> | R,
+    operationName: string
+  ): Promise<R> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (
+        this.shouldRecreate(error) &&
+        this.recreationCount < this.maxRecreations
+      ) {
+        logError(
+          `${operationName} failed, attempting to recreate connection ${error}`
+        );
+        await this._recreate();
+
+        // Reset recreation count on successful recreation
+        try {
+          const result = await operation();
+          this.recreationCount = 0; // Reset on success
+          return result;
+        } catch (retryError) {
+          logError(`${operationName} failed after recreation ${retryError}`);
+          throw retryError;
+        }
+      } else {
+        if (this.recreationCount >= this.maxRecreations) {
+          logError(
+            `${operationName} failed: maximum recreation attempts exceeded`
+          );
+        }
+        throw error;
+      }
+    }
+  }
+
+  // define the main PouchDB methods we need
+
+  async allDocs(options?: PouchDB.Core.AllDocsOptions) {
+    return this.withRetry(() => this.db.allDocs(options), 'allDocs');
+  }
+
+  async bulkDocs<C>(
+    docs: PouchDB.Core.PutDocument<T & C>[],
+    options?: PouchDB.Core.BulkDocsOptions
+  ) {
+    return this.withRetry(() => this.db.bulkDocs(docs, options), 'bulkDocs');
+  }
+
+  async get<Model>(id: string, options?: any) {
+    return this.withRetry(() => this.db.get<Model>(id, options), 'get');
+  }
+
+  async put<Model extends {}>(
+    doc: PouchDB.Core.PutDocument<T & Model>,
+    options?: any
+  ) {
+    console.log('db.pub', doc, options);
+    if (options)
+      return this.withRetry(() => this.db.put<Model>(doc, options), 'put');
+    else return this.withRetry(() => this.db.put<Model>(doc), 'put');
+  }
+
+  async post<Model extends {}>(
+    doc: PouchDB.Core.PostDocument<T & Model>,
+    options?: any
+  ) {
+    return this.withRetry(() => this.db.post<Model>(doc, options), 'post');
+  }
+
+  async find(query: PouchDB.Find.FindRequest<T>) {
+    return this.withRetry(() => this.db.find(query), 'find');
+  }
+
+  async remove(doc: any, options?: any) {
+    return this.withRetry(() => this.db.remove(doc, options), 'remove');
+  }
+
+  async info() {
+    return this.withRetry(() => this.db.info(), 'info');
+  }
+
+  async close() {
+    return this.withRetry(() => this.db.close(), 'close');
+  }
+
+  async query<Result extends {}, Model extends {} = T>(
+    fun: string | PouchDB.Map<Model, Result> | PouchDB.Filter<Model, Result>,
+    opts?: PouchDB.Query.Options<Model, Result>
+  ) {
+    return this.withRetry(() => this.db.query(fun, opts), 'query');
+  }
+
+  async security() {}
+
+  async destroy() {
+    return this.withRetry(() => this.db.destroy(), 'destroy');
+  }
+
+  // Reset recreation count manually if needed
+  resetRecreationCount(): void {
+    this.recreationCount = 0;
+  }
+}

--- a/app/src/context/slices/projectSlice.ts
+++ b/app/src/context/slices/projectSlice.ts
@@ -29,6 +29,7 @@ import {
   SyncEventHandlers,
 } from './helpers/databaseHelpers';
 import {databaseService} from './helpers/databaseService';
+import {PouchDBWrapper} from './helpers/pouchDBWrapper';
 
 // TYPES
 // =====
@@ -1121,8 +1122,8 @@ export const projectByIdentity = (
  */
 export function getAllDataDbs(
   state: RootState
-): PouchDB.Database<ProjectDataObject>[] {
-  const databases: PouchDB.Database<ProjectDataObject>[] = [];
+): PouchDBWrapper<ProjectDataObject>[] {
+  const databases: PouchDBWrapper<ProjectDataObject>[] = [];
   for (const server of Object.values(state.projects.servers)) {
     for (const project of Object.values(server.projects)) {
       if (project.isActivated && project.database?.localDbId) {

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -30,10 +30,11 @@ import './index.css';
 import {addNativeHooks} from './native_hooks';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import {shouldDisplayRecord} from './users';
+import {PouchDBWrapper} from './context/slices/helpers/pouchDBWrapper';
 
 export const localGetDataDb = (
   projectId: string
-): PouchDB.Database<ProjectDataObject> => {
+): PouchDBWrapper<ProjectDataObject> => {
   const projectState = store.getState();
   const dbId = selectAllProjects(projectState).find(
     p => p.projectId === projectId

--- a/app/src/sync/data-dump.ts
+++ b/app/src/sync/data-dump.ts
@@ -141,7 +141,7 @@ export async function progressiveSaveFiles(
   try {
     if (keepDumping)
       keepDumping = await progressiveDump(
-        databaseService.getLocalStateDatabase(),
+        databaseService.getLocalStateDatabase().db,
         writer(10, 12)
       );
   } catch {
@@ -151,7 +151,7 @@ export async function progressiveSaveFiles(
   try {
     if (keepDumping)
       keepDumping = await progressiveDump(
-        databaseService.getDraftDatabase(),
+        databaseService.getDraftDatabase().db,
         writer(15, 20)
       );
   } catch {

--- a/app/src/sync/draft-storage.ts
+++ b/app/src/sync/draft-storage.ts
@@ -38,8 +38,9 @@ import {databaseService} from '../context/slices/helpers/databaseService';
 import {selectProjectById} from '../context/slices/projectSlice';
 import {store} from '../context/store';
 import {logError} from '../logging';
+import {PouchDBWrapper} from '../context/slices/helpers/pouchDBWrapper';
 
-export type DraftDB = PouchDB.Database<EncodedDraft>;
+export type DraftDB = PouchDBWrapper<EncodedDraft>;
 
 // Note: duplicated from @faims3/data-model as it doesn't do anything important
 export function generate_file_name(): string {
@@ -262,7 +263,7 @@ export async function deleteStagedData(
       ? revision_cache
       : (await draftDb.get(draft_id))._rev;
 
-  await (draftDb as PouchDB.Database<{}>).put(
+  await (draftDb as PouchDBWrapper<{}>).put(
     {
       _id: draft_id,
       _rev: revision,

--- a/docs/user/conf.py
+++ b/docs/user/conf.py
@@ -14,7 +14,7 @@ sys.path.append(str(Path('_ext').resolve()))
 project = os.getenv("VITE_APP_NAME", "FAIMS")
 copyright = "2023, Electronic Field Notebooks Pty Ltd"
 author = "Electronic Field Notebooks Pty Ltd"
-release = "1.2.4"
+release = "1.2.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/library/data-model/src/data_storage/authDB/types.ts
+++ b/library/data-model/src/data_storage/authDB/types.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 import {CouchDocumentSchema, CouchExistingDocumentSchema} from '../utils';
+import {DatabaseInterface} from '../../types';
 
 // =============
 // V1 Definition
@@ -545,4 +546,4 @@ export type GetRefreshTokenIndex = 'id' | 'token';
 export type GetEmailCodeIndex = 'id' | 'code';
 export type GetVerificationChallengeIndex = 'id' | 'code';
 export type GetLongLivedTokenIndex = 'id' | 'tokenHash';
-export type AuthDatabase = PouchDB.Database<AuthRecordFields>;
+export type AuthDatabase = DatabaseInterface<AuthRecordFields>;

--- a/library/data-model/src/data_storage/invitesDB/types.ts
+++ b/library/data-model/src/data_storage/invitesDB/types.ts
@@ -19,6 +19,7 @@
  */
 
 import {Resource, Role} from '../../permission';
+import {DatabaseInterface} from '../../types';
 
 export type V1InviteDBFields = {
   // The project it refers to
@@ -78,4 +79,4 @@ export type InvitesDBFields = V3InviteDBFields;
 export type ExistingInvitesDBDocument =
   PouchDB.Core.ExistingDocument<InvitesDBFields>;
 export type InvitesDBDocument = PouchDB.Core.Document<InvitesDBFields>;
-export type InvitesDB = PouchDB.Database<InvitesDBFields>;
+export type InvitesDB = DatabaseInterface<InvitesDBFields>;

--- a/library/data-model/src/data_storage/migrations/migrationService.ts
+++ b/library/data-model/src/data_storage/migrations/migrationService.ts
@@ -13,6 +13,7 @@ import {
   MigrationsDBFields,
 } from '../migrationsDB';
 import {DB_MIGRATIONS, DB_TARGET_VERSIONS} from './migrations';
+import {DatabaseInterface} from '../../types';
 
 function generateErrorLog({
   reason,
@@ -153,7 +154,7 @@ export function identifyMigrations({
  * 5. Tracks and returns any issues encountered
  *
  * @param {Object} params - The parameters object.
- * @param {PouchDB.Database} params.db - The PouchDB database to migrate.
+ * @param {DatabaseInterface} params.db - The PouchDB database to migrate.
  * @param {MigrationFunc} params.migrationFunc - The migration function to apply to each document.
  * @returns {Object} - An object containing an array of issues encountered during migration.
  */
@@ -161,7 +162,7 @@ export async function performMigration({
   db,
   migrationFunc,
 }: {
-  db: PouchDB.Database;
+  db: DatabaseInterface;
   migrationFunc: MigrationFunc;
 }): Promise<{
   issues: string[];
@@ -278,7 +279,7 @@ export async function migrateDbs({
   migrationDb,
   userId = 'system',
 }: {
-  dbs: {dbType: DatabaseType; dbName: string; db: PouchDB.Database}[];
+  dbs: {dbType: DatabaseType; dbName: string; db: DatabaseInterface}[];
   migrationDb: MigrationsDB;
   userId?: string;
 }): Promise<void> {

--- a/library/data-model/src/data_storage/migrationsDB/types.ts
+++ b/library/data-model/src/data_storage/migrationsDB/types.ts
@@ -1,3 +1,4 @@
+import {DatabaseInterface} from '../../types';
 import {DatabaseType} from '../migrations/types';
 export type MigrationLog = {
   // from and to version ID
@@ -45,4 +46,4 @@ export type MigrationsDBFields = {
 };
 export type MigrationsDBDocument =
   PouchDB.Core.ExistingDocument<MigrationsDBFields>;
-export type MigrationsDB = PouchDB.Database<MigrationsDBFields>;
+export type MigrationsDB = DatabaseInterface<MigrationsDBFields>;

--- a/library/data-model/src/data_storage/peopleDB/types.ts
+++ b/library/data-model/src/data_storage/peopleDB/types.ts
@@ -21,6 +21,7 @@ import {z} from 'zod';
 import {Role} from '../../permission/model';
 import {resourceRoleSchema} from '../../permission/types';
 import {CouchDocumentSchema, CouchExistingDocumentSchema} from '../utils';
+import {DatabaseInterface} from '../../types';
 
 // Basic types defined as Zod schemas
 export const ServiceIDSchema = z.string();
@@ -152,4 +153,4 @@ export type ExistingPeopleDBDocument = z.infer<
 >;
 
 // Database
-export type PeopleDB = PouchDB.Database<PeopleDBFields>;
+export type PeopleDB = DatabaseInterface<PeopleDBFields>;

--- a/library/data-model/src/data_storage/projectsDB/types.ts
+++ b/library/data-model/src/data_storage/projectsDB/types.ts
@@ -1,4 +1,4 @@
-import {PossibleConnectionInfo} from '../../types';
+import {DatabaseInterface, PossibleConnectionInfo} from '../../types';
 
 // V1
 export type ProjectV1Fields = {
@@ -50,4 +50,4 @@ export type ExistingProjectDocument =
   PouchDB.Core.ExistingDocument<ProjectDBFields>;
 
 // DB Type (V2)
-export type ProjectDB = PouchDB.Database<ProjectDBFields>;
+export type ProjectDB = DatabaseInterface<ProjectDBFields>;

--- a/library/data-model/src/data_storage/storageFunctions.ts
+++ b/library/data-model/src/data_storage/storageFunctions.ts
@@ -15,6 +15,7 @@ import {getDataDB, shouldDisplayRecord} from '../callbacks';
 import {TokenContents} from '../permission/types';
 import {logError} from '../logging';
 import {
+  DatabaseInterface,
   DataDbType,
   FAIMSTypeName,
   ProjectDataObject,
@@ -27,6 +28,7 @@ import {
   RecordReference,
   RecordRevisionListing,
   Revision,
+  RevisionDbType,
   RevisionID,
   UnhydratedRecord,
 } from '../types';
@@ -218,12 +220,12 @@ export async function listFAIMSRecordRevisions({
 export async function listFAIMSProjectRevisions({
   dataDb,
 }: {
-  dataDb: DataDbType;
+  dataDb: DataDbType | RevisionDbType;
 }): Promise<ProjectRevisionListing> {
   try {
     // get all revision
     const result = await queryCouch<Revision>({
-      db: dataDb,
+      db: dataDb as RevisionDbType,
       index: REVISIONS_INDEX,
     });
     const revisionMap: ProjectRevisionListing = {};
@@ -846,7 +848,7 @@ export async function getSomeRecords(
   bookmark: string | null = null,
   filter_deleted = true
 ): Promise<RecordRevisionIndexDocument[]> {
-  const dataDB: PouchDB.Database<ProjectDataObject> | undefined =
+  const dataDB: DatabaseInterface<ProjectDataObject> | undefined =
     await getDataDB(project_id);
   if (!dataDB) throw Error('No data DB with project ID ' + project_id);
 

--- a/library/data-model/src/data_storage/teamsDB/types.ts
+++ b/library/data-model/src/data_storage/teamsDB/types.ts
@@ -18,6 +18,8 @@
  *   Data models related to users.
  */
 
+import {DatabaseInterface} from "../../types";
+
 export type TeamsV1Document = PouchDB.Core.ExistingDocument<TeamsV1Fields>;
 
 export interface TeamsV1Fields {
@@ -42,4 +44,4 @@ export type TeamsDBFields = TeamsV1Fields;
 export type ExistingTeamsDBDocument =
   PouchDB.Core.ExistingDocument<TeamsDBFields>;
 export type TeamsDBDocument = PouchDB.Core.Document<TeamsDBFields>;
-export type TeamsDB = PouchDB.Database<TeamsDBFields>;
+export type TeamsDB = DatabaseInterface<TeamsDBFields>;

--- a/library/data-model/src/data_storage/templatesDB/types.ts
+++ b/library/data-model/src/data_storage/templatesDB/types.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {EncodedUISpecificationSchema} from '../../types';
+import {DatabaseInterface, EncodedUISpecificationSchema} from '../../types';
 import {CouchDocumentSchema, CouchExistingDocumentSchema} from '../utils';
 
 // V1
@@ -45,4 +45,4 @@ export type ExistingTemplateDocument = z.infer<
 >;
 
 // Database
-export type TemplateDB = PouchDB.Database<TemplateDBFields>;
+export type TemplateDB = DatabaseInterface<TemplateDBFields>;

--- a/library/data-model/src/data_storage/utils.ts
+++ b/library/data-model/src/data_storage/utils.ts
@@ -1,6 +1,7 @@
 import PouchDB from 'pouchdb';
 import PouchDBSecurity from 'pouchdb-security-helper';
 import {z} from 'zod';
+import {DatabaseInterface} from '../types';
 PouchDB.plugin(PouchDBSecurity);
 
 // Zod schema for the document and existing document couch interfaces
@@ -74,7 +75,7 @@ export async function safeWriteDocument<T extends {}>({
   data,
   writeOnClash = true,
 }: {
-  db: PouchDB.Database<T>;
+  db: DatabaseInterface<T>;
   data: PouchDB.Core.Document<T>;
   writeOnClash?: boolean;
 }) {
@@ -109,7 +110,7 @@ export async function batchWriteDocuments<T extends {}>({
   documents,
   writeOnClash = true,
 }: {
-  db: PouchDB.Database<T>;
+  db: DatabaseInterface<T>;
   documents: PouchDB.Core.ExistingDocument<T>[];
   writeOnClash?: boolean;
 }): Promise<{successful: number; failed: number}> {
@@ -184,7 +185,7 @@ export async function writeNewDocument<T extends {}>({
   db,
   data,
 }: {
-  db: PouchDB.Database<T>;
+  db: DatabaseInterface<T>;
   data: PouchDB.Core.Document<T>;
 }): Promise<{
   wrote: boolean;
@@ -221,7 +222,7 @@ export async function writeNewDocument<T extends {}>({
 /**
  * Method to apply initialisation content to a database.
  *
- * @param db PouchDB.Database to initialise
+ * @param db DatabaseInterface to initialise
  * @param content The documents to write
  * @param config.forceWrite Override on clash?
  * @param config.applyPermissions Actually write security document?
@@ -231,7 +232,7 @@ export const couchInitialiser = async ({
   content,
   config: {forceWrite = false, applyPermissions = true} = {},
 }: {
-  db: PouchDB.Database;
+  db: DatabaseInterface;
   content: InitialisationContent;
   config?: {
     forceWrite?: boolean;

--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -388,15 +388,6 @@ export interface DatabaseInterface<Content extends {} = {}> {
   close(): Promise<void>;
   destroy(): Promise<void>;
 
-  // query<Result extends {}, Model extends {} = Content>(
-  //   fun: string | Map<Model, Result> | PouchDB.Filter<Model, Result>,
-  //   opts: PouchDB.Query.Options<Model, Result>,
-  //   callback: PouchDB.Core.Callback<PouchDB.Query.Response<Result>>
-  // ): void;
-  // query<Result extends {}, Model extends {} = Content>(
-  //   fun: string | Map<Model, Result> | PouchDB.Filter<Model, Result>,
-  //   callback: PouchDB.Core.Callback<PouchDB.Query.Response<Result>>
-  // ): void;
   query<Result extends {}, Model extends {} = Content>(
     fun: string | PouchDB.Map<Model, Result> | PouchDB.Filter<Model, Result>,
     opts?: PouchDB.Query.Options<Model, Result>

--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -329,7 +329,91 @@ export type DraftMetadataList = {
   [key: string]: DraftMetadata;
 };
 
-export type DataDbType = PouchDB.Database<ProjectDataObject>;
+// Define an abstract database interface that will allow for real
+// PouchDB databases or our wrapped version in the app
+export interface DatabaseInterface<Content extends {} = {}> {
+  name: string;
+
+  allDocs<Model>(
+    options?:
+      | PouchDB.Core.AllDocsWithKeysOptions
+      | PouchDB.Core.AllDocsOptions
+      | PouchDB.Core.AllDocsWithinRangeOptions
+  ): Promise<PouchDB.Core.AllDocsResponse<Content & Model>>;
+  allDocs<Model>(
+    options: PouchDB.Core.AllDocsWithKeysOptions
+  ): Promise<PouchDB.Core.AllDocsWithKeysResponse<Content & Model>>;
+
+  bulkDocs<Model>(
+    docs: Array<PouchDB.Core.PutDocument<Content & Model>>,
+    options?: PouchDB.Core.BulkDocsOptions
+  ): Promise<Array<PouchDB.Core.Response | PouchDB.Core.Error>>;
+  get<Model>(
+    id: string,
+    options?: PouchDB.Core.GetOptions
+  ): Promise<PouchDB.Core.Document<Content & Model> & PouchDB.Core.GetMeta>;
+  get<Model>(
+    docId: PouchDB.Core.DocumentId,
+    options: PouchDB.Core.GetOpenRevisions
+  ): Promise<Array<PouchDB.Core.Revision<Content & Model>>>;
+
+  put<Model>(
+    doc: PouchDB.Core.PutDocument<Content & Model>,
+    options?: PouchDB.Core.PutOptions
+  ): Promise<PouchDB.Core.Response>;
+
+  post<Model>(
+    doc: PouchDB.Core.PostDocument<Content & Model>,
+    options?: PouchDB.Core.Options
+  ): Promise<PouchDB.Core.Response>;
+
+  find(
+    query: PouchDB.Find.FindRequest<Content>
+  ): Promise<PouchDB.Find.FindResponse<Content>>;
+  remove(
+    doc: PouchDB.Core.RemoveDocument,
+    options?: PouchDB.Core.Options
+  ): Promise<PouchDB.Core.Response>;
+  remove(
+    docId: PouchDB.Core.DocumentId,
+    revision: PouchDB.Core.RevisionId,
+    options?: PouchDB.Core.Options
+  ): Promise<PouchDB.Core.Response>;
+  remove(
+    doc: PouchDB.Core.RemoveDocument,
+    options?: PouchDB.Core.Options
+  ): Promise<PouchDB.Core.Response>;
+
+  info(): Promise<PouchDB.Core.DatabaseInfo>;
+  close(): Promise<void>;
+  destroy(): Promise<void>;
+
+  // query<Result extends {}, Model extends {} = Content>(
+  //   fun: string | Map<Model, Result> | PouchDB.Filter<Model, Result>,
+  //   opts: PouchDB.Query.Options<Model, Result>,
+  //   callback: PouchDB.Core.Callback<PouchDB.Query.Response<Result>>
+  // ): void;
+  // query<Result extends {}, Model extends {} = Content>(
+  //   fun: string | Map<Model, Result> | PouchDB.Filter<Model, Result>,
+  //   callback: PouchDB.Core.Callback<PouchDB.Query.Response<Result>>
+  // ): void;
+  query<Result extends {}, Model extends {} = Content>(
+    fun: string | PouchDB.Map<Model, Result> | PouchDB.Filter<Model, Result>,
+    opts?: PouchDB.Query.Options<Model, Result>
+  ): Promise<PouchDB.Query.Response<Result>>;
+
+  security(
+    doc?: PouchDB.SecurityHelper.PartialSecurityDocument
+  ): PouchDB.SecurityHelper.Security;
+}
+
+// Add these type definitions after the existing DatabaseInterface
+export type RecordDbType = DatabaseInterface<EncodedRecord>;
+export type RevisionDbType = DatabaseInterface<Revision>;
+export type AvpDbType = DatabaseInterface<AttributeValuePair>;
+export type AttachmentDbType = DatabaseInterface<FAIMSAttachment>;
+
+export type DataDbType = DatabaseInterface<ProjectDataObject>;
 
 // end of types from datamodel/drafts.ts --------------------------------
 

--- a/library/data-model/tests/migrationService.test.ts
+++ b/library/data-model/tests/migrationService.test.ts
@@ -21,6 +21,7 @@ import {
   migrateDbs,
   performMigration,
 } from '../src/data_storage';
+import {DatabaseInterface} from '../src';
 
 // Register memory adapter
 PouchDB.plugin(PouchDBMemoryAdapter);
@@ -208,11 +209,13 @@ describe('Migration System Tests', () => {
    * Test performMigration function with in-memory PouchDB
    */
   describe('performMigration', () => {
-    let testDb: PouchDB.Database;
+    let testDb: DatabaseInterface;
 
     beforeEach(async () => {
       // Create a fresh in-memory database for each test
-      testDb = new PouchDB('test-migration-db', {adapter: 'memory'});
+      testDb = new PouchDB('test-migration-db', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
 
       // Add some test documents
       await testDb.bulkDocs([
@@ -337,7 +340,9 @@ describe('Migration System Tests', () => {
 
     it('should handle database errors gracefully', async () => {
       // Create a broken database by closing and trying to use it
-      const brokenDb = new PouchDB('broken-db', {adapter: 'memory'});
+      const brokenDb = new PouchDB('broken-db', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
       await brokenDb.destroy(); // This makes the DB unusable
 
       // Try to perform migration on broken DB
@@ -399,13 +404,17 @@ describe('Migration System Tests', () => {
    * Test migrateDbs function with in-memory PouchDB
    */
   describe('migrateDbs', () => {
-    let testMigrationDb: PouchDB.Database;
-    let testPeopleDb: PouchDB.Database;
+    let testMigrationDb: DatabaseInterface;
+    let testPeopleDb: DatabaseInterface;
 
     beforeEach(async () => {
       // Create in-memory databases
-      testMigrationDb = new PouchDB('test-migrations-db', {adapter: 'memory'});
-      testPeopleDb = new PouchDB('test-people-db', {adapter: 'memory'});
+      testMigrationDb = new PouchDB('test-migrations-db', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+      testPeopleDb = new PouchDB('test-people-db', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
 
       // Add design documents to migrations db
       await couchInitialiser({
@@ -467,7 +476,7 @@ describe('Migration System Tests', () => {
           {
             dbType: DatabaseType.PEOPLE,
             dbName: 'test-people-db',
-            db: testPeopleDb as PouchDB.Database,
+            db: testPeopleDb,
           },
         ],
         migrationDb: testMigrationDb as unknown as MigrationsDB,
@@ -510,7 +519,9 @@ describe('Migration System Tests', () => {
     });
 
     it('should handle existing database with migration document', async () => {
-      const realPeopleDb = new PouchDB('real-people-db', {adapter: 'memory'});
+      const realPeopleDb = new PouchDB('real-people-db', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
 
       // Add design documents to migrations db
       await couchInitialiser({
@@ -561,7 +572,7 @@ describe('Migration System Tests', () => {
           {
             dbType: DatabaseType.PEOPLE,
             dbName: 'real-people-db',
-            db: realPeopleDb as PouchDB.Database,
+            db: realPeopleDb,
           },
         ],
         migrationDb: testMigrationDb as unknown as MigrationsDB,
@@ -646,7 +657,7 @@ describe('Migration System Tests', () => {
           {
             dbType: DatabaseType.PEOPLE,
             dbName: 'test-people-db',
-            db: testPeopleDb as PouchDB.Database,
+            db: testPeopleDb,
           },
         ],
         migrationDb: testMigrationDb as unknown as MigrationsDB,
@@ -711,7 +722,7 @@ describe('Migration System Tests', () => {
           {
             dbType: DatabaseType.PEOPLE,
             dbName: 'test-people-db',
-            db: testPeopleDb as PouchDB.Database,
+            db: testPeopleDb,
           },
         ],
         migrationDb: testMigrationDb as unknown as MigrationsDB,
@@ -743,7 +754,7 @@ describe('Migration System Tests', () => {
       // Create another test database
       const testProjectsDb = new PouchDB('test-projects-db', {
         adapter: 'memory',
-      });
+      }) as DatabaseInterface;
       await testProjectsDb.put({_id: 'project1', name: 'Test Project'});
 
       try {
@@ -774,12 +785,12 @@ describe('Migration System Tests', () => {
             {
               dbType: DatabaseType.PEOPLE,
               dbName: 'test-people-db',
-              db: testPeopleDb as PouchDB.Database,
+              db: testPeopleDb,
             },
             {
               dbType: DatabaseType.PROJECTS,
               dbName: 'test-projects-db',
-              db: testProjectsDb as PouchDB.Database,
+              db: testProjectsDb,
             },
           ],
           migrationDb: testMigrationDb as unknown as MigrationsDB,

--- a/library/data-model/tests/mocks.ts
+++ b/library/data-model/tests/mocks.ts
@@ -41,7 +41,7 @@ const mockShouldDisplayRecord = async () => {
 };
 
 export const cleanDataDBS = async () => {
-  let db: PouchDB.Database;
+  let db: DatabaseInterface;
   for (const name in databaseList) {
     db = databaseList[name];
     delete databaseList[name];


### PR DESCRIPTION
# Add wrapper around PouchDB in the app to intercept connection failures

## Ticket

#1632

## Description

We are seeing intermittent failures of IndexedDB in IOS webview due perhaps to a bug.   It seems that one way around this is to re-open the database connection should it ever disappear.  


## Proposed Changes

Adds PouchDBWrapper in the app to act as a wrapper class for all database connections, mimicing the 
PouchDB.Database interface.   All methods are passed through a retry method that will re-open 
the database connetion if required, up to three times.   

In the normal course of things, this is a no-op wrapper.  Should the connection fail, it will re-open the
connection and try again.  We'll get a logError in this case to see that it is happening. 


## How to Test

Should have no effect on operation unless this bug hits.  All tests pass and it seems to work in casual testing. 

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
