### PR TITLE
feat: configurable AuthnRequest binding

### DIFF
--- a/api/.env.dist
+++ b/api/.env.dist
@@ -110,6 +110,10 @@ AUTH_SAML_IDP_PUBLIC_KEY=abcd1234
 # Sign the SAML metadata document? Requires private key
 AUTH_SAML_SIGN_METADATA=true
 
+# How the SP sends the AuthnRequest to the IdP (passport-saml authnRequestBinding):
+# HTTP-Redirect (default) or HTTP-POST (auto-submit HTML form to IdP)
+# AUTH_SAML_AUTHN_REQUEST_BINDING="HTTP-POST"
+
 # Optional SAML settings
 AUTH_SAML_SIGNATURE_ALGORITHM="sha256"
 AUTH_SAML_WANT_ASSERTIONS_SIGNED="true"

--- a/api/src/auth/strategies/samlStrategy.ts
+++ b/api/src/auth/strategies/samlStrategy.ts
@@ -154,6 +154,7 @@ export const samlStrategyGenerator = (
         options.callbackURL ||
         CONDUCTOR_PUBLIC_URL + providerAuthReturnUrl(options.id),
       path: options.path,
+      authnRequestBinding: options.authnRequestBinding,
       // SP signing/decryption keys
       privateKey: options.privateKey,
       decryptionPvk: options.enableDecryptionPvk

--- a/api/src/auth/strategies/strategyTypes.ts
+++ b/api/src/auth/strategies/strategyTypes.ts
@@ -84,6 +84,15 @@ export const SAMLAuthProviderConfigSchema = BaseAuthProviderConfigSchema.extend(
     callbackURL: z.string().optional(),
     /** Callback path if callbackURL not specified (default: /saml/callback) */
     path: z.string().optional(),
+    /**
+     * How the SP sends the AuthnRequest to the IdP (passport-saml `authnRequestBinding`).
+     * `HTTP-Redirect` (default): 302 to IdP with SAMLRequest query param.
+     * `HTTP-POST`: HTML form auto-post to IdP (POST binding for outbound auth request).
+     */
+    authnRequestBinding: z
+      .enum(['HTTP-Redirect', 'HTTP-POST'])
+      .optional()
+      .default('HTTP-POST'),
     /** Sign the metadata document with PK? */
     signMetadata: z
       .string()

--- a/api/src/auth/strategies/strategyTypes.ts
+++ b/api/src/auth/strategies/strategyTypes.ts
@@ -86,8 +86,8 @@ export const SAMLAuthProviderConfigSchema = BaseAuthProviderConfigSchema.extend(
     path: z.string().optional(),
     /**
      * How the SP sends the AuthnRequest to the IdP (passport-saml `authnRequestBinding`).
-     * `HTTP-Redirect` (default): 302 to IdP with SAMLRequest query param.
-     * `HTTP-POST`: HTML form auto-post to IdP (POST binding for outbound auth request).
+     * `HTTP-POST` (default): HTML form auto-post to IdP (POST binding for outbound auth request).
+     * `HTTP-Redirect`: 302 to IdP with SAMLRequest query param.
      */
     authnRequestBinding: z
       .enum(['HTTP-Redirect', 'HTTP-POST'])

--- a/api/test/authConfig.test.ts
+++ b/api/test/authConfig.test.ts
@@ -208,6 +208,23 @@ describe('readAuthProviderConfigFromEnv', () => {
       'https://conductor.example/auth/vg/sso-error'
     );
     expect(vg.ssoErrorPageReturnURL).to.equal('https://web.example/');
+    expect(vg.authnRequestBinding).to.equal('HTTP-Redirect');
+  });
+
+  it('parses SAML authnRequestBinding HTTP-POST from env', () => {
+    process.env.AUTH_VG_TYPE = 'saml';
+    process.env.AUTH_VG_DISPLAY_NAME = 'Vanguard';
+    process.env.AUTH_VG_SCOPE = 'profile,email';
+    process.env.AUTH_VG_ENTRY_POINT = 'https://idp.example/sso';
+    process.env.AUTH_VG_ISSUER = 'https://sp.example/';
+    process.env.AUTH_VG_IDP_PUBLIC_KEY = 'MIIB';
+    process.env.AUTH_VG_AUTHN_REQUEST_BINDING = 'HTTP-POST';
+
+    const result = readAuthProviderConfigFromEnv();
+
+    expect(result).to.not.be.null;
+    const vg = result?.vg as SAMLAuthProviderConfig;
+    expect(vg.authnRequestBinding).to.equal('HTTP-POST');
   });
 
   it('should return null and log errors when validation fails', () => {

--- a/docs/developer/docs/source/markdown/DeployingAWSStack.md
+++ b/docs/developer/docs/source/markdown/DeployingAWSStack.md
@@ -559,6 +559,8 @@ schema documentation available in `SAMLAuthProviderConfigSchema` in the CDK conf
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
 | `signMetadata`                 | Sign the metadata endpoint document using the provided privateKey? 'true' or 'false'. Default false.                     |
 | `callbackURL`                  | Full callback URL for SAML responses. If not specified, the system generates one automatically.                          |
+| `callbackMethods`              | HTTP methods for the ACS callback route: `GET`, `POST`, or both as `["GET","POST"]` in JSON (CDK) / comma-separated env (default in CDK: POST). |
+| `authnRequestBinding`          | Outbound sign-in request: `HTTP-Redirect` (default, 302 + query) or `HTTP-POST` (auto-submit form to IdP; passport-saml `authnRequestBinding`). |
 | `metadataErrorURL`             | Optional absolute URL for SPSSODescriptor `errorURL` in SAML metadata (default: Conductor `/auth/{provider}/sso-error`). |
 | `ssoErrorPageReturnURL`        | Primary button URL on the per-provider SSO error page (default: web app public URL).                                     |
 | `disableRequestedAuthnContext` | Set to `true` for ADFS compatibility                                                                                     |

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -142,6 +142,7 @@
         "scope": "profile email",
         "entryPoint": "https://idp.example.com/saml2/sso",
         "issuer": "https://faims.example.com",
+        "authnRequestBinding": "HTTP-POST",
         "callbackURL": "https://faims.example.com/auth/saml/callback",
         "signatureAlgorithm": "sha256",
         "wantAssertionsSigned": true

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -142,6 +142,13 @@ const SAMLAuthProviderConfigSchema = BaseAuthProviderConfigSchema.extend({
     .optional()
     .default('/saml/callback')
     .describe('Callback path if callbackURL not specified'),
+  authnRequestBinding: z
+    .enum(['HTTP-Redirect', 'HTTP-POST'])
+    .optional()
+    .default('HTTP-POST')
+    .describe(
+      'Outbound AuthnRequest binding for passport-saml: HTTP-POST (default) or HTTP-Redirect'
+    ),
   // If you want the metadata document signed using your PK
   signMetadata: z.boolean().optional().default(false),
   // IdP certificate for verifying signatures (can also be in secrets)


### PR DESCRIPTION
Adds passport-saml authnRequestBinding (HTTP-Redirect | HTTP-POST) to the SAML strategy, API Zod/env parsing, and CDK SAMLAuthProviderConfigSchema; documents env/CDK usage and extends auth config tests.