### PR TITLE
advanced helper info icon to be blue - secondary main color of bss and default theme - blue and orange

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
@@ -117,7 +117,7 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
             {heading}
             {required && (
               <span
-                data-testid="required-indicator" 
+                data-testid="required-indicator"
                 style={{
                   color: theme.palette.error.main,
                   marginLeft: 2,
@@ -150,6 +150,7 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
                   sx={{
                     fontSize: '1.6rem',
                     strokeWidth: 0.8,
+                    color: theme.palette.secondary.main,
                   }}
                 />
               </IconButton>


### PR DESCRIPTION

Updated advanced helper text to be blue - updated theme color which was previously added for this 
Tested on both theme
blue for dass
orange for default

<img width="364" height="409" alt="image" src="https://github.com/user-attachments/assets/fe4014fd-6bfa-4b7a-8d09-fc4eb2cb9ccd" />

<img width="1097" height="481" alt="image" src="https://github.com/user-attachments/assets/bd62c98f-c05d-412c-a34f-e261e38b8246" />


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
