### PR TITLE
Fix reset-password page

### DIFF
--- a/api/src/auth/authPages.ts
+++ b/api/src/auth/authPages.ts
@@ -36,7 +36,6 @@ import patch from '../utils/patchExpressAsync';
 import {validateEmailCode} from '../couchdb/emailReset';
 import {RegisteredAuthProviders} from './strategies/applyStrategies';
 import {LOCAL_LOGIN_ENABLED} from '../buildconfig';
-import {userHasLocalProfile} from '../couchdb/users';
 
 // This must occur before express app is used
 patch();
@@ -297,7 +296,6 @@ export function addAuthPages(
 
       return res.render('forgot-password', {
         postUrl: '/auth/forgotPassword',
-        hasLocalProfile: await userHasLocalProfile(req.user),
         forgotPasswordPostPayload: {
           redirect,
         },

--- a/api/views/forgot-password.handlebars
+++ b/api/views/forgot-password.handlebars
@@ -1,44 +1,36 @@
 <div class='auth-header'>
   <h2>Reset Password</h2>
-  {{#if !hasLocalProfile}}
-    <h3>You have logged into this account using an SSO provider.  Please contact
-      your administrator for assistance.
-    </h3>
-  {{else}}
   <p>Enter your email address below and we'll send you instructions to reset your password.</p>
-  {{/if}}
 </div>
 
-{{#if !hasLocalProfile}}
-  <form method='post' action='{{postUrl}}'>
-    {{#if messages.error.forgotPasswordError}}
-      <div class='alert alert-danger'>{{messages.error.forgotPasswordError.msg}}</div>
-    {{/if}}
-    
-    {{#if messages.success}}
-      <div class='alert alert-success'>{{messages.success}}</div>
-    {{/if}}
+<form method='post' action='{{postUrl}}'>
+  {{#if messages.error.forgotPasswordError}}
+    <div class='alert alert-danger'>{{messages.error.forgotPasswordError.msg}}</div>
+  {{/if}}
+  
+  {{#if messages.success}}
+    <div class='alert alert-success'>{{messages.success}}</div>
+  {{/if}}
 
-    <div class='mb-3'>
-      <label for='EmailInput' class='form-label'>Email Address</label>
-      <input
-        type='email'
-        autocomplete='email'
-        name='email'
-        class='form-control'
-        id='EmailInput'
-        value='{{messages.email}}'
-        placeholder='Enter your email address'
-        required
-      />
-      {{#if messages.error.email}}
-        <div class='alert alert-danger'>{{messages.error.email.msg}}</div>
-      {{/if}}
-    </div>
+  <div class='mb-3'>
+    <label for='EmailInput' class='form-label'>Email Address</label>
+    <input
+      type='email'
+      autocomplete='email'
+      name='email'
+      class='form-control'
+      id='EmailInput'
+      value='{{messages.email}}'
+      placeholder='Enter your email address'
+      required
+    />
+    {{#if messages.error.email}}
+      <div class='alert alert-danger'>{{messages.error.email.msg}}</div>
+    {{/if}}
+  </div>
 
-    <div class='button-container'>
-      <button type='submit' class='auth-button'>Reset Password</button>
-      <a href='/login' class='auth-button-outline'>Back to Login</a>
-    </div>
-  </form>
-{{/if}}
+  <div class='button-container'>
+    <button type='submit' class='auth-button'>Reset Password</button>
+    <a href='/login' class='auth-button-outline'>Back to Login</a>
+  </div>
+</form>


### PR DESCRIPTION
# Fix reset-password page

## Ticket

#1948

## Description

In adding the configurable local login option, the reset password page got some 
conditional logic that doesn't make sense, including a syntax error in the handlebars
markup.

Some text was conditional on the user having a local login but since we don't know the user
this could never work.

## Proposed Changes

Removes the conditionals in the reset password page.   This page will never be shown in
an SSO only configuration. For an SSO user, they can request a password reset if local
logins are allowed and it should work.

## How to Test

Visit the reset password page.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
