### PR TITLE
feat: adds grace period for login banner

### DIFF
--- a/app/.env.dist
+++ b/app/.env.dist
@@ -35,6 +35,8 @@ VITE_HEADING_APP_NAME=Fieldmark
 VITE_TOKEN_REFRESH_INTERVAL_MS=15000
 # The allowable window for token expiry in which no actual refresh request is made
 VITE_TOKEN_REFRESH_WINDOW_MS=60000
+# Grace period (ms) after app initialisation before showing the login banner
+VITE_LOGIN_BANNER_GRACE_MS=10000
 # Set to 'true' to ignore for debugging purposes/backwards compatibility
 VITE_IGNORE_TOKEN_EXP=false
 # Set to one of 'osm', 'maptiler', ''

--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -366,6 +366,26 @@ function tokenRefreshWindowMs(): number {
   }
 }
 
+// Grace period before showing the logged-out banner after app initialisation
+const DEFAULT_LOGIN_BANNER_GRACE_MS = 10000;
+
+/**
+ * @returns The grace period in milliseconds before showing the login banner
+ * after the app has initialised.
+ */
+function loginBannerGraceMs(): number {
+  const loginBannerGraceMs = import.meta.env.VITE_LOGIN_BANNER_GRACE_MS;
+  if (loginBannerGraceMs === '' || loginBannerGraceMs === undefined) {
+    return DEFAULT_LOGIN_BANNER_GRACE_MS;
+  }
+  try {
+    return parseInt(loginBannerGraceMs);
+  } catch (err) {
+    logError(err);
+    return DEFAULT_LOGIN_BANNER_GRACE_MS;
+  }
+}
+
 // Ignore the expiry from the JWT - use 1 year expiry instead - disables token
 // refreshing - debug/compat usage only!
 const DEFAULT_IGNORE_TOKEN_EXP = false;
@@ -500,6 +520,7 @@ export const HEADING_APP_NAME = get_heading_app_name();
 export const APP_ID = get_app_id();
 export const TOKEN_REFRESH_INTERVAL_MS = tokenRefreshIntervalMs();
 export const TOKEN_REFRESH_WINDOW_MS = tokenRefreshWindowMs();
+export const LOGIN_BANNER_GRACE_MS = loginBannerGraceMs();
 export const IGNORE_TOKEN_EXP = ignoreTokenExp();
 export const OFFLINE_MAPS = offline_maps();
 export const NAVIGATION_STYLE = navigation_style();

--- a/app/src/constants/privateRouter.tsx
+++ b/app/src/constants/privateRouter.tsx
@@ -11,6 +11,7 @@ import {useEffect, useRef, useState} from 'react';
 import {Navigate, Link as RouterLink} from 'react-router-dom';
 import {useAppSelector} from '../context/store';
 import {useIsOnline} from '../utils/customHooks';
+import {LOGIN_BANNER_GRACE_MS} from '../buildconfig';
 import * as ROUTES from './routes';
 
 interface PrivateRouteProps {
@@ -243,7 +244,22 @@ export const TolerantPrivateRoute = (
   const isAuthenticated = useAppSelector(state => state.auth.isAuthenticated);
   const isToken = useAppSelector(state => !!state.auth.activeUser?.token);
   const {isOnline} = useIsOnline();
-  const bannerVisible = !isAuthenticated && isToken && isOnline;
+  const [isGracePeriodOver, setIsGracePeriodOver] = useState(false);
+
+  // Hide the login banner for a short grace period after app initialisation
+  // so that background token refreshes can complete without alarming the user.
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setIsGracePeriodOver(true);
+    }, LOGIN_BANNER_GRACE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  const bannerVisible =
+    !isAuthenticated && isToken && isOnline && isGracePeriodOver;
 
   // Good case - all good
   if (!isAuthenticated && !isToken) {


### PR DESCRIPTION
### Problem
Logged-out warning banner appears immediately on app launch/return, even while a background token refresh is succeeding, confusing users who briefly see “You are currently logged out”.

### Cause
`TolerantPrivateRoute` shows the `OfflineLoginBanner` whenever `!isAuthenticated && isToken && isOnline`, with no grace period around app initialisation or token refresh.

### Solution
Introduce a configurable login-banner grace period (`VITE_LOGIN_BANNER_GRACE_MS`) and update `TolerantPrivateRoute` to delay showing the banner until this grace period has elapsed, preventing logged-out warnings while tokens are being refreshed successfully.