### PR TITLE
added zoom to photos in read only view to be tested well in phone

### DIFF
--- a/library/forms/lib/components/PhotoLightbox.tsx
+++ b/library/forms/lib/components/PhotoLightbox.tsx
@@ -1,0 +1,80 @@
+import CloseIcon from '@mui/icons-material/Close';
+import {Box, Dialog, DialogContent, IconButton} from '@mui/material';
+import React from 'react';
+
+/**
+ * Shared full-screen lightbox for viewing a photo at full size.
+ * Used by both the TakePhoto view-only renderer and the TakePhoto edit component.
+ * Includes a floating close button (top-left) and click-outside-to-close.
+ */
+export const PhotoLightbox: React.FC<{
+  url: string;
+  onClose: () => void;
+}> = ({url, onClose}) => {
+  return (
+    <Dialog
+      open={true}
+      onClose={onClose}
+      maxWidth={false}
+      fullScreen
+      sx={{
+        '& .MuiDialog-paper': {
+          backgroundColor: 'rgba(0,0,0,0.92)',
+        },
+      }}
+    >
+      <DialogContent
+        onClick={onClose}
+        sx={{
+          p: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'auto',
+          touchAction: 'manipulation',
+          position: 'relative',
+        }}
+      >
+        <IconButton
+          aria-label="Close preview"
+          size="large"
+          onClick={e => {
+            e.stopPropagation();
+            onClose();
+          }}
+          sx={{
+            position: 'absolute',
+            top: 'max(56px, env(safe-area-inset-top, 0px) + 48px)',
+            left: 16,
+            zIndex: 1,
+            color: 'white',
+            bgcolor: 'rgba(255, 255, 255, 0.22)',
+            boxShadow: '0 4px 20px rgba(0, 0, 0, 0.25)',
+            padding: 2,
+            '& .MuiSvgIcon-root': {
+              fontSize: 32,
+            },
+            '&:hover': {
+              bgcolor: 'rgba(255, 255, 255, 0.32)',
+              boxShadow: '0 6px 24px rgba(0, 0, 0, 0.35)',
+            },
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <Box
+          component="img"
+          src={url}
+          alt="Full size preview"
+          onClick={e => e.stopPropagation()}
+          sx={{
+            maxWidth: '100%',
+            maxHeight: '100%',
+            objectFit: 'contain',
+            display: 'block',
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/library/forms/lib/fieldRegistry/fields/TakePhoto/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/TakePhoto/index.tsx
@@ -21,6 +21,7 @@ import {Buffer} from 'buffer';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {z} from 'zod';
 import {CameraPermissionIssue} from '../../../components/PermissionAlerts';
+import {PhotoLightbox} from '../../../components/PhotoLightbox';
 import {FullFormConfig} from '../../../formModule/formManagers/types';
 import {
   BaseFieldPropsSchema,
@@ -31,10 +32,10 @@ import {
   useAttachments,
   useAttachmentsResult,
 } from '../../../hooks/useAttachment';
+import {logError, logWarn} from '../../../logging';
 import {TakePhotoRender} from '../../../rendering/fields/view/specialised/TakePhoto';
 import {FieldInfo} from '../../types';
 import FieldWrapper from '../wrappers/FieldWrapper';
-import {logWarn, logError} from '../../../logging';
 
 // Reduce image size by scaling down capacitor quality
 const IMAGE_QUALITY_0_100 = 60;
@@ -374,42 +375,6 @@ const PendingPhotoItem: React.FC<{
 };
 
 /**
- * Full-screen lightbox dialog for viewing photos at full size.
- * Opens when a user clicks on a photo thumbnail.
- */
-const Lightbox: React.FC<{
-  url: string;
-  onClose: () => void;
-}> = ({url, onClose}) => {
-  return (
-    <Dialog
-      open={true}
-      onClose={onClose}
-      maxWidth="lg"
-      fullWidth
-      sx={{
-        '& .MuiDialog-paper': {
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        },
-      }}
-    >
-      <DialogContent sx={{p: 0, display: 'flex', justifyContent: 'center'}}>
-        <Box
-          component="img"
-          src={url}
-          alt="Full size preview"
-          sx={{
-            maxWidth: '100%',
-            maxHeight: '90vh',
-            objectFit: 'contain',
-          }}
-        />
-      </DialogContent>
-    </Dialog>
-  );
-};
-
-/**
  * Unified photo entry for the gallery - can be either a loaded photo or a pending one.
  */
 type GalleryPhoto =
@@ -608,7 +573,7 @@ const PhotoGallery: React.FC<{
 
       {/* Lightbox */}
       {lightboxUrl && (
-        <Lightbox url={lightboxUrl} onClose={handleLightboxClose} />
+        <PhotoLightbox url={lightboxUrl} onClose={handleLightboxClose} />
       )}
     </>
   );

--- a/library/forms/lib/rendering/fields/view/specialised/TakePhoto.tsx
+++ b/library/forms/lib/rendering/fields/view/specialised/TakePhoto.tsx
@@ -1,7 +1,7 @@
-import CloseIcon from '@mui/icons-material/Close';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
-import {Box, Dialog, DialogContent, IconButton, Paper, Typography} from '@mui/material';
+import {Box, Paper, Typography} from '@mui/material';
 import {useMemo, useState} from 'react';
+import {PhotoLightbox} from '../../../../components/PhotoLightbox';
 import {useAttachments} from '../../../../hooks/useAttachment';
 import {IMAGE_TYPES} from '../../../../utils';
 import {DataViewFieldRender} from '../../../types';
@@ -105,72 +105,7 @@ export const TakePhotoRender: DataViewFieldRender = props => {
         </Box>
       )}
       {zoomUrl && (
-        <Dialog
-          open={true}
-          onClose={() => setZoomUrl(null)}
-          maxWidth={false}
-          fullScreen
-          sx={{
-            '& .MuiDialog-paper': {
-              backgroundColor: 'rgba(0,0,0,0.92)',
-            },
-          }}
-        >
-          <DialogContent
-            onClick={() => setZoomUrl(null)}
-            sx={{
-              p: 0,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              overflow: 'auto',
-              //browser webView will handle native pinch to zoom.
-              touchAction: 'manipulation',
-              position: 'relative',
-            }}
-          >
-            <IconButton
-              aria-label="Close preview"
-              size="large"
-              onClick={e => {
-                e.stopPropagation();
-                setZoomUrl(null);
-              }}
-              sx={{
-                position: 'absolute',
-                top: 'max(56px, env(safe-area-inset-top, 0px) + 48px)',
-                left: 16,
-                zIndex: 1,
-                color: 'white',
-                bgcolor: 'rgba(255, 255, 255, 0.22)',
-                boxShadow: '0 4px 20px rgba(0, 0, 0, 0.25)',
-                padding: 2,
-                '& .MuiSvgIcon-root': {
-                  fontSize: 32,
-                },
-                '&:hover': {
-                  bgcolor: 'rgba(255, 255, 255, 0.32)',
-                  boxShadow: '0 6px 24px rgba(0, 0, 0, 0.35)',
-                },
-              }}
-            >
-              <CloseIcon />
-            </IconButton>
-            <Box
-              component="img"
-              src={zoomUrl}
-              alt="Full size preview"
-              onClick={e => e.stopPropagation()}
-              sx={{
-                // native pinch-zoom can magnify beyond the viewport
-                maxWidth: '100%',
-                maxHeight: '100%',
-                objectFit: 'contain',
-                display: 'block',
-              }}
-            />
-          </DialogContent>
-        </Dialog>
+        <PhotoLightbox url={zoomUrl} onClose={() => setZoomUrl(null)} />
       )}
     </div>
   );


### PR DESCRIPTION

## JIRA Ticket

https://jira.csiro.au/browse/BSS-1165

## Description

Added zoom to photos in read-only view 

In read-only/view mode, photos were shown as small fcstatic 300×300px thumbnails with no way to see the full image. There was no tap/click interaction at all.

Edit mode already had a working lightbox (tap photo → full screen) but the read-only renderer had none of this.
They now shw cursor zoom in

the device's native pinch to zoom works inside the lightbox to zoom in and out. This works because the app viewport does not set user-scalable=no



## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
