### PR TITLE
Fix: make sure provisioning config is passed throut in cdk

### DIFF
--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -260,12 +260,7 @@ export class FaimsConductor extends Construct {
         KEY_SOURCE: 'AWS_SM',
         AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
         NEW_CONDUCTOR_URL: props.webUrl,
-
-        ...(props.provisionSSOUsersPolicy
-          ? {
-              PROVISION_SSO_USERS_POLICY: props.provisionSSOUsersPolicy,
-            }
-          : {}),
+        PROVISION_SSO_USERS_POLICY: props.config.provisionSSOUsersPolicy,
 
         // Bugsnag (optional)
         ...(props.bugsnagApiKey ? {BUGSNAG_API_KEY: props.bugsnagApiKey} : {}),

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -338,6 +338,10 @@ const ConductorConfigSchema = z.object({
   conductorDockerImageTag: z.string().default('latest'),
   /** The prefix to use for the short codes in the app */
   shortCodePrefix: z.string().default('FAIMS'),
+  /** Provision SSO users policy - do we create a new user for an unknown SSO sign-in? Default 'reject' */
+  provisionSSOUsersPolicy: z
+    .enum(['own-team', 'general-user', 'reject'])
+    .default('reject'),
   /** The number of CPU units for the Fargate task */
   cpu: z.number().int().positive(),
   /** The amount of memory (in MiB) for the Fargate task */


### PR DESCRIPTION
# Fix: make sure provisioning config is passed throut in cdk

## JIRA Ticket

None 

## Description

The configuration for PROVISION_SSO_USERS_POLICY was not making it through to the deployment because of a missing slot in the schema.
