### PR TITLE
Add deleted property for revision

### DIFF
--- a/library/data-model/src/databaseEngine/engine.ts
+++ b/library/data-model/src/databaseEngine/engine.ts
@@ -817,6 +817,7 @@ class HydratedOperations {
         formId: record.type,
         heads: record.heads,
         revisions: record.revisions,
+        deleted: revision.deleted ?? false,
       },
       revision: {
         _id: revision._id,
@@ -828,6 +829,7 @@ class HydratedOperations {
         parents: revision.parents,
         recordId: revision.record_id,
         relationship: formRelationship,
+        deleted: revision.deleted ?? false,
       },
       data: mappedData,
       metadata: {

--- a/library/data-model/src/databaseEngine/types.ts
+++ b/library/data-model/src/databaseEngine/types.ts
@@ -599,6 +599,8 @@ export const hydratedRecordDocumentSchema = z.object({
   heads: z.array(z.string()),
   /** Form identifier for this document */
   formId: z.string(),
+  /** Optional deleted property, true if the latest revision of this record is 'deleted' */
+  deleted: z.boolean().optional(),
 });
 
 export type HydratedRecordDocument = z.infer<
@@ -627,6 +629,8 @@ export const hydratedRevisionDocumentSchema = z.object({
   formId: z.string(),
   /** Optional relationship information if this is a related record */
   relationship: formRelationshipSchema.optional(),
+  /** Optional deleted property, true if this revision is 'deleted' */
+  deleted: z.boolean().optional(),
 });
 
 export type HydratedRevisionDocument = z.infer<


### PR DESCRIPTION
# Add deleted property for revision

## JIRA Ticket

#1795

## Description

The 'deleted' property was not present in the schema for revision documents.

## Proposed Changes

Adds the 'deleted' property to the schema for revision documents so that they can be validated.

Adds the optional 'deleted' property to the HydratedRecord type in both the 'record' and 'revision' properties based on the deleted status of the head revision (false if not present).   

Does not yet support setting this property via the new database engine - task for a later PR.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
