### PR TITLE
Fix bad dev server in web

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,7 +23,13 @@ export default defineConfig({
     fs: {allow: ['..']},
   },
   optimizeDeps: {
-    include: [],
+    include: [
+      '@mui/material',
+      '@mui/icons-material',
+      '@emotion/react',
+      '@emotion/styled',
+      '@emotion/react/jsx-runtime',
+    ],
     exclude: [],
   },
   // Polyfill global in case of weird importing going on!


### PR DESCRIPTION
# Fix bad dev server in web

## JIRA Ticket

None

## Description

From a fresh clone of the repo, the web app threw errors about symbols not being defined.

## Proposed Changes

TanStackRouterVite used in vite.config.ts is deprecated, updating this fixes the problem.

## How to Test

Clone the repo into a fresh folder, build, run `pnpm dev` in web.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
