### PR TITLE
Don't check invites on login success

### DIFF
--- a/api/src/auth/authRoutes.ts
+++ b/api/src/auth/authRoutes.ts
@@ -277,9 +277,6 @@ export function addAuthRoutes(
           return res.render('redirect-error', {redirect});
         }
 
-        // Is there an invite present?
-        const inviteId = loginPayload.inviteId;
-
         // Login with local passport strategy - catching the on success to apply
         // invite (if present) and redirect with token back to client
         // application (at redirect URL requested)
@@ -308,18 +305,7 @@ export function addAuthRoutes(
             }
             // reset any failed login attempts
             resetFailedLoginAttempts(req.body.email);
-            // We have logged in - do we also want to consume an invite?
-            if (inviteId) {
-              // We have an invite to consume - go ahead and use it
-              await validateAndApplyInviteToUser({
-                inviteCode: inviteId,
-                dbUser: user,
-              });
-              // avoid saving unwanted details here
-              await saveExpressUser(user);
-            }
-            // Always upgrade prior to returning token to ensure we have latest!
-
+            // Always upgrade prior to returning token to ensure we have latest
             // token
             return redirectWithToken({
               res,


### PR DESCRIPTION
# Don't check invites on login success

## Ticket

#1936

## Description

Bug where invites were being checked after login success meant that login failed if there was a left over session that contained an invite.   We  should never use invites in the login route.

## Proposed Changes

Removes the check for invites in the login route. 

## How to Test

Register an account, then login again in the same browser session, all should work ok.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
