### PR TITLE
feat: easier addition of notebooks from home page

### DIFF
--- a/app/src/gui/components/authentication/shortCodeOnly.tsx
+++ b/app/src/gui/components/authentication/shortCodeOnly.tsx
@@ -22,13 +22,19 @@ import {replaceOrAppendRedirect} from '../../../utils/helpers';
 import {Server} from '../../../context/slices/projectSlice';
 import {QRCodeButton} from '@faims3/forms';
 
+interface QRCodeButtonOnlyProps {
+  servers: Server[];
+  /** Called when scan is initiated (e.g. to close a parent dialog) */
+  onScanStart?: () => void;
+}
+
 /**
  * Component to register a button for scanning a QR code to register
  * for a notebook
  * @param props Component properties include only `servers`
  * @returns component content
  */
-export function QRCodeButtonOnly(props: {servers: Server[]}) {
+export function QRCodeButtonOnly(props: QRCodeButtonOnlyProps) {
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const handleRegister = async (url: string) => {
@@ -63,6 +69,7 @@ export function QRCodeButtonOnly(props: {servers: Server[]}) {
     <QRCodeButton
       label={'Scan QR Code'}
       onScanResult={handleRegister}
+      onScanStart={props.onScanStart}
       buttonProps={{
         variant: 'outlined',
         fullWidth: true,

--- a/app/src/gui/components/workspace/notebooks.tsx
+++ b/app/src/gui/components/workspace/notebooks.tsx
@@ -19,7 +19,7 @@
  */
 
 import {ProjectStatus} from '@faims3/data-model';
-import {RefreshOutlined} from '@mui/icons-material';
+import {AddOutlined, RefreshOutlined} from '@mui/icons-material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Box,
@@ -40,6 +40,8 @@ import {GridColDef} from '@mui/x-data-grid';
 import {useMutation} from '@tanstack/react-query';
 import {useState} from 'react';
 import {
+  CAPACITOR_PLATFORM,
+  IS_WEB_PLATFORM,
   NOTEBOOK_LIST_TYPE,
   NOTEBOOK_NAME,
   NOTEBOOK_NAME_CAPITALIZED,
@@ -50,12 +52,17 @@ import {
   initialiseProjects,
   Project,
   selectProjectsByServerId,
+  selectServers,
 } from '../../../context/slices/projectSlice';
 import {useAppDispatch, useAppSelector} from '../../../context/store';
 import {useIsOnline} from '../../../utils/customHooks';
 import NotebookSyncSwitch from '../notebook/settings/sync_switch';
 import HeadingProjectGrid from '../ui/heading-grid';
 import Tabs from '../ui/tab-grid';
+import {
+  QRCodeButtonOnly,
+  ShortCodeOnlyComponent,
+} from '../authentication/shortCodeOnly';
 
 // Survey status naming conventions
 
@@ -218,6 +225,10 @@ export default function NoteBooks() {
   const notify = useNotification();
 
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const servers = useAppSelector(selectServers);
+  const platform = CAPACITOR_PLATFORM;
+  const allowQr = platform === 'ios' || platform === 'android';
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
 
   return (
     <Box component={Paper} elevation={0} p={2}>
@@ -228,18 +239,27 @@ export default function NoteBooks() {
         spacing={2}
         sx={{mt: 1, mb: 2}}
       >
-        <Stack direction="row" spacing={1} alignItems="center">
+        <Stack direction="row" spacing={1} alignItems="center" sx={{flex: 1}}>
           <Button
             variant="contained"
             disabled={!showRefreshButton || doRefresh.isPending}
-            fullWidth={isMobile}
-            sx={{backgroundColor: theme.palette.primary.main}}
+            sx={{backgroundColor: theme.palette.primary.main, flex: 1}}
             startIcon={<RefreshOutlined />}
             onClick={() => {
               doRefresh.mutate();
             }}
           >
-            Refresh {NOTEBOOK_NAME}s
+            Refresh
+          </Button>
+          <Button
+            variant="contained"
+            sx={{backgroundColor: theme.palette.primary.main, flex: 1}}
+            startIcon={<AddOutlined />}
+            onClick={() => {
+              setAddDialogOpen(true);
+            }}
+          >
+            Add {NOTEBOOK_NAME}
           </Button>
           {doRefresh.isPending && <CircularProgress size={24} />}
         </Stack>
@@ -280,6 +300,87 @@ export default function NoteBooks() {
           {notActivatedAdvice}
         </Typography>
       )}
+
+      {/* Custom floating overlay for "Add notebook" - not Material Dialog, so it doesn't conflict with QR scanner's overlay */}
+      <Box
+        sx={{
+          display: addDialogOpen ? 'flex' : 'none',
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: theme.zIndex.modal,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'rgba(0,0,0,0.5)',
+          p: 2,
+        }}
+        onClick={() => setAddDialogOpen(false)}
+        role="presentation"
+      >
+        <Paper
+          elevation={8}
+          sx={{
+            maxWidth: 'sm',
+            width: '100%',
+            overflow: 'hidden',
+          }}
+          onClick={e => e.stopPropagation()}
+        >
+          <Box sx={{p: 2.5, pb: 0}}>
+            <Typography variant="h4" gutterBottom>
+              Add a new {NOTEBOOK_NAME_CAPITALIZED}
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 2}}>
+              {allowQr
+                ? `Enter an access code or scan a QR code to get access to a ${NOTEBOOK_NAME}.`
+                : `Enter an access code to get access to a ${NOTEBOOK_NAME}.`}
+            </Typography>
+          </Box>
+          <Box sx={{px: 2.5, py: 2, borderTop: 1, borderColor: 'divider'}}>
+            {servers.length > 0 && (
+              <Stack spacing={3} sx={{mt: 1}}>
+                <Box>
+                  <Typography
+                    variant="subtitle1"
+                    sx={{fontWeight: 'bold', mb: 1.5}}
+                  >
+                    Enter code
+                  </Typography>
+                  <ShortCodeOnlyComponent servers={servers} />
+                </Box>
+                {allowQr && (
+                  <Box>
+                    <Typography
+                      variant="subtitle1"
+                      sx={{fontWeight: 'bold', mb: 1.5}}
+                    >
+                      Scan QR code
+                    </Typography>
+                    <QRCodeButtonOnly
+                      servers={servers}
+                      onScanStart={() => setAddDialogOpen(false)}
+                    />
+                  </Box>
+                )}
+              </Stack>
+            )}
+          </Box>
+          <Box
+            sx={{
+              px: 2.5,
+              py: 1.5,
+              borderTop: 1,
+              borderColor: 'divider',
+              display: 'flex',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <Button onClick={() => setAddDialogOpen(false)}>Close</Button>
+          </Box>
+        </Paper>
+      </Box>
 
       <Dialog
         open={infoDialogOpen}

--- a/library/forms/lib/components/qrCodes/QRCodeButton.tsx
+++ b/library/forms/lib/components/qrCodes/QRCodeButton.tsx
@@ -12,11 +12,11 @@
  * - Component now uses MUI sx styling internally (no visual change)
  */
 
-import React, {useState, useCallback} from 'react';
 import {BarcodeScanner} from '@capacitor-mlkit/barcode-scanning';
 import {Camera} from '@capacitor/camera';
 import {Capacitor} from '@capacitor/core';
 import {Box, Button, ButtonProps, Typography} from '@mui/material';
+import React, {useCallback, useState} from 'react';
 import {
   ScannerOverlay,
   hideAppBackground,
@@ -58,6 +58,8 @@ export interface QRCodeButtonProps {
   label?: string;
   /** Callback when a QR code is successfully scanned */
   onScanResult: (value: string) => void;
+  /** Called when the user initiates a scan (e.g. to close a parent dialog first) */
+  onScanStart?: () => void;
   /** Whether the button is disabled */
   disabled?: boolean;
   /**
@@ -70,6 +72,7 @@ export interface QRCodeButtonProps {
 export const QRCodeButton: React.FC<QRCodeButtonProps> = ({
   label = 'Scan QR Code',
   onScanResult,
+  onScanStart,
   disabled = false,
   buttonProps,
 }) => {
@@ -79,6 +82,9 @@ export const QRCodeButton: React.FC<QRCodeButtonProps> = ({
   const isWeb = Capacitor.getPlatform() === 'web';
 
   const startScan = useCallback(async () => {
+    // Trigger for any interested parent dialog
+    onScanStart?.();
+
     // Request camera permission
     const permissions = await Camera.requestPermissions({
       permissions: ['camera'],
@@ -122,7 +128,7 @@ export const QRCodeButton: React.FC<QRCodeButtonProps> = ({
     );
 
     await BarcodeScanner.startScan();
-  }, [onScanResult]);
+  }, [onScanResult, onScanStart]);
 
   const stopScan = useCallback(async () => {
     showAppBackground();


### PR DESCRIPTION
Adds a new feature to the homepage of the app which allows the user to add a survey or notebook name more directly than navigating through the manage page. 

Achieved through a new new button triggering a dialog which then uses the existing access code or QR code components. 

**Note** I had to implement a custom dialogue that didn't interact poorly with the overlay. Had some confusing issues in this area, so went with a simple conditional display on a floating flex layout. 

<img width="605" height="1049" alt="image" src="https://github.com/user-attachments/assets/c1044ea0-5175-4f06-a0d3-e989cba0ad0c" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/60d7be37-26b2-4823-ad9b-fe080a1b118c" />
