### PR TITLE
docs(field-types): cross-link field type names across 17 guides

### DIFF
--- a/docs/user/field-types/adding-a-field.md
+++ b/docs/user/field-types/adding-a-field.md
@@ -46,14 +46,14 @@ The tab bar organises field types into nine categories:
 | Tab | Field Types |
 | --- | ----------- |
 | **ALL** | Shows every available field type (default view) |
-| **TEXT** | FAIMS Text Field, Multi-line Text Field, Email, Templated String, QR / Barcode Scanner, Address |
-| **NUMBERS** | Number Input, Controlled Number, Auto Incrementing Field |
-| **DATE & TIME** | Date time picker, Date picker, Month picker, Date and Time with Now button |
-| **MEDIA** | Take Photo, Upload a File |
-| **LOCATION** | Take GPS Point, Map Field |
-| **CHOICE** | Select Field, Select Multiple, Checkbox, Select Field (Hierarchical), Select one option |
-| **RELATIONSHIP** | Related Records |
-| **DISPLAY** | Rich Text |
+| **TEXT** | [FAIMS Text Field](faims-text-field.md), [Multi-line Text Field](multiline-text-field.md), [Email](email-field.md), [Templated String](templated-string.md), [QR / Barcode Scanner](qr-barcode-scanner.md), [Address](address.md) |
+| **NUMBERS** | [Number Input](number-input.md), [Controlled Number](controlled-number.md), [Auto Incrementing Field](auto-incrementing-field.md) |
+| **DATE & TIME** | [Date time picker](date-time-picker.md), [Date picker](date-picker.md), [Month picker](month-picker.md), [Date and Time with Now button](date-time-now.md) |
+| **MEDIA** | [Take Photo](take-photo.md), [Upload a file](attach-file.md) |
+| **LOCATION** | [Take point](take-gps-point.md), [Map field](map-input.md) |
+| **CHOICE** | [Select Field](select.md), [Select Multiple](multi-select.md), [Checkbox](checkbox.md), [Select Field (Hierarchical)](hierarchical-select.md), [Select one option](radio-group.md) |
+| **RELATIONSHIP** | [Add Related Record](related-records.md) |
+| **DISPLAY** | [RichText](rich-text.md) |
 
 > **Note:** Not all tabs may be visible at once. If you see a **›**
 > arrow button on the right side of the tab bar, **click** it to scroll

--- a/docs/user/field-types/attach-file.md
+++ b/docs/user/field-types/attach-file.md
@@ -54,7 +54,7 @@ and Display in child records — see
 
 ## Tips
 
-- **More flexible than Take Photo but less streamlined for camera
+- **More flexible than [Take Photo](take-photo.md) but less streamlined for camera
   workflows.** Use Attach File when you need to upload documents,
   data files, or media from external sources (e.g., photos from an
   external camera). Use Take Photo when attached media will include

--- a/docs/user/field-types/auto-incrementing-field.md
+++ b/docs/user/field-types/auto-incrementing-field.md
@@ -65,7 +65,7 @@ and Display in child records — see
 - **The identifier is a padded string, not a number.** A 5-digit
   counter generates "00042", not 42. This preserves leading zeros in
   exports and avoids numeric sorting issues in spreadsheets.
-- **Wrap in a Templated String** to build meaningful composite
+- **Wrap in a [Templated String](templated-string.md)** to build meaningful composite
   identifiers — for example, "SAMPLE-00042-2026" combines the auto-
   incremented number with a prefix and year.
 - **Ranges are configured per-device in the data collector.**

--- a/docs/user/field-types/checkbox.md
+++ b/docs/user/field-types/checkbox.md
@@ -10,7 +10,7 @@ A Checkbox Field provides a toggle that stores a boolean
 value — checked (true) or unchecked (false). Use it for
 presence/absence indicators, consent acknowledgements, procedural
 confirmations, or data quality flags. Unlike other choice fields
-(e.g., Select Field, Select Multiple), a Checkbox captures a
+(e.g., [Select Field](select.md), [Select Multiple](multi-select.md)), a Checkbox captures a
 single yes/no state rather than a selection from a list.
 
 ## Adding the Field
@@ -63,7 +63,7 @@ and Display in child records — see
   to leave it unchecked (false). If you need to force a checked state (e.g.,
   for consent forms), this must be configured via JSON validation rules.
 - **For questions with more than two states** (e.g., "yes / no / unknown"),
-  use a Select Field or a 'Select one option' field instead of a Checkbox.
+  use a [Select Field](select.md) or a '[Select one option](radio-group.md)' field instead of a Checkbox.
 - **Checkbox is ideal for quick binary flags** during rapid data collection —
   presence/absence of charcoal, bioturbation observed, safety check completed.
 - **Enable Annotation and Uncertainty** if collectors might need to qualify

--- a/docs/user/field-types/controlled-number.md
+++ b/docs/user/field-types/controlled-number.md
@@ -11,7 +11,7 @@ A Controlled Number field accepts bounded numeric values, enforcing
 minimum and maximum constraints at the point of entry. Use it for
 ratings, scores, percentages, and measurements with known valid
 ranges — such as pH (0–14), condition ratings (1–5), or percentage
-cover (0–100). Unlike Number Input, it catches out-of-range entries
+cover (0–100). Unlike [Number Input](number-input.md), it catches out-of-range entries
 immediately rather than during post-processing.
 
 ## Adding the Field

--- a/docs/user/field-types/date-picker.md
+++ b/docs/user/field-types/date-picker.md
@@ -53,7 +53,7 @@ and Display in child records — see
 
 ## Tips
 
-- **Better than Date/Time with Now for historical or future dates**
+- **Better than [Date and Time with Now button](date-time-now.md) for historical or future dates**
   (e.g., "Scheduled revisit date", "Date of last disturbance") where
   the time component is meaningless. The calendar picker interface
   helps users navigate to the correct date visually.
@@ -61,6 +61,6 @@ and Display in child records — see
   (YYYY-MM-DD), there is no risk of timezone-related data corruption.
   This makes Date Picker safe for any project regardless of how many
   timezones the team spans.
-- **If you also need the time, use Date/Time with Now instead.** Do
+- **If you also need the time, use Date and Time with Now button instead.** Do
   not pair a Date Picker with a separate time field — use a single
-  Date/Time with Now field for combined date-and-time capture.
+  Date and Time with Now button field for combined date-and-time capture.

--- a/docs/user/field-types/date-time-picker.md
+++ b/docs/user/field-types/date-time-picker.md
@@ -8,15 +8,16 @@ Editor.*
 ## What This Field Does
 
 A Date Time Picker captures a date and time as a local datetime string
-without timezone information. It is functionally similar to Date/Time
-with Now but lacks timezone preservation, making timestamps ambiguous
-when teams span multiple timezones.
+without timezone information. It is functionally similar to
+[Date and Time with Now button](date-time-now.md) but lacks timezone
+preservation, making timestamps ambiguous when teams span multiple
+timezones.
 
 > **Warning:** This field is **discouraged for new {{notebooks}}.** Because
 > it stores timestamps without timezone information, the same time value
 > (e.g., "14:30") represents different times in different
-> locations. Use [Date/Time with Now](date-time-now.md) instead for
-> timezone-safe dates. Date/Time with Now accepts arbitrary dates in
+> locations. Use [Date and Time with Now button](date-time-now.md) instead for
+> timezone-safe dates. Date and Time with Now button accepts arbitrary dates in
 > addition to "now" timestamps.
 
 ## Adding the Field
@@ -60,9 +61,9 @@ and Display in child records — see
 
 ## Tips
 
-- **Use Date/Time with Now instead** unless your project operates
-  entirely within a single timezone with no device travel. Date/Time
-  with Now stores UTC timestamps that survive timezone changes and
+- **Use [Date and Time with Now button](date-time-now.md) instead** unless your project operates
+  entirely within a single timezone with no device travel. Date and Time
+  with Now button stores UTC timestamps that survive timezone changes and
   enable accurate cross-site synchronisation.
 - **If you must use this field**, add Helper Text documenting the
   assumed timezone (e.g., "All times are AEST") so the assumption is

--- a/docs/user/field-types/faims-text-field.md
+++ b/docs/user/field-types/faims-text-field.md
@@ -61,7 +61,7 @@ and Display in child records — see
   consistent data with fewer errors. Fields with pre-populated
   options are also faster to complete in the field.
 - **Best for entries under about 50 characters.** For longer text
-  (descriptions, narratives), use Multi-line Text Field instead.
+  (descriptions, narratives), use [Multi-line Text Field](multiline-text-field.md) instead.
 - **Enable Speech-to-Text** for fields where collectors may be working
   hands-free or in wet/dirty conditions.
 - **Review the Field ID before saving** — it is auto-generated from the

--- a/docs/user/field-types/field-selection-guide.md
+++ b/docs/user/field-types/field-selection-guide.md
@@ -259,8 +259,8 @@ document and media types.
   measurements when estimates suffice, or impose ranges that
   are too tight — match precision to your actual research
   needs.
-- **Ignoring platform constraints.** QR / Barcode Scanner is
-  mobile only; Map field requires an internet connection;
+- **Ignoring platform constraints.** [QR / Barcode Scanner](qr-barcode-scanner.md) is
+  mobile only; [Map field](map-input.md) requires an internet connection;
   location accuracy in the web app on desktop may be poor.
   Design for your actual deployment platform.
 - **Over-using required fields.** Marking fields as required

--- a/docs/user/field-types/field-type-index.md
+++ b/docs/user/field-types/field-type-index.md
@@ -103,7 +103,7 @@ The **DATE & TIME** tab contains field types for recording dates, times, and
 timestamps.
 
 - **[Date time picker](date-time-picker.md)** — Captures date and time
-  values. Consider **Date and Time with Now button** instead for timezone
+  values. Consider **[Date and Time with Now button](date-time-now.md)** instead for timezone
   support.
 - **[Date picker](date-picker.md)** — Date-only selection for administrative
   records, permits, and excavation dates.

--- a/docs/user/field-types/form-design-patterns.md
+++ b/docs/user/field-types/form-design-patterns.md
@@ -30,9 +30,9 @@ need to go beyond single-field recording.
 
 When recording a measurement, combine:
 
-- A **Select one option** or **[Select Field](select.md)** for the
+- A **[Select one option](radio-group.md)** or **[Select Field](select.md)** for the
   measurement type (e.g., length, width, depth).
-- A **Controlled Number** for the numeric value, with minimum and
+- A **[Controlled Number](controlled-number.md)** for the numeric value, with minimum and
   maximum bounds set to catch entry errors.
 - A unit indicator — either included in the field label (e.g.,
   "Depth (cm)") or as a separate **Select one option** field if
@@ -45,7 +45,7 @@ When recording a measurement, combine:
 When recording an identification that may be provisional, combine:
 
 - A **[Select Field](select.md)** or
-  **Select Field (Hierarchical)** for the identification (e.g.,
+  **[Select Field (Hierarchical)](hierarchical-select.md)** for the identification (e.g.,
   species, soil type, artefact class) drawn from a controlled
   vocabulary.
 - Use of "Uncertainty" if a simple "certain" vs. "uncertain"
@@ -55,7 +55,7 @@ When recording an identification that may be provisional, combine:
 - A **[Checkbox](checkbox.md)** labelled "Requires verification",
   conditionally revealed when confidence (selected through
   Select one option) is not Certain.
-- A **Multi-line Text Field** for detailed notes, conditionally
+- A **[Multi-line Text Field](multiline-text-field.md)** for detailed notes, conditionally
   revealed alongside the verification flag.
 
 ### The Complex Observation Pattern
@@ -69,7 +69,7 @@ combine:
   selection.
 - Standard metadata captured automatically by the platform (recorder,
   timestamp, location).
-- A **Take Photo** field with Annotation enabled for visual
+- A **[Take Photo](take-photo.md)** field with Annotation enabled for visual
   documentation.
 
 ### The Progressive Detail Pattern
@@ -109,7 +109,7 @@ and human-readable identifier (HRID) structures.
 Archaeological forms typically need to capture stratigraphic
 relationships, contextual inheritance, and structured identifiers:
 
-- **Stratigraphic relationships** — Use **Add Related Record** with
+- **Stratigraphic relationships** — Use **[Add Related Record](related-records.md)** with
   defined vocabulary pairs (e.g., "cuts / cut by", "fills / filled by",
   "above / below") to record temporal and physical relationships between
   contexts (temporal and physical relationships can be
@@ -126,11 +126,11 @@ relationships, contextual inheritance, and structured identifiers:
 Ecological survey forms often centre on transect-based observation and
 abundance estimation:
 
-- **Transect observations** — Use an **Auto Incrementing Field** for
-  sequential observation points, combined with **Take point** for
+- **Transect observations** — Use an **[Auto Incrementing Field](auto-incrementing-field.md)** for
+  sequential observation points, combined with **[Take point](take-gps-point.md)** for
   each location along a transect.
-- **Abundance estimation** — Use **Controlled Number** fields for
-  percentage cover or species counts, or a **Select one option** field
+- **Abundance estimation** — Use **[Controlled Number](controlled-number.md)** fields for
+  percentage cover or species counts, or a **[Select one option](radio-group.md)** field
   for categorical scales (e.g., DAFOR: Dominant, Abundant, Frequent,
   Occasional, Rare).
 - **HRID structure** — A typical ecological identifier combines
@@ -148,7 +148,7 @@ data:
 - **Orientation data** — Use grouped **Controlled Number**
   fields for strike and dip measurements or plunge and trend
   for linear features.
-- **Sample identifiers** — Use QR / Barcode Scanner to scan
+- **Sample identifiers** — Use **[QR / Barcode Scanner](qr-barcode-scanner.md)** to scan
   a sample label in the field to avoid transcription errors
   (consider implementing IGSNs).
 - **HRID structure** — A typical geological identifier combines

--- a/docs/user/field-types/hierarchical-select.md
+++ b/docs/user/field-types/hierarchical-select.md
@@ -83,7 +83,7 @@ and Display in child records — see
   geological classifications, vegetation communities. The tree
   navigation feels natural for inherently hierarchical data.
 - **Performance degrades above ~100 tree nodes.** For very large
-  taxonomies, consider splitting into cascading Select Field dropdowns
+  taxonomies, consider splitting into cascading [Select Field](select.md) dropdowns
   instead (e.g., one for material, one for technique, one for form).
 - **Once a selection is made, it cannot be cleared** — there is no
   deselect mechanism. If users might need to undo a selection,

--- a/docs/user/field-types/multiline-text-field.md
+++ b/docs/user/field-types/multiline-text-field.md
@@ -8,7 +8,7 @@
 
 A Multiline Text Field provides an extended text area for narrative
 content, detailed observations, and descriptive passages. Unlike the
-single-line FAIMS Text Field, it supports multiple lines with internal
+single-line [FAIMS Text Field](faims-text-field.md), it supports multiple lines with internal
 scrolling, making it suitable for entries that commonly exceed a
 sentence or two — such as context descriptions, condition assessments,
 and interpretative notes.

--- a/docs/user/field-types/number-input.md
+++ b/docs/user/field-types/number-input.md
@@ -69,7 +69,7 @@ and Display in child records — see
   data where missing values have different analytical implications.
 - **On iOS devices, the number keyboard lacks a minus key.** If collectors
   need to enter negative values (e.g., below-datum elevations), consider
-  using a FAIMS Text Field with format guidance instead, or instruct
+  using a [FAIMS Text Field](faims-text-field.md) with format guidance instead, or instruct
   collectors to copy-paste the minus character.
 - **Enable Annotation and Uncertainty** for measurement fields
   where collectors might need to note instrument type, recording

--- a/docs/user/field-types/qr-barcode-scanner.md
+++ b/docs/user/field-types/qr-barcode-scanner.md
@@ -16,7 +16,7 @@ equipment, storage location) to digital records via pre-printed labels.
 > **Note:** This field is **mobile only**. It is
 > non-functional on the desktop web app, where the interface is
 > disabled. If your {{notebook}} will be used on both mobile and desktop
-> platforms, pair this field with a FAIMS Text Field so desktop users
+> platforms, pair this field with a [FAIMS Text Field](faims-text-field.md) so desktop users
 > can enter the code manually.
 
 ## Adding the Field

--- a/docs/user/field-types/select.md
+++ b/docs/user/field-types/select.md
@@ -97,10 +97,10 @@ and Display in child records — see
 
 - **Choose the right selection field for your list size.** Select
   Field is ideal for lists of 8–20 options. For shorter lists
-  (2–7 items), consider 'Select one option' for more rapid entry,
+  (2–7 items), consider '[Select one option](radio-group.md)' for more rapid entry,
   at the cost of more screen real estate.
   For very long (>20 items) or intrinsically hierarchical lists,
-  consider Select Field (Hierarchical).
+  consider [Select Field (Hierarchical)](hierarchical-select.md).
 - **Include a "-- None --" option** if collectors need to clear a
   selection — there is no built-in deselect button. Without a blank option,
   once a choice is made it cannot be undone.

--- a/docs/user/field-types/take-photo.md
+++ b/docs/user/field-types/take-photo.md
@@ -55,7 +55,7 @@ and Display in child records — see
 
 ## Tips
 
-- **Preferred over Attach File for camera-first workflows.** Take Photo
+- **Preferred over [Upload a file](attach-file.md) for camera-first workflows.** Take Photo
   opens the device camera directly for immediate capture, making it
   faster when photos are the primary media type. Upload of photos
   from the device's gallery or captured using an external camera


### PR DESCRIPTION
## Description

Add first-mention-per-section cross-links across 17 field type
documentation files so readers can navigate between related guides.
Also standardises 5 variant field type names to match the canonical
Add a Field dialog card labels.

## Proposed Changes

- **Cross-links**: ~47 new inline links added across 17 files, scoped
  to the first mention of each field type per `##` section
- **Name standardisation** (5 fixes):
  - "Take GPS Point" → "Take point"
  - "Upload a File" → "Upload a file"
  - "Related Records" → "Add Related Record"
  - "Rich Text" → "RichText"
  - "Date/Time with Now" → "Date and Time with Now button"
- **Key files**: `adding-a-field.md` (24 links in tabs table),
  `form-design-patterns.md` (11 links), `date-time-picker.md`
  (3 links + 4 name fixes)

## How to Test

1. Build the docs locally with `docker compose up` from `docs/`
2. Navigate to any field type guide and verify cross-links resolve
3. Spot-check `adding-a-field.md` tabs table — every field type
   name should be a working link
4. Check `date-time-picker.md` — all "Date/Time with Now" references
   should now read "Date and Time with Now button"

## Additional Information

- Follows up on #1937 which added the field type guides
- `conditions.md` is intentionally excluded (replaced upstream)
- Link scoping rule: first mention per `##` section becomes a link;
  subsequent mentions in the same section remain plain/bold text

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.