### PR TITLE
Disable interactions on map previews

### DIFF
--- a/library/forms/lib/components/maps/MapPreview.tsx
+++ b/library/forms/lib/components/maps/MapPreview.tsx
@@ -119,6 +119,7 @@ export const MapPreview: React.FC<MapPreviewProps> = props => {
         zoom: 2,
       }),
       controls: [],
+      interactions: [],
     });
 
     // Fit the view to the geometry extent if features exist


### PR DESCRIPTION

# Disable interactions on map previews

## Ticket

#1840

## Description

Currently the map preview used in the read-only form and in editable form will scroll if you touch it on mobile or use the scroll wheel on desktop, this is probably not useful and generally not what you want. 


## Proposed Changes

Disable scrolling so that we only have a fixed map shown in the preview.

## How to Test

View a notebook record with maps.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
