### PR TITLE
Feat: allow Operations Admin to change own team role

### DIFF
--- a/api/src/api/teams.ts
+++ b/api/src/api/teams.ts
@@ -283,8 +283,9 @@ api.post(
       );
     }
 
-    // Cannot modify your own roles as protection
-    if (targetUser.user_id === req.user.user_id) {
+    // Cannot modify your own roles as protection unless you have specific permission
+    if (targetUser.user_id === req.user.user_id && 
+        !userCanDo({user: req.user, action: Action.CHANGE_OWN_ROLE_IN_TEAM, resourceId: teamId})) {
       throw new Exceptions.ForbiddenException(
         'You cannot change your own role within a team.'
       );

--- a/docs/user/admin/user-roles-and-permissions-guide.md
+++ b/docs/user/admin/user-roles-and-permissions-guide.md
@@ -99,6 +99,7 @@ The **Operations Administrator** role handles routine system management without 
 - View all system users and their roles
 - Add or remove system roles
 - Create new teams
+- Assign a role for yourself in a team
 - Assign Team Administrator roles
 
 **Cannot do (by design):**
@@ -113,7 +114,7 @@ The **Operations Administrator** role handles routine system management without 
 During onboarding, enterprise users are typically assigned:
 
 - **Content Creator** system role — they can create {{notebooks}} and templates
-- **Team Administrator** of their assigned team — they have full control over their team
+- **Team Administrator** of their assigned team — they have full control over their team (but they can't change their own role in the team)
 
 These roles are granted through invites created by an Operations Administrator or Super User (see "How Users Are Created" below). Once onboarded, a typical user can immediately:
 

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -141,6 +141,7 @@ export enum Action {
   UPDATE_TEAM_DETAILS = 'UPDATE_TEAM_DETAILS',
   VIEW_TEAM_DETAILS = 'VIEW_TEAM_DETAILS',
   VIEW_TEAM_MEMBERS = 'VIEW_TEAM_MEMBERS',
+  CHANGE_OWN_ROLE_IN_TEAM = 'CHANGE_OWN_ROLE_IN_TEAM',
 
   // Direct management
   ADD_ADMIN_TO_TEAM = 'ADD_ADMIN_TO_TEAM',
@@ -538,7 +539,12 @@ export const actionDetails: Record<Action, ActionDetails> = {
     resourceSpecific: true,
     resource: Resource.TEAM,
   },
-
+  [Action.CHANGE_OWN_ROLE_IN_TEAM]: {
+    name: 'Change own role in team',
+    description: 'Change your own role within a team',
+    resourceSpecific: true,
+    resource: Resource.TEAM,
+  },
   [Action.ADD_ADMIN_TO_TEAM]: {
     name: 'Add Admin to Team',
     description: 'Grant a user administrator privileges for a specific team',
@@ -1148,6 +1154,10 @@ export const roleActions: Record<
       Action.REMOVE_MANAGER_FROM_TEAM,
       Action.ADD_MEMBER_TO_TEAM,
       Action.REMOVE_MEMBER_FROM_TEAM,
+      // Only operations admin can change their own role
+      // to allow for bootstrapping of teams when there are no team admins
+      // eg. create a team, add yourself as admin
+      Action.CHANGE_OWN_ROLE_IN_TEAM,
 
       // These are special permissions!
       Action.ADD_ADMIN_TO_TEAM,

--- a/web/src/components/forms/teams/add-user-to-team-form.tsx
+++ b/web/src/components/forms/teams/add-user-to-team-form.tsx
@@ -87,12 +87,14 @@ export function AddUserToTeamForm({
       user,
     });
 
-    if (!response.ok)
+    if (!response.ok) {
+      const responseBody = await response.json();
+      const message = responseBody.error.message || 'Error adding user to team';
       return {
         type: 'submit',
-        message:
-          'Error adding user to team! Are you sure the email is correct?',
+        message,
       };
+    }
 
     QueryClient.invalidateQueries({queryKey: ['teamusers', teamId]});
 


### PR DESCRIPTION
# Feat: allow Operations Admin to change own team role

## Ticket

#2003

## Description

We had a bootstrapping issue with a new server where we wanted to create a team and add ourselves as team admin. This is currently disallowed. 


## Proposed Changes

Introduces a new action CHANGE_OWN_ROLE_IN_TEAM which allows 
a user to change thier own role in the API POST /:id/members endpoint. 

Assign this action to the Operations Admin user only.

## How to Test

Login as operations admin user, create a new team and add yourself to that team.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
