### PR TITLE
Fix: remove publishButtonBehaviour setting

### DIFF
--- a/library/data-model/src/data_storage/migrations/notebookMigrations/test-notebook-V1.ts
+++ b/library/data-model/src/data_storage/migrations/notebookMigrations/test-notebook-V1.ts
@@ -327,7 +327,6 @@ export const sampleNotebook: NotebookV1 = {
       Primary: {
         label: 'Observation',
         views: ['Primary-Next-Section', 'Primary-New-Section'],
-        publishButtonBehaviour: 'always',
       },
     },
     visible_types: ['Primary'],

--- a/library/data-model/src/types.ts
+++ b/library/data-model/src/types.ts
@@ -452,7 +452,6 @@ export interface ProjectUIViewset {
   hridField?: string;
   // Layout option
   layout?: 'inline' | 'tabs';
-  publishButtonBehaviour?: 'always' | 'visited' | 'noErrors';
 }
 
 export interface ProjectUIViewsets {

--- a/library/data-model/tests/engineTestUiSpec.json
+++ b/library/data-model/tests/engineTestUiSpec.json
@@ -274,13 +274,11 @@
     "viewsets": {
       "A": {
         "label": "A",
-        "views": ["A-A", "A-B"],
-        "publishButtonBehaviour": "always"
+        "views": ["A-A", "A-B"]
       },
       "B": {
         "label": "B",
-        "views": ["B-A", "B-B"],
-        "publishButtonBehaviour": "always"
+        "views": ["B-A", "B-B"]
       }
     },
     "visible_types": ["A", "B"]

--- a/library/forms/src/sample-notebook.json
+++ b/library/forms/src/sample-notebook.json
@@ -583,13 +583,11 @@
       "Person": {
         "label": "Person",
         "views": ["Person-Main", "Person-Detail", "Person-New-Section"],
-        "publishButtonBehaviour": "always",
         "hridField": "hridPerson-Main"
       },
       "School": {
         "label": "School",
-        "views": ["School-New-Section", "School-Location"],
-        "publishButtonBehaviour": "always"
+        "views": ["School-New-Section", "School-Location"]
       }
     },
     "visible_types": ["Person", "School"]

--- a/web/src/designer/components/form-settings.tsx
+++ b/web/src/designer/components/form-settings.tsx
@@ -28,7 +28,6 @@ import DebouncedTextField from './debounced-text-field';
 import {
   viewSetHridUpdated,
   viewSetLayoutUpdated,
-  viewSetPublishButtonBehaviourUpdated,
   viewSetSummaryFieldsUpdated,
 } from '../store/slices/uiSpec';
 
@@ -38,7 +37,6 @@ type ViewSetType = {
   summary_fields?: string[];
   layout?: 'inline' | 'tabs';
   hridField?: string;
-  publishButtonBehaviour?: 'always' | 'visited' | 'noErrors';
 };
 
 /**
@@ -91,33 +89,6 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
     state => state.notebook['ui-specification'].present.fviews
   );
   const [expanded, setExpanded] = React.useState(false);
-
-  const [selectedPublishBehaviour, setSelectedPublishBehaviour] =
-    React.useState<'always' | 'visited' | 'noErrors'>('always');
-
-  // Ensure selected value persists and is updated in the Redux store
-  React.useEffect(() => {
-    if (viewSet?.publishButtonBehaviour) {
-      setSelectedPublishBehaviour(viewSet.publishButtonBehaviour);
-    }
-  }, [viewSet?.publishButtonBehaviour]);
-
-  /**
-   * Updates the Finish Button Behavior setting in Redux and persists it
-   */
-  const handlePublishButtonBehaviourChange = (
-    event: SelectChangeEvent<'always' | 'visited' | 'noErrors'>
-  ) => {
-    const newValue = event.target.value as 'always' | 'visited' | 'noErrors';
-    setSelectedPublishBehaviour(newValue);
-
-    dispatch(
-      viewSetPublishButtonBehaviourUpdated({
-        viewSetId,
-        publishButtonBehaviour: newValue,
-      })
-    );
-  };
 
   /**
    * Collects all fields that belong to any view in the current viewset
@@ -233,26 +204,6 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
 
       <Collapse in={expanded}>
         <CardContent>
-          {/* Finish Button Behavior*/}
-          <SettingSection
-            title="Finish Button Behavior"
-            description="Configure when the Finish and Close buttons should be shown."
-          >
-            <Select
-              fullWidth
-              value={selectedPublishBehaviour}
-              onChange={handlePublishButtonBehaviourChange}
-            >
-              <MenuItem value="always">Always Show</MenuItem>
-              <MenuItem value="visited">
-                Show Once All Sections Visited
-              </MenuItem>
-              <MenuItem value="noErrors">
-                Show Only When No Errors Exist
-              </MenuItem>
-            </Select>
-          </SettingSection>
-
           {/* Layout Style section  */}
           <SettingSection
             title="Layout Style"

--- a/web/src/designer/state/initial.ts
+++ b/web/src/designer/state/initial.ts
@@ -153,7 +153,6 @@ export type NotebookUISpec = {
       summary_fields?: string[];
       layout?: 'inline' | 'tabs';
       hridField?: string;
-      publishButtonBehaviour: 'always' | 'visited' | 'noErrors';
     };
   };
   visible_types: string[];

--- a/web/src/designer/store/slices/uiSpec/index.ts
+++ b/web/src/designer/store/slices/uiSpec/index.ts
@@ -64,7 +64,6 @@ export const {
   viewSetMoved,
   viewSetRenamed,
   formVisibilityUpdated,
-  viewSetPublishButtonBehaviourUpdated,
   viewSetLayoutUpdated,
   viewSetSummaryFieldsUpdated,
   viewSetHridUpdated,

--- a/web/src/designer/store/slices/uiSpec/uiSpec-reducer.test.ts
+++ b/web/src/designer/store/slices/uiSpec/uiSpec-reducer.test.ts
@@ -175,7 +175,7 @@ describe('uiSpecificationReducer', () => {
     expect(deleted.viewsets.formB.views).toEqual(['sectionB']);
   });
 
-  it('updates viewset visibility and presentation settings', () => {
+  it('updates viewset visibility and display settings', () => {
     const initial = createBaseUiSpec();
 
     const summaryUpdated = uiSpecificationReducer.reducer(
@@ -196,25 +196,28 @@ describe('uiSpecificationReducer', () => {
     );
     expect(layoutUpdated.viewsets.formA.layout).toBe('tabs');
 
-    const hidden = uiSpecificationReducer.reducer(
-      publishUpdated,
-      formVisibilityUpdated({
-        viewSetId: 'formA',
-        ticked: false,
-        initialIndex: 0,
-      })
-    );
-    expect(hidden.visible_types).toEqual(['formB']);
+    expect(layoutUpdated.visible_types).toEqual(['formA', 'formB']);
 
     const shown = uiSpecificationReducer.reducer(
-      hidden,
+      layoutUpdated,
       formVisibilityUpdated({
         viewSetId: 'formA',
         ticked: true,
         initialIndex: 0,
       })
     );
-    expect(shown.visible_types).toEqual(['formB', 'formA']);
+    expect(shown.visible_types).toEqual(['formA', 'formB']);
+
+    const hidden = uiSpecificationReducer.reducer(
+      layoutUpdated,
+      formVisibilityUpdated({
+        viewSetId: 'formB',
+        ticked: false,
+        initialIndex: 0,
+      })
+    );
+    expect(hidden.visible_types).toEqual(['formA']);
+
   });
 
   it('deletes viewset with its sections and fields', () => {

--- a/web/src/designer/store/slices/uiSpec/uiSpec-reducer.test.ts
+++ b/web/src/designer/store/slices/uiSpec/uiSpec-reducer.test.ts
@@ -18,7 +18,6 @@ import {
   viewSetDeleted,
   viewSetHridUpdated,
   viewSetLayoutUpdated,
-  viewSetPublishButtonBehaviourUpdated,
   viewSetSummaryFieldsUpdated,
 } from '.';
 
@@ -38,13 +37,11 @@ const createBaseUiSpec = (): NotebookUISpec => ({
     formA: {
       label: 'Form A',
       views: ['sectionA'],
-      publishButtonBehaviour: 'always',
       summary_fields: [],
     },
     formB: {
       label: 'Form B',
       views: ['sectionB'],
-      publishButtonBehaviour: 'always',
     },
   },
   visible_types: ['formA', 'formB'],
@@ -198,17 +195,6 @@ describe('uiSpecificationReducer', () => {
       viewSetLayoutUpdated({viewSetId: 'formA', layout: 'tabs'})
     );
     expect(layoutUpdated.viewsets.formA.layout).toBe('tabs');
-
-    const publishUpdated = uiSpecificationReducer.reducer(
-      layoutUpdated,
-      viewSetPublishButtonBehaviourUpdated({
-        viewSetId: 'formA',
-        publishButtonBehaviour: 'noErrors',
-      })
-    );
-    expect(publishUpdated.viewsets.formA.publishButtonBehaviour).toBe(
-      'noErrors'
-    );
 
     const hidden = uiSpecificationReducer.reducer(
       publishUpdated,

--- a/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
+++ b/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
@@ -148,7 +148,8 @@ export const viewSetReducers = {
         visibleType => visibleType !== viewSetId
       );
       state.visible_types = newVisibleTypes;
-    } else {
+    } else if (!state.visible_types.includes(viewSetId)) {
+      // insert if not already present
       state.visible_types.splice(state.visible_types.length, 0, viewSetId);
     }
   },

--- a/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
+++ b/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
@@ -27,7 +27,6 @@ export const viewSetReducers = {
     const newViewSet = {
       label: formName,
       views: [],
-      publishButtonBehaviour: 'always' as 'always' | 'visited' | 'noErrors',
     };
     const formID = slugify(formName);
     if (formID in state.viewsets) {
@@ -151,19 +150,6 @@ export const viewSetReducers = {
       state.visible_types = newVisibleTypes;
     } else {
       state.visible_types.splice(state.visible_types.length, 0, viewSetId);
-    }
-  },
-  /** When the publish/save button is shown in the field app for this form. */
-  viewSetPublishButtonBehaviourUpdated: (
-    state: NotebookUISpec,
-    action: PayloadAction<{
-      viewSetId: string;
-      publishButtonBehaviour: 'always' | 'visited' | 'noErrors';
-    }>
-  ) => {
-    const {viewSetId, publishButtonBehaviour} = action.payload;
-    if (viewSetId in state.viewsets) {
-      state.viewsets[viewSetId].publishButtonBehaviour = publishButtonBehaviour;
     }
   },
 };

--- a/web/src/designer/store/undoConfig.ts
+++ b/web/src/designer/store/undoConfig.ts
@@ -47,7 +47,6 @@ export const UNDOABLE_UI_SPEC_ACTIONS = [
   'ui-specification/viewSetRenamed',
   'ui-specification/viewSetMoved',
   'ui-specification/formVisibilityUpdated',
-  'ui-specification/viewSetPublishButtonBehaviourUpdated',
   'ui-specification/viewSetLayoutUpdated',
   'ui-specification/viewSetSummaryFieldsUpdated',
   'ui-specification/viewSetHridUpdated',

--- a/web/src/designer/test-notebook.ts
+++ b/web/src/designer/test-notebook.ts
@@ -331,7 +331,6 @@ export const sampleNotebook: Notebook = {
       Primary: {
         label: 'Observation',
         views: ['Primary-Next-Section', 'Primary-New-Section'],
-        publishButtonBehaviour: 'always',
       },
     },
     visible_types: ['Primary'],


### PR DESCRIPTION
# Fix: remove publishButtonBehaviour setting

## Ticket

#1940

## Description

We no longer use the publishButtonBehaviour setting but it is included in the designer.

## Proposed Changes

Removes all mention of this setting and tests that include it.

Fixes a minor bug in the uiSpec reducer that was adding duplicates to visible_types.


## How to Test

Nothing should have changed except that this setting is no longer shown in the designer form settings tab.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
