### PR TITLE
fix: errant false string output

### DIFF
--- a/web/src/components/forms/create-project-from-template.tsx
+++ b/web/src/components/forms/create-project-from-template.tsx
@@ -41,7 +41,7 @@ export function CreateProjectFromTemplateForm({
       },
       {
         name: 'team',
-        label: `Create ${NOTEBOOK_NAME} in this team${canCreateGlobally && ' (optional)'}`,
+        label: `Create ${NOTEBOOK_NAME} in this team${canCreateGlobally ? ' (optional)' : ''}`,
         options: teams?.teams.map(({_id, name}) => ({
           label: name,
           value: _id,


### PR DESCRIPTION
**Issue**: When creating a survey based on a template, uncertain why but sometimes it shows this errant 'false' in the output html.

**Cause**: Label used canCreateGlobally && ' (optional)', which becomes the boolean false when the condition is false and was rendered as the string "false".

**Change**: Use a ternary: canCreateGlobally ? ' (optional)' : '' so the suffix is always a string (either " (optional)" or "").