### PR TITLE
Invalidate project query after uploading a notebook JSON

### DIFF
--- a/web/src/components/dialogs/edit-project-dialog.tsx
+++ b/web/src/components/dialogs/edit-project-dialog.tsx
@@ -16,9 +16,11 @@ import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
  * EditProjectDialog component renders a dialog for editing a project.
  * It provides a button to open the dialog and a form to update the project.
  *
+ * The onSuccess callback is called after a successful update.
+ *
  * @returns {JSX.Element} The rendered EditProjectDialog component.
  */
-export const EditProjectDialog = ({callback}: {callback: () => void}) => {
+export const EditProjectDialog = ({onSuccess}: {onSuccess: () => void}) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -37,7 +39,7 @@ export const EditProjectDialog = ({callback}: {callback: () => void}) => {
             new file must be a valid JSON file.
           </DialogDescription>
         </DialogHeader>
-        <UpdateProjectForm setDialogOpen={setOpen} callback={callback} />
+        <UpdateProjectForm setDialogOpen={setOpen} onSuccess={onSuccess} />
       </DialogContent>
     </Dialog>
   );

--- a/web/src/components/dialogs/edit-template.tsx
+++ b/web/src/components/dialogs/edit-template.tsx
@@ -26,7 +26,7 @@ import {Pencil} from 'lucide-react';
  *
  * @returns {JSX.Element} The rendered EditTemplateDialog component.
  */
-export const EditTemplateDialog = ({callback}: {callback: () => void}) => {
+export const EditTemplateDialog = ({onSuccess}: {onSuccess: () => void}) => {
   const {user} = useAuth();
   const {templateId} = Route.useParams();
   const {data} = useGetTemplate(user, templateId);
@@ -64,7 +64,7 @@ export const EditTemplateDialog = ({callback}: {callback: () => void}) => {
                 new file must be a valid JSON file.
               </DialogDescription>
             </DialogHeader>
-            <UpdateTemplateForm setDialogOpen={setOpen} callback={callback} />
+            <UpdateTemplateForm setDialogOpen={setOpen} onSuccess={onSuccess} />
           </DialogContent>
         </Dialog>
       )}

--- a/web/src/components/forms/update-project-form.tsx
+++ b/web/src/components/forms/update-project-form.tsx
@@ -16,16 +16,17 @@ const fields = [
 /**
  * UpdateProjectForm component renders a form for updating a project.
  * It provides a button to submit the form and a file input for selecting a JSON file.
+ * The onSuccess callback is called after a successful update.
  *
  * @param {React.Dispatch<React.SetStateAction<boolean>>} setDialogOpen - A function to set the dialog open state.
  * @returns {JSX.Element} The rendered UpdateProjectForm component.
  */
 export function UpdateProjectForm({
   setDialogOpen,
-  callback,
+  onSuccess,
 }: {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  callback: () => void;
+  onSuccess: () => void;
 }) {
   const {user} = useAuth();
   const {projectId} = Route.useParams();
@@ -49,11 +50,11 @@ export function UpdateProjectForm({
       }
     );
 
-    // call the callback to invalidate the project query
-    callback();
-
     if (!response.ok)
       return {type: 'submit', message: 'Error updating template'};
+
+    // call the onSuccess callback if everything worked
+    onSuccess();
 
     setDialogOpen(false);
   };

--- a/web/src/components/forms/update-template-form.tsx
+++ b/web/src/components/forms/update-template-form.tsx
@@ -15,18 +15,19 @@ export const fields = [
 
 interface UpdateTemplateFormProps {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  callback: () => void;
+  onSuccess: () => void;
 }
 
 /**
  * UpdateTemplateForm component renders a form for updating a template.
  * It provides a button to open the dialog and a form to update the template.
+ * The onSuccess callback is called after a successful update.
  *
  * @returns {JSX.Element} The rendered UpdateTemplateForm component.
  */
 export function UpdateTemplateForm({
   setDialogOpen,
-  callback,
+  onSuccess,
 }: UpdateTemplateFormProps) {
   const {user} = useAuth();
   const {templateId} = Route.useParams();
@@ -50,12 +51,11 @@ export function UpdateTemplateForm({
       }
     );
 
-    // call the callback to invalidate the project query
-    callback();
-
     if (!response.ok)
       return {type: 'submit', message: 'Error updating template'};
 
+    // call the onSuccess callback if everything worked
+    onSuccess();
     setDialogOpen(false);
   };
 

--- a/web/src/components/tabs/project/actions.tsx
+++ b/web/src/components/tabs/project/actions.tsx
@@ -231,7 +231,7 @@ const ProjectActions = (): JSX.Element => {
                 </ListDescription>
               </ListItem>
               <ListItem>
-                <EditProjectDialog callback={uploadProjectCallback} />
+                <EditProjectDialog onSuccess={uploadProjectCallback} />
               </ListItem>
             </List>
           </Card>

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -185,7 +185,7 @@ const TemplateActions = () => {
                 </ListDescription>
               </ListItem>
               <ListItem>
-                <EditTemplateDialog callback={uploadTemplateCallback} />
+                <EditTemplateDialog onSuccess={uploadTemplateCallback} />
               </ListItem>
             </List>
           </Card>


### PR DESCRIPTION
# Invalidate query after uploading a notebook or template JSON

## JIRA Ticket

None

## Description

When you upload a new JSON for a notebook or template, the notebook is replaced on the server but the app doesn't re-fetch it for a subsequent edit.

## Proposed Changes

Invalidate the project query when we upload JSON.

## How to Test

Download project JSON, make a change in the editor, re-upload the JSON, you should see the change you made reverted.

Ditto for templates.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
