### PR TITLE
feat: form context

### DIFF
--- a/library/forms/lib/formModule/Field.tsx
+++ b/library/forms/lib/formModule/Field.tsx
@@ -1,10 +1,12 @@
 import React, {useMemo} from 'react';
 import {EncodedFieldSpecification, FaimsForm} from './types';
 import {getFieldInfo} from '../fieldRegistry/registry';
+import {FormContext} from './FormManager';
 
 interface FieldProps {
   fieldSpec: EncodedFieldSpecification;
   form: FaimsForm;
+  context: FormContext;
 }
 
 export const Field = React.memo((props: FieldProps) => {
@@ -37,7 +39,11 @@ export const Field = React.memo((props: FieldProps) => {
     <props.form.Field
       name={props.fieldSpec['component-parameters'].name}
       children={field => (
-        <Component {...props.fieldSpec['component-parameters']} field={field} />
+        <Component
+          {...props.fieldSpec['component-parameters']}
+          field={field}
+          context={props.context}
+        />
       )}
     />
   );

--- a/library/forms/lib/formModule/FormManager.tsx
+++ b/library/forms/lib/formModule/FormManager.tsx
@@ -1,4 +1,8 @@
-import type {EncodedNotebook} from '@faims3/data-model';
+import type {
+  DataEngine,
+  EncodedNotebook,
+  IAttachmentService,
+} from '@faims3/data-model';
 import {useForm, useStore} from '@tanstack/react-form';
 import type {ComponentProps} from 'react';
 import {FaimsForm, FaimsFormData} from './types';
@@ -22,9 +26,52 @@ const FormStateDisplay = ({form}: {form: FaimsForm}) => {
   );
 };
 
+// Base interface for common properties
+interface BaseFormContext {
+  mode: 'full' | 'preview';
+}
+
+// Full mode - has access to data engine and full powers
+export interface FullFormContext extends BaseFormContext {
+  mode: 'full';
+  // A function to generate an instance of the data engine - this is a function
+  // as instance references may change due to DBs being updated
+  dataEngine: () => DataEngine;
+  // An attachment engine for use - again a function to generate
+  attachmentEngine: () => IAttachmentService;
+  // Functions which redirect to other records
+  redirect: {
+    // Go to a record (no revision specified)
+    toRecord: (params: {recordId: string}) => void;
+    // Go to a specific record revision
+    toRevision: (params: {recordId: string; revisionId: string}) => void;
+  };
+  // Triggers for special behaviour
+  trigger: {
+    // This forces a commit of the record
+    commit: () => void;
+  };
+}
+
+// Preview mode - used for form previews which aren't in the context of a fully
+// functional app - useful for designer (for example)
+export interface PreviewFormContext extends BaseFormContext {
+  mode: 'preview';
+
+  // Currently there is no special context provided
+}
+
+// Discriminated union
+export type FormContext = FullFormContext | PreviewFormContext;
+
+export interface FormConfig {
+  context: FormContext;
+}
+
 export interface FormManagerProps extends ComponentProps<any> {
   project: EncodedNotebook;
   formName: string;
+  config: FormConfig;
 }
 
 export const FormManager = (props: FormManagerProps) => {
@@ -62,6 +109,7 @@ export const FormManager = (props: FormManagerProps) => {
             form={form}
             uiSpec={uiSpec}
             section={sectionName}
+            config={props.config}
           />
         ))}
       </form>

--- a/library/forms/lib/formModule/FormSection.tsx
+++ b/library/forms/lib/formModule/FormSection.tsx
@@ -1,15 +1,22 @@
 import {EncodedUISpecification} from '@faims3/data-model';
 import {FaimsForm} from './types';
 import {Field} from './Field';
+import {FormConfig} from './FormManager';
 
 interface FormSectionProps {
   uiSpec: EncodedUISpecification;
   section: string;
   form: FaimsForm;
+  config: FormConfig;
 }
 
 // A form section contains the fields defined for one section of a form
-export const FormSection = ({uiSpec, section, form}: FormSectionProps) => {
+export const FormSection = ({
+  uiSpec,
+  section,
+  form,
+  config,
+}: FormSectionProps) => {
   const sectionSpec = uiSpec.fviews[section];
   if (!sectionSpec) {
     throw new Error(`Section ${section} not found in UISpec`);
@@ -22,7 +29,14 @@ export const FormSection = ({uiSpec, section, form}: FormSectionProps) => {
       <h2>Section: {sectionSpec.label}</h2>
       {sectionSpec.fields.map((fieldName: string) => {
         const fieldSpec = uiSpec.fields[fieldName];
-        return <Field form={form} fieldSpec={fieldSpec} key={fieldName} />;
+        return (
+          <Field
+            form={form}
+            fieldSpec={fieldSpec}
+            key={fieldName}
+            context={config.context}
+          />
+        );
       })}
     </div>
   );

--- a/library/forms/lib/formModule/types.ts
+++ b/library/forms/lib/formModule/types.ts
@@ -1,6 +1,7 @@
 import {useForm} from '@tanstack/react-form';
 import React from 'react';
 import {z} from 'zod';
+import {FormContext} from './FormManager';
 
 export type FaimsFormData = Record<string, any>;
 
@@ -54,4 +55,5 @@ export type BaseFieldProps = z.infer<typeof BaseFieldPropsSchema>;
 // These are the additional FaimsForm props passed
 export type FormFieldContextProps = {
   field: FaimsFormField;
+  context: FormContext;
 };

--- a/library/forms/src/App.tsx
+++ b/library/forms/src/App.tsx
@@ -1,7 +1,10 @@
 import './App.css';
-import {FormManager} from '../lib';
+import {FormConfig, FormManager} from '../lib';
 
 function App(props: {project: any}) {
+  const formConfig: FormConfig = {
+    context: {mode: 'preview'},
+  };
   return (
     <>
       <h1>FAIMS3 Forms</h1>
@@ -13,7 +16,11 @@ function App(props: {project: any}) {
             borderRadius: '8px',
           }}
         >
-          <FormManager project={props.project} formName="Person" />
+          <FormManager
+            project={props.project}
+            formName="Person"
+            config={formConfig}
+          />
         </div>
       </div>
     </>


### PR DESCRIPTION
Drills down a type discriminated form context.

Mode: 'full' | 'preview' 

Full = full power!
Preview = for form previews - can still edit values etc but special stuff like attachments etc may not work. The field can use this to intelligently render different versions.