### PR TITLE
feat: quick expiry selector usage for all invite forms

### DIFF
--- a/web/src/components/expiry-selector.tsx
+++ b/web/src/components/expiry-selector.tsx
@@ -50,6 +50,8 @@ export interface ExpirySelectorProps {
   neverExpiresWarningMessage?: string;
   /** Show maximum duration info */
   showMaxDurationInfo?: boolean;
+  /** Maximum token duration message prefix {message}: {days} days */
+  maximumDurationPrefix?: string;
 }
 
 type SelectionMode = 'hints' | 'custom';
@@ -69,6 +71,7 @@ export const ExpirySelector: React.FC<ExpirySelectorProps> = ({
   neverExpiresText = 'Never expires',
   currentSelectionPrefix = 'Current Selection:',
   neverExpiresWarningTitle = 'Security Warning',
+  maximumDurationPrefix = 'Maximum token duration',
   neverExpiresWarningMessage = "This token will never expire automatically. Make sure to revoke it manually when it's no longer needed.",
   showMaxDurationInfo = true,
 }) => {
@@ -272,7 +275,7 @@ export const ExpirySelector: React.FC<ExpirySelectorProps> = ({
       {/* Maximum duration info */}
       {showMaxDurationInfo && maxDurationDays && (
         <div className="text-xs text-muted-foreground">
-          Maximum token duration: {maxDurationDays} days
+          {maximumDurationPrefix}: {maxDurationDays} days
         </div>
       )}
     </div>

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -146,6 +146,7 @@ function getLongLivedTokenDurationHints(): number[] {
 }
 
 export const LONG_LIVED_TOKEN_DURATION_HINTS = getLongLivedTokenDurationHints();
+export const INVITE_TOKEN_HINTS = DEFAULT_HINTS;
 
 // Help link to use for the long lived token docs
 export const LONG_LIVED_TOKEN_HELP_LINK =


### PR DESCRIPTION
Makes the expiry duration selector use the superior quick selector from the long lived tokens (instead of the calendar thing which is annoying). Users reported not liking the calendar workflow.