### PR TITLE
PouchDB Wrapper: only log on failure to recreate connections

### DIFF
--- a/app/src/context/slices/helpers/pouchDBWrapper.ts
+++ b/app/src/context/slices/helpers/pouchDBWrapper.ts
@@ -76,9 +76,6 @@ export class PouchDBWrapper<T extends {}> implements DatabaseInterface<T> {
 
   private async _recreate(): Promise<void> {
     this.recreationCount++;
-    logError(
-      `PouchDB connection error, recreating (attempt ${this.recreationCount}) ${this.name}`
-    );
 
     try {
       // Destroy the old database instance


### PR DESCRIPTION
# PouchDB Wrapper: only log on failure to recreate connections

## JIRA Ticket

None

## Description

Reduce logging of connection recreation - we know this works. Only log failure to recreate.

