### PR TITLE
feat: makes hydration caching less aggressive for visible page

### DIFF
--- a/app/src/gui/components/notebook/record_table.tsx
+++ b/app/src/gui/components/notebook/record_table.tsx
@@ -1052,6 +1052,11 @@ const useRowHydration = (
       },
       networkMode: 'always',
       staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+      // Force a refresh on mount - this will help to ensure that the live page
+      // is not stale - this does not invalidate the total record list query
+      // which is more expensive in very large record lists. The old data will
+      // also be shown in the meantime.
+      refetchOnMount: 'always',
     })),
   });
 


### PR DESCRIPTION
Sets `refetchOnMount` to `always` for the hydrated records query to ensure that when a user finishes up with their edits and returns to the record list, they see the latest version. Won't prevent the 'instant load' feeling of react query caching, as old data is used unless invalidated with new data from the fetch.