### PR TITLE
Fix data loss on editing unsaved new record draft

### DIFF
--- a/app/src/gui/components/record/form.tsx
+++ b/app/src/gui/components/record/form.tsx
@@ -264,7 +264,6 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
         currentValues,
         this.state.lastProcessedValues
       );
-
       if (!valuesUnchanged) {
         const changed = recomputeDerivedFields({
           context: this.state.recordContext,
@@ -621,6 +620,20 @@ class RecordForm extends React.Component<RecordFormProps, RecordFormState> {
             revisionId: revision_id,
           })) ?? undefined)
         : undefined;
+
+      // if there is no existing revision then this is either a brand new
+      // record or an existing saved draft
+      if (!revision_id && this.props.draft_id) {
+        // if it is an existing draft, we want to pull the data from the draft
+        // db to populate the form, let's force a fetch of the draft data
+        await this.draftState._fetchData({
+          type: this.state.type_cached!,
+          field_types: getReturnedTypesForViewSet(
+            this.props.ui_specification,
+            this.getViewsetName()
+          ),
+        });
+      }
 
       // data and annotations or nothing
       const database_data = fromdb ? fromdb.data : {};


### PR DESCRIPTION
Signed-off-by: Steve Cassidy <steve@fieldnote.au>

# Fix data loss on editing unsaved new record draft

##  Ticket

#1698

## Description

If you create a new record but don't save it, it is saved in a draft. If you then go back to edit the draft, any data you entered is wiped and if there is an auto-incrementer, a new incrementer value is generated.

## Proposed Changes

Bug is in the insane form.tsx relating to the way that the form is initialised. In this case, there is no explicit initialisation from the stored draft, instead it is supposed to happen in some async process. The timing is such that the draft is overwritten by a blank record before it can be retrieved from the database.  

I've forced retrieval of the draft by inserting a call to _fechData in the forms setInitialValues method.  This seems to be enough to populate the form properly with the saved values and 
retains the expected behaviour in other cases.

## How to Test

- Create a new record in the app
- Add some data to some fields
- don't save but click on the header to get out of the record
- Note that a draft is created, shows eg. the HRID you entered
- Edit the draft - you should see the data you entered in the form

Repeat for an existing record (edit a record, don't save, visit the draft).

Try making a new record, should correctly show blank fields and save a draft.


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
