### PR TITLE
feat: truncate long descriptions in survey and template list tables (…

### DIFF
--- a/web/src/components/tables/projects.tsx
+++ b/web/src/components/tables/projects.tsx
@@ -4,6 +4,12 @@ import {ColumnDef} from '@tanstack/react-table';
 import {DataTableColumnHeader} from '../data-table/column-header';
 import {TeamCellComponent} from './cells/team-cell';
 import {TemplateCellComponent} from './cells/template-cell';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
 
 export const columns: ColumnDef<GetNotebookListResponse[number]>[] = [
   {
@@ -53,10 +59,34 @@ export const columns: ColumnDef<GetNotebookListResponse[number]>[] = [
       />
     ),
   },
-  {
+{
     accessorKey: 'metadata.pre_description',
     header: ({column}) => (
       <DataTableColumnHeader column={column} title="Description" />
     ),
-  },
+    cell: ({getValue}) => {
+      const description = getValue<string>();
+      if (!description) return null;
+      const maxLength = 100;
+      const isTruncated = description.length > maxLength;
+      const displayText = isTruncated
+        ? description.slice(0, maxLength) + '…'
+        : description;
+
+      if (!isTruncated) return <span>{displayText}</span>;
+
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-help">{displayText}</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">
+              <p>{description}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    },
+  }
 ];

--- a/web/src/components/tables/templates.tsx
+++ b/web/src/components/tables/templates.tsx
@@ -3,6 +3,12 @@ import {DataTableColumnHeader} from '../data-table/column-header';
 import {RoleCard} from '../ui/role-card';
 import {TeamCellComponent} from './cells/team-cell';
 import {NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
 
 export type Column = any;
 
@@ -56,5 +62,29 @@ export const columns: ColumnDef<Column>[] = [
     header: ({column}) => (
       <DataTableColumnHeader column={column} title="Description" />
     ),
+    cell: ({getValue}) => {
+      const description = getValue<string>();
+      if (!description) return null;
+      const maxLength = 100;
+      const isTruncated = description.length > maxLength;
+      const displayText = isTruncated
+        ? description.slice(0, maxLength) + '…'
+        : description;
+
+      if (!isTruncated) return <span>{displayText}</span>;
+
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-help">{displayText}</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">
+              <p>{description}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    },
   },
 ];


### PR DESCRIPTION
# feat: truncate long descriptions in survey and template list tables (#1674)

## JIRA Ticket

N/A (GitHub issue #1674)

## Description

Long descriptions in the survey and template list tables caused extremely tall table rows, making the UI difficult to use. Descriptions are now truncated to 100 characters with a tooltip showing the full text on hover.

## Proposed Changes

- Added truncation with hover tooltip to the description column in `web/src/components/tables/projects.tsx`
- Applied the same fix to `web/src/components/tables/templates.tsx`
- Uses the existing Radix Tooltip component for consistent UI

## How to Test

1. Log in to the web manager
2. Create a project with a description longer than 100 characters
3. The description column should show truncated text with an ellipsis
4. Hovering over the truncated text shows the full description in a tooltip

## Additional Information

Closes #1674

**Before fix:**

<img width="1579" height="1020" alt="499139322-998ea36a-bd23-486c-b77a-f01e03531e36 (1)" src="https://github.com/user-attachments/assets/20c5f706-513e-49ea-aa9b-9d8cad41cf61" />

**After fix — truncated with tooltip on hover:**
<img width="1889" height="780" alt="Screenshot 2026-03-23 180427" src="https://github.com/user-attachments/assets/7f321b9d-5891-4d97-a399-c2e720fa51f9" />


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.