### PR TITLE
Disable 'Finish and New'

### DIFF
--- a/app/src/gui/components/record/formButton.tsx
+++ b/app/src/gui/components/record/formButton.tsx
@@ -205,7 +205,11 @@ export default function FormButtonGroup({
               handleFormSubmit={handleFormSubmit}
               is_final_view={is_final_view}
             />
-            <FormSubmitButton
+            {/** Disabled for now because there is a bug that loses the link to the
+             * first child record when this is used
+             * TODO: re-enable when bug is fixed
+             */
+            /* <FormSubmitButton
               color="secondary"
               data-testid="finish-new-record"
               disabled={!showPublishButton}
@@ -214,7 +218,7 @@ export default function FormButtonGroup({
               action="new"
               handleFormSubmit={handleFormSubmit}
               is_final_view={is_final_view}
-            />
+            /> */}
 
             <FormSubmitButton
               color="warning"


### PR DESCRIPTION
# Disable 'Finish and New'

## Ticket

#1583 (does not fix)

## Description

When adding child records with 'Finish and New', the first added record gets lost - it is not attached to the parent. 


## Proposed Changes

I can't fix this given the current implementation of RecordForm.  This PR disables this feature pending future re-implementation.

## How to Test

Note that there is no longer a Finish and New button on the record form.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
