### PR TITLE
asterisk to be red for required fields, all themes

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
@@ -117,8 +117,9 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
             {heading}
             {required && (
               <span
-                data-testid="required-indicator"
+                data-testid="required-indicator" 
                 style={{
+                  color: theme.palette.error.main,
                   marginLeft: 2,
                   fontSize: '1.4em',
                   fontWeight: 'bold',


### PR DESCRIPTION
]

## Description

Required fields asterisk is "red" .

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
