### PR TITLE
feat: avoid sending full template payload in list endpoints

### DIFF
--- a/api/api_testing/templates.http
+++ b/api/api_testing/templates.http
@@ -2,11 +2,11 @@
 @notebooksBaseUrl = {{$dotenv BASE_URL}}/api/notebooks
 @token = {{$dotenv API_TOKEN}}
 
-### List templates
+### List templates (summaries only — no ui-specification; use Get by ID for full JSON)
 GET {{templateBaseUrl}}
 Authorization: Bearer {{token}}
 
-### Get by ID
+### Get by ID (full template including ui-specification)
 # @prompt templateId
 
 GET {{templateBaseUrl}}/{{templateId}}

--- a/api/public/swagger.json
+++ b/api/public/swagger.json
@@ -1128,7 +1128,7 @@
     "/templates/": {
       "get": {
         "summary": "Get a list of templates",
-        "description": "Lists templates the caller may see. By default only non-archived templates are returned. Pass `includeArchived=true` to list archived templates (still subject to `READ_TEMPLATE_DETAILS`). Optional `teamId` scopes to a team.",
+        "description": "Lists template summaries (metadata only; no `ui-specification` form payload). Use GET `/api/templates/{id}` for full detail. By default only non-archived templates are returned. Pass `includeArchived=true` to list archived templates (still subject to `READ_TEMPLATE_DETAILS`). Optional `teamId` scopes to a team.",
         "tags": ["Templates"],
         "produces": ["application/json"],
         "security": [
@@ -2342,10 +2342,31 @@
         "templates": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/TemplateDocument"
+            "$ref": "#/definitions/TemplateListItem"
           }
         }
       }
+    },
+    "TemplateListItem": {
+      "type": "object",
+      "description": "Template summary for GET /api/templates (excludes ui-specification).",
+      "properties": {
+        "_id": {"type": "string"},
+        "_rev": {"type": "string"},
+        "name": {"type": "string"},
+        "version": {"type": "number"},
+        "archived": {"type": "boolean"},
+        "ownedByTeamId": {"type": "string"},
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "project_lead": {},
+            "pre_description": {"type": "string"},
+            "template_id": {"type": "string"}
+          }
+        }
+      },
+      "required": ["_id", "_rev", "name", "version", "archived"]
     },
     "GetTemplateByIdResponse": {
       "$ref": "#/definitions/TemplateDocument"

--- a/api/src/api/templates.ts
+++ b/api/src/api/templates.ts
@@ -61,10 +61,10 @@ patch();
 export const api: express.Router = express.Router();
 
 /**
- * GET list templates Gets a list of templates from the templates DB.
+ * GET list templates — lightweight summaries from a CouchDB view (no
+ * ui-specification). Use GET /api/templates/:id for full detail.
  *
- * Can filter by team if desired -  uses an efficient index to do so.
- *
+ * Can filter by team; uses an index that omits the form payload.
  */
 api.get(
   '/',

--- a/api/src/couchdb/templates.ts
+++ b/api/src/couchdb/templates.ts
@@ -12,7 +12,10 @@ import {
   slugify,
   TemplateDBFields,
   TemplateDocument,
+  TemplateListItem,
   TEMPLATES_BY_TEAM_ID,
+  TEMPLATES_LISTING_BY_TEAM_ID,
+  TEMPLATES_LISTING_BY_TEMPLATE_ID,
 } from '@faims3/data-model';
 import {getTemplatesDb} from '.';
 import * as Exceptions from '../exceptions';
@@ -22,38 +25,34 @@ import {getTeamById} from './teams';
 import {stripTemplateRolesForTemplateId} from './users';
 
 /**
- * Lists all documents in the templates DB. Returns as TemplateDbDocument. TODO
- * validate with Zod.
- * @returns an array of template objects
+ * Lists templates using CouchDB views whose map `value` is the template doc
+ * without `ui-specification`. Uses `include_docs: false` on purpose: with
+ * `include_docs: true`, CouchDB would also attach the full stored document for
+ * each row (including `ui-specification`), which would defeat the lean list.
+ *
+ * @returns an array of template list items (from each row's `value`)
  */
 export const getTemplates = async ({
   teamId,
 }: {
   teamId?: string;
-}): Promise<ExistingTemplateDocument[]> => {
+}): Promise<TemplateListItem[]> => {
   const templatesDb = getTemplatesDb();
   try {
-    let resultList;
-    if (teamId) {
-      resultList = await templatesDb.query<TemplateDBFields>(
-        TEMPLATES_BY_TEAM_ID,
-        {
+    const resultList = teamId
+      ? await templatesDb.query<TemplateListItem>(TEMPLATES_LISTING_BY_TEAM_ID, {
           key: teamId,
-          include_docs: true,
-        }
-      );
-    } else {
-      resultList = await templatesDb.allDocs({
-        include_docs: true,
-      });
-    }
+          include_docs: false,
+        })
+      : await templatesDb.query<TemplateListItem>(
+          TEMPLATES_LISTING_BY_TEMPLATE_ID,
+          {
+            include_docs: false,
+          }
+        );
     return resultList.rows
-      .filter(document => {
-        return !!document.doc && !document.id.startsWith('_');
-      })
-      .map(document => {
-        return document.doc!;
-      });
+      .filter(row => row.value != null && row.id && !row.id.startsWith('_'))
+      .map(row => row.value!);
   } catch (error) {
     throw new Exceptions.InternalSystemError(
       'An error occurred while reading templates from the Template DB.'

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -248,6 +248,25 @@ describe('template API tests', () => {
   //======= TEMPLATES ===========
   //=============================
 
+  it('GET list returns summaries without ui-specification; GET by id includes full payload', async () => {
+    const {template, notebook: nb} = await createSampleTemplate(app, {
+      name: 'list-vs-detail',
+    });
+    const listed = await listTemplates(app);
+    const summary = listed.templates.find(t => t._id === template._id);
+    expect(summary).to.be.ok;
+    expect(summary!).to.not.have.property('ui-specification');
+
+    const detail = await getATemplate(app, template._id);
+    expect(detail['ui-specification']).to.be.ok;
+    expect(JSON.stringify(detail['ui-specification'])).to.equal(
+      JSON.stringify(nb['ui-specification'])
+    );
+
+    await setTemplateArchived(app, template._id, true);
+    await deleteATemplate(app, template._id);
+  });
+
   it('excludes archived templates by default; includeArchived lists archived only', async () => {
     const {template: activeTpl} = await createSampleTemplate(app, {
       name: 'active-template',
@@ -332,39 +351,21 @@ describe('template API tests', () => {
     const {template, notebook: nb} = await createSampleTemplate(app, {name});
     const templateId1 = template._id;
 
-    // list and see the new template
+    // list and see the new template (summaries only — no ui-specification)
     await listTemplates(app).then(templateList => {
-      // Check that the list exists and has one entry
       expect(templateList.templates.length).to.equal(1);
 
-      // Get the first entry and check ID matches as well as spec etc
       const entry = templateList.templates[0];
 
-      // Check all properties match
       expect(entry._id).to.equal(templateId1);
       expect(entry.name).to.equal(name);
-
-      // TODO This is no longer true because the metadata is injected with the template ID, see BSS-343
-      // expect(JSON.stringify(entry['ui-specification'])).to.equal(
-      //   JSON.stringify(nb['ui-specification'])
-      // );
-      // expect(JSON.stringify(entry.metadata)).to.equal(
-      //   JSON.stringify(nb.metadata)
-      // );
-
-      // Instead - let's remove the template_id from the result and then check equality
-      // TODO BSS-343
-      delete entry.metadata.template_id;
-
-      expect(JSON.stringify(entry['ui-specification'])).to.equal(
-        JSON.stringify(nb['ui-specification'])
-      );
+      expect(entry).to.not.have.property('ui-specification');
 
       // should be version 1
       expect(entry.version).to.equal(1);
     });
 
-    // get the specific new template
+    // get the specific new template (full document including ui-specification)
     await getATemplate(app, templateId1).then(template => {
       // Check all properties match
       expect(template._id).to.equal(templateId1);
@@ -380,24 +381,15 @@ describe('template API tests', () => {
     const {template: template2} = await createSampleTemplate(app, {});
     const templateId2 = template2._id;
 
-    // list and see the new template
     await listTemplates(app).then(templateList => {
-      // Check that the list exists and has correct length
       expect(templateList.templates.length).to.equal(2);
 
-      // Get the new entry
       const entry = templateList.templates.find(t => t._id === templateId2);
       expect(entry).to.not.be.undefined;
-
-      // Check all properties match
       expect(entry?._id).to.equal(templateId2);
       if (entry) {
-        expect(JSON.stringify(entry['ui-specification'])).to.equal(
-          JSON.stringify(nb['ui-specification'])
-        );
+        expect(entry).to.not.have.property('ui-specification');
       }
-
-      // should be version 1
       expect(entry?.version).to.equal(1);
     });
 

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -252,11 +252,13 @@ describe('template API tests', () => {
     const {template, notebook: nb} = await createSampleTemplate(app, {
       name: 'list-vs-detail',
     });
+    // List: each row is a template summary (no ui-specification in the JSON body)
     const listed = await listTemplates(app);
     const summary = listed.templates.find(t => t._id === template._id);
     expect(summary).to.be.ok;
     expect(summary!).to.not.have.property('ui-specification');
 
+    // Detail: single-template GET must still return the full document for edit/create flows
     const detail = await getATemplate(app, template._id);
     expect(detail['ui-specification']).to.be.ok;
     expect(JSON.stringify(detail['ui-specification'])).to.equal(
@@ -351,21 +353,38 @@ describe('template API tests', () => {
     const {template, notebook: nb} = await createSampleTemplate(app, {name});
     const templateId1 = template._id;
 
-    // list and see the new template (summaries only — no ui-specification)
+    // list and see the new template
     await listTemplates(app).then(templateList => {
+      // Check that the list exists and has one entry
       expect(templateList.templates.length).to.equal(1);
 
+      // Get the first entry and check ID matches as well as summary fields
       const entry = templateList.templates[0];
 
+      // Check all properties match
       expect(entry._id).to.equal(templateId1);
       expect(entry.name).to.equal(name);
+
+      // List endpoint returns summaries only (no ui-specification field).
       expect(entry).to.not.have.property('ui-specification');
+
+      // TODO This is no longer true because the metadata is injected with the template ID, see BSS-343
+      // expect(JSON.stringify(entry['ui-specification'])).to.equal(
+      //   JSON.stringify(nb['ui-specification'])
+      // );
+      // expect(JSON.stringify(entry.metadata)).to.equal(
+      //   JSON.stringify(nb.metadata)
+      // );
+
+      // Instead - let's remove the template_id from the result and then check equality
+      // TODO BSS-343
+      // delete entry.metadata.template_id;
 
       // should be version 1
       expect(entry.version).to.equal(1);
     });
 
-    // get the specific new template (full document including ui-specification)
+    // get the specific new template
     await getATemplate(app, templateId1).then(template => {
       // Check all properties match
       expect(template._id).to.equal(templateId1);
@@ -381,15 +400,23 @@ describe('template API tests', () => {
     const {template: template2} = await createSampleTemplate(app, {});
     const templateId2 = template2._id;
 
+    // list and see the new template
     await listTemplates(app).then(templateList => {
+      // Check that the list exists and has correct length
       expect(templateList.templates.length).to.equal(2);
 
+      // Get the new entry
       const entry = templateList.templates.find(t => t._id === templateId2);
       expect(entry).to.not.be.undefined;
+
+      // Check all properties match
       expect(entry?._id).to.equal(templateId2);
       if (entry) {
+        // Same as above: list entries are summaries without ui-specification
         expect(entry).to.not.have.property('ui-specification');
       }
+
+      // should be version 1
       expect(entry?.version).to.equal(1);
     });
 

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -10,6 +10,7 @@ import {PeopleDBDocumentSchema, ProjectStatus} from './data_storage';
 import {
   ExistingTemplateDocumentSchema,
   TemplateDBFieldsSchema,
+  TemplateListItemSchema,
 } from './data_storage/templatesDB/types';
 import {Resource, Role, roleDetails, RoleScope} from './permission/model';
 import {EncodedUISpecificationSchema} from './types';
@@ -458,9 +459,9 @@ export type PutUpdateTemplateResponse = z.infer<
   typeof PutUpdateTemplateResponseSchema
 >;
 
-// GET list all templates response
+// GET list all templates response (summaries only; no ui-specification)
 export const GetListTemplatesResponseSchema = z.object({
-  templates: z.array(ExistingTemplateDocumentSchema),
+  templates: z.array(TemplateListItemSchema),
 });
 export type GetListTemplatesResponse = z.infer<
   typeof GetListTemplatesResponseSchema

--- a/library/data-model/src/data_storage/templatesDB/design.ts
+++ b/library/data-model/src/data_storage/templatesDB/design.ts
@@ -5,8 +5,14 @@ import {convertToCouchDBString} from '../utils';
 // Index constants
 const INDEX_DOCUMENT_NAME = 'index';
 const TEMPLATES_BY_TEAM_ID_POSTFIX = 'byTeamId';
+const TEMPLATES_LISTING_BY_TEMPLATE_ID_POSTFIX = 'listingByTemplateId';
+const TEMPLATES_LISTING_BY_TEAM_ID_POSTFIX = 'listingByTeam';
 
 export const TEMPLATES_BY_TEAM_ID = `${INDEX_DOCUMENT_NAME}/${TEMPLATES_BY_TEAM_ID_POSTFIX}`;
+/** View value: template list metadata only (no ui-specification / form payload). */
+export const TEMPLATES_LISTING_BY_TEMPLATE_ID = `${INDEX_DOCUMENT_NAME}/${TEMPLATES_LISTING_BY_TEMPLATE_ID_POSTFIX}`;
+/** Same list shape as {@link TEMPLATES_LISTING_BY_TEMPLATE_ID}, keyed by ownedByTeamId. */
+export const TEMPLATES_LISTING_BY_TEAM_ID = `${INDEX_DOCUMENT_NAME}/${TEMPLATES_LISTING_BY_TEAM_ID_POSTFIX}`;
 
 /**
  * Design document for indexing by key fields
@@ -23,6 +29,35 @@ const indexDocument = {
         ) {
           emit(doc.ownedByTeamId, 1);
         }
+      }),
+    },
+    [TEMPLATES_LISTING_BY_TEMPLATE_ID_POSTFIX]: {
+      map: convertToCouchDBString(doc => {
+        if (!doc) {
+          return;
+        }
+        if (!doc._id || doc._id[0] === '_') {
+          return;
+        }
+        var row = {...doc};
+        delete row['ui-specification'];
+        emit(doc._id, row);
+      }),
+    },
+    [TEMPLATES_LISTING_BY_TEAM_ID_POSTFIX]: {
+      map: convertToCouchDBString(doc => {
+        if (!doc) {
+          return;
+        }
+        if (!doc._id || doc._id[0] === '_') {
+          return;
+        }
+        if (!doc.ownedByTeamId) {
+          return;
+        }
+        var row = {...doc};
+        delete row['ui-specification'];
+        emit(doc.ownedByTeamId, row);
       }),
     },
   },

--- a/library/data-model/src/data_storage/templatesDB/types.ts
+++ b/library/data-model/src/data_storage/templatesDB/types.ts
@@ -51,5 +51,11 @@ export type ExistingTemplateDocument = z.infer<
   typeof ExistingTemplateDocumentSchema
 >;
 
+/** Stored template shape without the form payload (matches listing view value). */
+export const TemplateListItemSchema = ExistingTemplateDocumentSchema.omit({
+  'ui-specification': true,
+});
+export type TemplateListItem = z.infer<typeof TemplateListItemSchema>;
+
 // Database
 export type TemplateDB = DatabaseInterface<TemplateDBFields>;

--- a/web/src/components/forms/create-project-form.tsx
+++ b/web/src/components/forms/create-project-form.tsx
@@ -3,7 +3,7 @@ import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
 import {useAuth} from '@/context/auth-provider';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {useGetTeams, useGetTemplates} from '@/hooks/queries';
-import {Action, GetTemplateByIdResponse} from '@faims3/data-model';
+import {Action, TemplateListItem} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
 import {Divider} from '../ui/word-divider';
@@ -54,7 +54,7 @@ export function CreateProjectForm({
     {
       name: 'template',
       label: `Existing ${NOTEBOOK_NAME_CAPITALIZED} Template (optional)`,
-      options: templates?.map(({_id, name}: GetTemplateByIdResponse) => ({
+      options: templates?.map(({_id, name}: TemplateListItem) => ({
         label: name,
         value: _id,
       })),

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -311,7 +311,7 @@ export const useGetTemplates = ({
     queryFn: async () => {
       const qs = includeArchived ? '?includeArchived=true' : '';
       const data = await get<GetListTemplatesResponse>(
-        `/api/templates/${qs}`,
+        `/api/templates${qs}`,
         user
       );
       return data.templates;


### PR DESCRIPTION
Splits up the template listing endpoints into summary vs details (just omitting the very large payload JSONs). 

This makes all list views much faster. 

Omits right from the DB view level with new design docs so that we aren't just server side filtering. 

We are observing slow list load times in production DASS due to a large number of detailed survey JSON pulls (85k lines of JSON each). 

NOTE: requires DB schema update through the `pnpm run migrate` command targeting deployment. Is breaking change for /web until migrated.