### PR TITLE
Set localdb values safely

### DIFF
--- a/app/src/local-data/autoincrement.ts
+++ b/app/src/local-data/autoincrement.ts
@@ -18,7 +18,11 @@
  *   Manage autoincrementer state for a project
  */
 
-import {ProjectID, ProjectUIFields, safeWriteDocument} from '@faims3/data-model';
+import {
+  ProjectID,
+  ProjectUIFields,
+  safeWriteDocument,
+} from '@faims3/data-model';
 import {compiledSpecService} from '../context/slices/helpers/compiledSpecService';
 import {selectProjectById} from '../context/slices/projectSlice';
 import {store} from '../context/store';

--- a/app/src/local-data/field-persistent.ts
+++ b/app/src/local-data/field-persistent.ts
@@ -22,7 +22,12 @@
  *  persistent state will be updated when record been saved( to be discussed)
  */
 
-import {Annotations, FAIMSTypeName, ProjectID, safeWriteDocument} from '@faims3/data-model';
+import {
+  Annotations,
+  FAIMSTypeName,
+  ProjectID,
+  safeWriteDocument,
+} from '@faims3/data-model';
 import stable_stringify from 'fast-json-stable-stringify';
 import {databaseService} from '../context/slices/helpers/databaseService';
 import {logError} from '../logging';


### PR DESCRIPTION
# Set localdb values safely

## JIRA Ticket

None

## Description

There was a db conflct when initially creating an autoincrementer in development due to a double write of the initial state document.

## Proposed Changes

use safeWriteDocument to ensure the write doesn't fail.

## How to Test

Create a record in a form with an auto incrementer. Note the lack of error messages about document conflicts.


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
