### PR TITLE
Fix: Add fieldmark theme option to aws-cdk

### DIFF
--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -316,7 +316,7 @@ Note that this validation is at a schema level, it might not catch improperly fo
   - `retentionDays`: The number of days to retain backups (default: 30)
   - `scheduleExpression`: The cron schedule for running backups (default: daily at 3 AM)
 - `uiConfiguration`: UI and app build-time settings for the main FAIMS frontend.
-  - `uiTheme`: The UI theme: `bubble`, `default`, or `bssTheme`
+  - `uiTheme`: The UI theme: `bubble`, `default`, `fieldmark` or `bssTheme`
   - `notebookListType`: Notebook list display mode: `tabs` or `headings`
   - `notebookName`: Display name for notebooks, e.g. `survey` or `notebook`
   - `appName`: App name used in app store and headings (e.g. "FAIMS Mobile")

--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -36,7 +36,7 @@ export interface FaimsFrontEndProps {
   faimsDomainNames: Array<string>;
 
   // customisation
-  uiTheme: 'bubble' | 'default' | 'bssTheme';
+  uiTheme: 'bubble' | 'default' | 'bssTheme' | 'fieldmark';
   notebookListType: 'tabs' | 'headings';
   notebookName: string;
   // App display name

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -465,7 +465,7 @@ const AppSupportLinksSchema = z.object({
 export const UiConfiguration = z
   .object({
     /** The UI Theme for the app */
-    uiTheme: z.enum(['bubble', 'default', 'bssTheme']),
+    uiTheme: z.enum(['bubble', 'default', 'bssTheme', 'fieldmark']),
     /** The notebook list type for the app */
     notebookListType: z.enum(['tabs', 'headings']),
     /** The display name for notebooks e.g. survey, notebook */


### PR DESCRIPTION
# Fix: Add fieldmark theme option to aws-cdk

## JIRA Ticket

None

## Description

The new theme 'fieldmark' was not an option for AWS deployment.  This adds that option.


