### PR TITLE
feat: transparency in background of tabs and using stepperColors

### DIFF
--- a/library/forms/lib/formModule/sections/TabbedSections.tsx
+++ b/library/forms/lib/formModule/sections/TabbedSections.tsx
@@ -131,10 +131,23 @@ const getStepColor = (
   hasError: boolean,
   theme: Theme
 ): string => {
-  if (hasError) return theme.palette.error.main;
-  if (isActive) return theme.palette.primary.main;
-  if (isCompleted) return theme.palette.primary.main;
-  return theme.palette.grey[400];
+  // The theme should have these - but typing unclear
+  const themeAny = theme as {
+    stepperColors?: {
+      current?: string;
+      visited?: string;
+      error?: string;
+      notVisited?: string;
+    };
+  };
+
+  if (hasError)
+    return themeAny.stepperColors?.error ?? theme.palette.error.main;
+  if (isActive)
+    return themeAny.stepperColors?.current ?? theme.palette.primary.main;
+  if (isCompleted)
+    return themeAny.stepperColors?.visited ?? theme.palette.success.main;
+  return themeAny.stepperColors?.notVisited ?? theme.palette.grey[400];
 };
 
 /**
@@ -200,6 +213,11 @@ const StepperTab = styled(Tab)(() => ({
   alignItems: 'center',
   // Offset to align the circle center with connector line
   paddingTop: '14px',
+
+  backgroundColor: 'transparent',
+  '&.Mui-selected': {
+    backgroundColor: 'transparent',
+  },
 
   // Connector line between steps
   '&::after': {


### PR DESCRIPTION
To address #1818 uses the themes stepper colors (noting the hack on the typing for now), and applies transparency to MUI default background color on the tab - rather than changing theme colors as in #1829 . For consideration. Rest of the app looks good in both themes.