### PR TITLE
Ensure getSelectedServer returns one if configured

### DIFF
--- a/app/src/context/slices/projectSlice.ts
+++ b/app/src/context/slices/projectSlice.ts
@@ -224,12 +224,8 @@ const projectsSlice = createSlice({
           `Cannot select server with ID ${serverId} since it does not exist.`
         );
       }
+      console.log(`Selecting server with ID ${serverId}`);
       state.selectedServerId = serverId;
-    },
-
-    // Clear all servers - do this before re-initialisation
-    clearServers: state => {
-      state.servers = {};
     },
 
     /**
@@ -1518,6 +1514,9 @@ export const initialiseServers = createAsyncThunk<void>(
   'projects/initialiseServers',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async (_, {dispatch, getState}) => {
+    // cast and get state
+    const state = getState() as RootState;
+    const projectState = state.projects;
     const appDispatch = dispatch as AppDispatch;
 
     // for each URL in the conductor URLs - fetch directory
@@ -1531,27 +1530,40 @@ export const initialiseServers = createAsyncThunk<void>(
         });
     }
 
-    // clear existing servers
-    appDispatch(clearServers());
-    // Add all the discovered servers to the state
     for (const apiServerInfo of discoveredServers) {
       // pull out the server ID
       const serverId = apiServerInfo.id;
 
-      // Create
-      appDispatch(
-        addServer({
-          serverId,
-          serverTitle: apiServerInfo.name,
-          serverUrl: apiServerInfo.conductor_url,
-          shortCodePrefix: apiServerInfo.prefix,
-          // We don't know this yet - it's considered sensitive so we need
-          // authentication.
-          couchDbUrl: undefined,
-          description: apiServerInfo.description,
-          serverVersion: apiServerInfo.serverVersion,
-        })
-      );
+      // see if we already have that server
+      const existingServer = serverById(projectState, serverId);
+      if (existingServer) {
+        // Update
+        appDispatch(
+          updateServerDetails({
+            serverId,
+            serverTitle: apiServerInfo.name,
+            serverUrl: apiServerInfo.conductor_url,
+            shortCodePrefix: apiServerInfo.prefix,
+            description: apiServerInfo.description,
+            serverVersion: apiServerInfo.serverVersion,
+          })
+        );
+      } else {
+        // Create
+        appDispatch(
+          addServer({
+            serverId,
+            serverTitle: apiServerInfo.name,
+            serverUrl: apiServerInfo.conductor_url,
+            shortCodePrefix: apiServerInfo.prefix,
+            // We don't know this yet - it's considered sensitive so we need
+            // authentication.
+            couchDbUrl: undefined,
+            description: apiServerInfo.description,
+            serverVersion: apiServerInfo.serverVersion,
+          })
+        );
+      }
     }
   }
 );
@@ -2142,7 +2154,6 @@ const {
 // Public reducers
 export const {
   addProject,
-  clearServers,
   addServer,
   selectServer,
   startSyncingAttachments,


### PR DESCRIPTION
# Ensure getSelectedServer returns one if configured

## JIRA Ticket

None

## Description

Catches an edge case where the selected server has not been initialised - seen in first use of the updated app. 

Now getSelectedServer will always return a valid server if it has one configured.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
