### PR TITLE
feat:  sort web notebook list newest first

### DIFF
--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -1,5 +1,6 @@
 import {buildRegisterUrl} from '@/constants';
 import {User} from '@/context/auth-provider';
+import {sortNotebookListNewestFirst} from '@/lib/utils';
 import type {
   GetCurrentUserResponse,
   GetListAllUsersResponse,
@@ -139,6 +140,7 @@ export const useGetProjects = ({
           : '/api/notebooks/',
         user
       ),
+    select: sortNotebookListNewestFirst,
     enabled: !!user && enabled,
   });
 
@@ -202,6 +204,7 @@ export const useGetProjectsForTeam = ({
     queryKey: ['projectsbyteam', user?.token, teamId],
     queryFn: () =>
       get<GetNotebookListResponse>(`/api/notebooks?teamId=${teamId}`, user),
+    select: sortNotebookListNewestFirst,
   });
 
 /**

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import type {GetNotebookListResponse} from '@faims3/data-model';
 import {clsx, type ClassValue} from 'clsx';
 import {twMerge} from 'tailwind-merge';
 import {z} from 'zod';
@@ -137,3 +138,30 @@ export const getDaysDifference = (date: Date): number => {
   const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
   return diffDays;
 };
+
+function notebookCreatedMs(row: GetNotebookListResponse[number]): number {
+  if (row.created) {
+    const t = Date.parse(row.created);
+    if (!Number.isNaN(t)) {
+      return t;
+    }
+  }
+  const head = row.project_id.split('-')[0] ?? '';
+  const n = parseInt(head, 10);
+  if (!Number.isNaN(n) && String(n) === head) {
+    return n;
+  }
+  return 0;
+}
+
+/**
+ * Returns a new array of notebook list rows sorted newest first (by `created`
+ * when present, else the millisecond prefix of standard `project_id` values).
+ */
+export function sortNotebookListNewestFirst(
+  notebooks: GetNotebookListResponse
+): GetNotebookListResponse {
+  return [...notebooks].sort(
+    (a, b) => notebookCreatedMs(b) - notebookCreatedMs(a)
+  );
+}


### PR DESCRIPTION
Notebook list queries now return rows sorted by creation time (using created when present, otherwise the timestamp prefix of project_id). Sorting lives in `web/src/lib/utils.ts` as `sortNotebookListNewestFirst`, applied via React Query select on `useGetProjects` and `useGetProjectsForTeam`.