### PR TITLE
feat: map help text, grayed out save

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
@@ -523,6 +523,7 @@ function MapWrapper(props: MapProps) {
                             geometry: point,
                           });
                           source.addFeature(feature);
+                          setHasDrawnFeatures(true);
                         }
                         // Center map on the point
                         if (mapRef.current && point) {


### PR DESCRIPTION
Adds help text for each geometry type explaining the action needed. 

Greys out the save option when the user a) had existing features and b) hasn't finished drawing a point (or selected using the new select current location).