### PR TITLE
metadata setting is a string so coerce to boolean

### DIFF
--- a/app/src/gui/components/notebook/add_record_by_type.tsx
+++ b/app/src/gui/components/notebook/add_record_by_type.tsx
@@ -33,7 +33,7 @@ export default function AddRecordButtons({
   const [selectedRecord, setSelectedRecord] = useState<
     RecordMetadata | undefined
   >(undefined);
-  const showQRButton = metadata['showQRCodeButton'] === true;
+  const showQRButton = !!metadata['showQRCodeButton'];
   const buttonLabel = `Add new ${recordLabel}`;
   const uiSpecification = compiledSpecService.getSpec(uiSpecificationId);
 
@@ -161,7 +161,7 @@ export default function AddRecordButtons({
           {showQRButton && (
             <QRCodeButton
               key="scan-qr"
-              label="Scan QR"
+              label="Search By QR Code"
               onScanResult={handleScanResult}
             />
           )}


### PR DESCRIPTION
Signed-off-by: Steve Cassidy <steve@fieldnote.au>

# feat/fix/chore: pr title

## Ticket

#1587

## Description

Search by QR code doesn't show when enabled in the notebook.

## Proposed Changes

Was looking for a boolean value when it's a string. 

## How to Test

Select a notebook with QR search enabled (on the Info panel in the editor) and check that the button appears (disabled on desktop but visible).

QR search could do with some refinement but we'll leave that until we get some feedback from users on how it might work better.  Currently does nothing if there is no matching record, jumps to one of them if there is at least one. 


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
