### PR TITLE
Fix: configuration for 'web' title in AWS deployment

### DIFF
--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -158,7 +158,9 @@
     "androidAppPublicUrl": "https://play.google.com/store/apps/details?id=your.android.app.id",
     "iosAppPublicUrl": "https://apps.apple.com/app/your-ios-app-id"
   },
-  "web": {},
+  "web": {
+    "title": "Control Centre"
+  },
   "docs": {},
   "smtp": {
     "emailServiceType": "SMTP",

--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -66,7 +66,7 @@ export interface FaimsFrontEndProps {
   // docs config (Sphinx user docs site)
   docsDomainName: string;
   /** Management website title for docs variable substitution (default: Control Centre) */
-  docsManagementWebsiteTitle?: string;
+  managementWebsiteTitle?: string;
   /** Mobile app store URLs for docs variable substitution */
   androidAppPublicUrl: string;
   iosAppPublicUrl: string;
@@ -418,7 +418,7 @@ export class FaimsFrontEnd extends Construct {
       VITE_APP_URL: this.faimsAppUrl,
       VITE_NOTEBOOK_NAME: props.notebookName,
       VITE_THEME: props.uiTheme,
-      VITE_WEBSITE_TITLE: 'Control Centre',
+      VITE_WEBSITE_TITLE: props.managementWebsiteTitle ?? 'Control Centre',
       VITE_DOCS_URL: props.docsUrl || '',
       // Maps setup for web
       VITE_MAP_SOURCE: props.offlineMaps.mapSource,
@@ -557,7 +557,7 @@ export class FaimsFrontEnd extends Construct {
     const docsEnv: {[key: string]: string} = {
       VITE_APP_NAME: props.appName,
       VITE_NOTEBOOK_NAME: props.notebookName,
-      VITE_WEBSITE_TITLE: props.docsManagementWebsiteTitle ?? 'Control Centre',
+      VITE_WEBSITE_TITLE: props.managementWebsiteTitle ?? 'Control Centre',
       // Uses default for now, as other themes are not implemented properly
       VITE_THEME: 'default',
       VITE_API_URL: props.conductorUrl,

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -418,7 +418,9 @@ const ConductorConfigSchema = z.object({
   localhostWhitelist: z.boolean().default(false),
 });
 
-const WebConfigSchema = z.object({});
+const WebConfigSchema = z.object({
+  title: z.string().default('Control Centre'),
+});
 
 /** Documentation site (Sphinx user docs) configuration */
 const DocsConfigSchema = z.object({});

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -169,7 +169,7 @@ export class FaimsInfraStack extends cdk.Stack {
       headingAppName: config.uiConfiguration.headingAppName,
       webDomainName: domains.web,
       docsDomainName: domains.docs,
-      docsManagementWebsiteTitle: 'Control Centre',
+      managementWebsiteTitle: config.web.title,
       androidAppPublicUrl: config.mobileApps.androidAppPublicUrl,
       iosAppPublicUrl: config.mobileApps.iosAppPublicUrl,
       offlineMaps: config.uiConfiguration.offlineMaps,


### PR DESCRIPTION
# Fix: configuration for 'web' title in AWS deployment

## Ticket

#2036

## Description

The title for the web application was hard-coded to 'Control Centre' in the AWS deployment.

## Proposed Changes

Adds 'title' config option for the web component, defaults to Control Centre.  Uses this to set VITE_WEBSITE_TITLE for both the web and docs configuration environments. 

## How to Test

Deploy with a configured setting for this variable.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
