### PR TITLE
fix: invalidate projects cache when creating survey from template

### DIFF
--- a/web/src/components/forms/create-project-from-template.tsx
+++ b/web/src/components/forms/create-project-from-template.tsx
@@ -77,7 +77,13 @@ export function CreateProjectFromTemplateForm({
     if (!response.ok)
       return {type: 'submit', message: `Error creating ${NOTEBOOK_NAME}.`};
 
-    QueryClient.invalidateQueries({queryKey: ['projects', undefined]});
+    // Invalidate projects list so template's survey list and sidebar refresh
+    await QueryClient.invalidateQueries({queryKey: ['projects']});
+    if (team) {
+      await QueryClient.invalidateQueries({
+        queryKey: ['projectsbyteam', user.token, team],
+      });
+    }
 
     setDialogOpen(false);
   };


### PR DESCRIPTION
**Issue**: Creating a survey from a template did not refresh the template’s survey list.
**Cause**: Invalidation used ['projects', undefined] while the list query uses ['projects', user?.token], so the cache was never invalidated.
**Change**: Invalidate with ['projects'] (prefix match) and, when a team is chosen, also invalidate ['projectsbyteam', user.token, team]. Await invalidation before closing the dialog.