### PR TITLE
feat: public templates and visibility controls

### DIFF
--- a/api/public/swagger.json
+++ b/api/public/swagger.json
@@ -1128,7 +1128,7 @@
     "/templates/": {
       "get": {
         "summary": "Get a list of templates",
-        "description": "Lists templates the caller may see. By default only non-archived templates are returned. Pass `includeArchived=true` to list archived templates (still subject to `READ_TEMPLATE_DETAILS`). Optional `teamId` scopes to a team.",
+        "description": "Lists templates the caller may see. By default only non-archived templates are returned. Pass `includeArchived=true` to list archived templates (still subject to `READ_TEMPLATE_DETAILS`). Optional `teamId` scopes to a team. Each item may include `ownedByTeamDisplayName` when the template has `ownedByTeamId` and the server can resolve the team — so clients can show the owning team name without calling the teams API (e.g. for public catalogue templates).",
         "tags": ["Templates"],
         "produces": ["application/json"],
         "security": [
@@ -1215,7 +1215,7 @@
     "/templates/{id}": {
       "get": {
         "summary": "Get a specific template",
-        "description": "Gets a specific template by ID from the templates DB.",
+        "description": "Gets a specific template by ID from the templates DB. The response may include `ownedByTeamDisplayName` when the template has `ownedByTeamId` and the server can resolve the team (same behaviour as the list endpoint).",
         "tags": ["Templates"],
         "parameters": [
           {
@@ -1295,6 +1295,59 @@
           },
           "401": {
             "$ref": "#/components/responses/UnauthorizedError"
+          }
+        }
+      }
+    },
+    "/templates/{id}/set-visibility": {
+      "put": {
+        "summary": "Set template public catalogue visibility",
+        "description": "Sets whether the template is listed in the public catalogue (`isPublic`). Does not change other template fields. Requires `CHANGE_TEMPLATE_VISIBILITY` (operations or system administrators). Returns the updated template document.",
+        "tags": ["Templates"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Template id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "produces": ["application/json"],
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "requestBody": {
+          "description": "Public visibility flag",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/definitions/PutTemplateSetVisibilityInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/definitions/PutUpdateTemplateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "description": "Not allowed"
           }
         }
       }
@@ -1992,7 +2045,7 @@
       "required": ["count"]
     },
     "PostRestoreTemplateResponse": {
-      "$ref": "#/definitions/TemplateDocument"
+      "$ref": "#/definitions/TemplateStoredDocument"
     },
     "Notebook": {
       "type": "object",
@@ -2338,6 +2391,7 @@
     },
     "GetListTemplatesResponse": {
       "type": "object",
+      "description": "Template list items match the stored document plus optional `ownedByTeamDisplayName` from the server.",
       "properties": {
         "templates": {
           "type": "array",
@@ -2371,7 +2425,7 @@
       "required": ["name", "metadata", "ui_specification"]
     },
     "PostCreateTemplateResponse": {
-      "$ref": "#/definitions/TemplateDocument"
+      "$ref": "#/definitions/TemplateStoredDocument"
     },
     "PutUpdateTemplateInput": {
       "type": "object",
@@ -2393,15 +2447,47 @@
       "required": []
     },
     "PutUpdateTemplateResponse": {
-      "$ref": "#/definitions/TemplateDocument"
+      "$ref": "#/definitions/TemplateStoredDocument"
     },
-    "TemplateDocument": {
+    "PutTemplateSetVisibilityInput": {
+      "type": "object",
+      "properties": {
+        "isPublic": {
+          "type": "boolean",
+          "description": "When true, the template is included in the public catalogue for users with permission to read public template details."
+        }
+      },
+      "required": ["isPublic"]
+    },
+    "TemplateApiResponseExtensions": {
+      "type": "object",
+      "description": "Optional fields returned only by GET /templates and GET /templates/{id}. Not persisted on the template document and not returned by POST/PUT restore responses.",
+      "properties": {
+        "ownedByTeamDisplayName": {
+          "type": "string",
+          "description": "Display name of the owning team (`name` from the teams DB), injected when `ownedByTeamId` is set and the team record exists."
+        }
+      }
+    },
+    "TemplateStoredDocument": {
+      "description": "Template as stored in CouchDB (create/update/restore responses).",
       "allOf": [
         {
           "$ref": "#/definitions/TemplateDetails"
         },
         {
           "$ref": "#/definitions/CouchDocumentFields"
+        }
+      ]
+    },
+    "TemplateDocument": {
+      "description": "Stored template plus optional GET-only fields (e.g. team display name).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TemplateStoredDocument"
+        },
+        {
+          "$ref": "#/definitions/TemplateApiResponseExtensions"
         }
       ]
     },

--- a/api/public/swagger.json
+++ b/api/public/swagger.json
@@ -1176,7 +1176,7 @@
       },
       "post": {
         "summary": "Create a new template",
-        "description": "Creates a new template. The payload is validated before processing. Requires appropriate permissions.",
+        "description": "Creates a new template. The payload is validated before processing. Requires `CREATE_TEMPLATE` or `CREATE_TEMPLATE_IN_TEAM` as appropriate. Setting `isPublic` to true additionally requires `CREATE_PUBLIC_TEMPLATE` (operations or system administrators), same grant as `CHANGE_TEMPLATE_VISIBILITY`.",
         "tags": ["Templates"],
         "produces": ["application/json"],
         "security": [

--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -52,6 +52,7 @@ import {
   Role,
   slugify,
   isPeopleUserAccountDisabled,
+  userCanReadTemplateDocument,
   userHasProjectRole,
 } from '@faims3/data-model';
 import {stripDeletedRelatedRefsFromRecordData} from '../couchdb/export/stripDeletedRelatedRefs';
@@ -475,6 +476,20 @@ api.post(
     if (isFromTemplate(req.body)) {
       // Now we use the template to get details needed to instantiate a new notebook
       const template = await getTemplate(req.body.template_id);
+
+      if (
+        !userCanReadTemplateDocument({
+          decodedToken: {
+            globalRoles: req.user.globalRoles,
+            resourceRoles: req.user.resourceRoles,
+          },
+          template,
+        })
+      ) {
+        throw new Exceptions.UnauthorizedException(
+          'You are not authorized to use this template.'
+        );
+      }
 
       if (template.archived === true) {
         throw new Exceptions.InvalidRequestException(

--- a/api/src/api/templates.ts
+++ b/api/src/api/templates.ts
@@ -28,9 +28,11 @@ import {
   PostCreateTemplateInputSchema,
   PostCreateTemplateResponse,
   PostRestoreTemplateResponse,
+  PutTemplateSetVisibilityInputSchema,
   PutUpdateTemplateInputSchema,
   PutUpdateTemplateResponse,
   Role,
+  userCanReadTemplateDocument,
 } from '@faims3/data-model';
 import express, {Response} from 'express';
 import {z} from 'zod';
@@ -43,13 +45,15 @@ import {
   getTemplate,
   getTemplates,
   restoreTemplateFromArchive,
+  setTemplateVisibility,
   updateExistingTemplate,
+  withOwnedByTeamDisplayName,
+  withOwnedByTeamDisplayNames,
 } from '../couchdb/templates';
 import * as Exceptions from '../exceptions';
 import {
   isAllowedToMiddleware,
   requireAuthenticationAPI,
-  userCanDo,
 } from '../middleware';
 
 import {saveExpressUser} from '../couchdb/users';
@@ -92,15 +96,50 @@ api.get(
       return includeArchived ? archived : !archived;
     });
 
+    const visible = filteredByArchive.filter(t =>
+      userCanReadTemplateDocument({
+        decodedToken: {
+          globalRoles: req.user!.globalRoles,
+          resourceRoles: req.user!.resourceRoles,
+        },
+        template: t,
+      })
+    );
     res.json({
-      templates: filteredByArchive.filter(t =>
-        userCanDo({
-          action: Action.READ_TEMPLATE_DETAILS,
-          user: req.user!,
-          resourceId: t._id,
-        })
-      ),
+      templates: await withOwnedByTeamDisplayNames(visible),
     });
+  }
+);
+
+/**
+ * GET count of surveys (projects) that still reference this template id.
+ */
+api.get(
+  '/:id/references',
+  requireAuthenticationAPI,
+  processRequest({
+    params: z.object({id: z.string()}),
+  }),
+  async (req, res: Response<GetTemplateSurveyReferencesResponse>) => {
+    if (!req.user) {
+      throw new Exceptions.UnauthorizedException();
+    }
+    const template = await getTemplate(req.params.id);
+    if (
+      !userCanReadTemplateDocument({
+        decodedToken: {
+          globalRoles: req.user.globalRoles,
+          resourceRoles: req.user.resourceRoles,
+        },
+        template,
+      })
+    ) {
+      throw new Exceptions.UnauthorizedException(
+        'You are not authorized to perform this action.'
+      );
+    }
+    const ids = await getProjectIdsReferencingTemplate(req.params.id);
+    res.json({count: ids.length});
   }
 );
 
@@ -111,39 +150,28 @@ api.get(
 api.get(
   '/:id',
   requireAuthenticationAPI,
-  isAllowedToMiddleware({
-    action: Action.READ_TEMPLATE_DETAILS,
-    getResourceId(req) {
-      return req.params.id;
-    },
-  }),
   processRequest({
     params: z.object({id: z.string()}),
   }),
   async (req, res: Response<GetTemplateByIdResponse>) => {
+    if (!req.user) {
+      throw new Exceptions.UnauthorizedException();
+    }
     const template = await getTemplate(req.params.id);
-    res.json(template);
-  }
-);
-
-/**
- * GET count of surveys (projects) that still reference this template id.
- */
-api.get(
-  '/:id/references',
-  requireAuthenticationAPI,
-  isAllowedToMiddleware({
-    action: Action.READ_TEMPLATE_DETAILS,
-    getResourceId(req) {
-      return req.params.id;
-    },
-  }),
-  processRequest({
-    params: z.object({id: z.string()}),
-  }),
-  async (req, res: Response<GetTemplateSurveyReferencesResponse>) => {
-    const ids = await getProjectIdsReferencingTemplate(req.params.id);
-    res.json({count: ids.length});
+    if (
+      !userCanReadTemplateDocument({
+        decodedToken: {
+          globalRoles: req.user.globalRoles,
+          resourceRoles: req.user.resourceRoles,
+        },
+        template,
+      })
+    ) {
+      throw new Exceptions.UnauthorizedException(
+        'You are not authorized to perform this action.'
+      );
+    }
+    res.json(await withOwnedByTeamDisplayName(template));
   }
 );
 
@@ -200,6 +228,28 @@ api.post(
     await saveExpressUser(req.user);
 
     res.json(newTemplate);
+  }
+);
+
+/**
+ * PUT set public/private visibility only.
+ */
+api.put(
+  '/:id/set-visibility',
+  requireAuthenticationAPI,
+  isAllowedToMiddleware({
+    action: Action.CHANGE_TEMPLATE_VISIBILITY,
+    getResourceId(req) {
+      return req.params.id;
+    },
+  }),
+  processRequest({
+    params: z.object({id: z.string()}),
+    body: PutTemplateSetVisibilityInputSchema,
+  }),
+  async (req, res: Response<PutUpdateTemplateResponse>) => {
+    const updated = await setTemplateVisibility(req.params.id, req.body.isPublic);
+    res.json(updated);
   }
 );
 

--- a/api/src/api/templates.ts
+++ b/api/src/api/templates.ts
@@ -24,6 +24,7 @@ import {
   GetListTemplatesResponse,
   GetTemplateByIdResponse,
   GetTemplateSurveyReferencesResponse,
+  isAuthorized,
   PostCreateTemplateInput,
   PostCreateTemplateInputSchema,
   PostCreateTemplateResponse,
@@ -214,9 +215,25 @@ api.post(
       throw new Exceptions.UnauthorizedException();
     }
 
+    const body = req.body as PostCreateTemplateInput;
+    if (
+      body.isPublic === true &&
+      !isAuthorized({
+        decodedToken: {
+          globalRoles: req.user.globalRoles,
+          resourceRoles: req.user.resourceRoles,
+        },
+        action: Action.CREATE_PUBLIC_TEMPLATE,
+      })
+    ) {
+      throw new Exceptions.UnauthorizedException(
+        'You are not authorized to create a public template.'
+      );
+    }
+
     // Now we can create the new template and return it
     const newTemplate = await createTemplate({
-      payload: req.body,
+      payload: body,
     });
 
     // Make the creator the admin

--- a/api/src/couchdb/templates.ts
+++ b/api/src/couchdb/templates.ts
@@ -14,6 +14,7 @@ import {
   TemplateDocument,
   TEMPLATES_BY_TEAM_ID,
 } from '@faims3/data-model';
+import type {TemplateApiDocument} from '@faims3/data-model';
 import {getTemplatesDb} from '.';
 import * as Exceptions from '../exceptions';
 import {generateRandomString} from '../utils';
@@ -109,6 +110,63 @@ export const getTemplate = async (id: string) => {
   }
 };
 
+async function teamDisplayNameForId(teamId: string): Promise<string | undefined> {
+  try {
+    const team = await getTeamById(teamId);
+    return team.name;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Adds {@link TemplateApiDocument.ownedByTeamDisplayName} for API responses so
+ * clients can show the team name without calling the teams API.
+ */
+export const withOwnedByTeamDisplayName = async (
+  template: ExistingTemplateDocument
+): Promise<TemplateApiDocument> => {
+  if (!template.ownedByTeamId) {
+    return template;
+  }
+  const ownedByTeamDisplayName = await teamDisplayNameForId(
+    template.ownedByTeamId
+  );
+  return ownedByTeamDisplayName !== undefined
+    ? {...template, ownedByTeamDisplayName}
+    : template;
+};
+
+export const withOwnedByTeamDisplayNames = async (
+  templates: ExistingTemplateDocument[]
+): Promise<TemplateApiDocument[]> => {
+  const ids = [
+    ...new Set(
+      templates
+        .map(t => t.ownedByTeamId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    ),
+  ];
+  const nameById = new Map<string, string>();
+  await Promise.all(
+    ids.map(async id => {
+      const name = await teamDisplayNameForId(id);
+      if (name !== undefined) {
+        nameById.set(id, name);
+      }
+    })
+  );
+  return templates.map(t => {
+    if (!t.ownedByTeamId) {
+      return t;
+    }
+    const ownedByTeamDisplayName = nameById.get(t.ownedByTeamId);
+    return ownedByTeamDisplayName !== undefined
+      ? {...t, ownedByTeamDisplayName}
+      : t;
+  });
+};
+
 /**
  * Generate a good project identifier for a new project
  *
@@ -163,6 +221,7 @@ export const createTemplate = async ({
     _id: templateId,
     version: 1,
     archived: false,
+    isPublic: payload.isPublic ?? false,
     'ui-specification': payload['ui-specification'],
     metadata: payload.metadata,
     ownedByTeamId: payload.teamId,
@@ -241,11 +300,13 @@ export const updateExistingTemplate = async (
   metadata.template_id = templateId;
 
   const archived = existingTemplate.archived ?? false;
+  const isPublic = existingTemplate.isPublic ?? false;
 
   const newDocument = {
     metadata: metadata,
     'ui-specification': uiSpecification,
     archived,
+    isPublic,
     // explicitly retain these details!
     _id: templateId,
     _rev: existingTemplate._rev,
@@ -261,6 +322,47 @@ export const updateExistingTemplate = async (
       'An unexpected error occurred while trying to update an existing template.'
     );
   }
+  try {
+    return await templateDb.get(templateId);
+  } catch (e) {
+    throw new Exceptions.InternalSystemError(
+      'An unexpected error occurred while trying to fetch the updated template.'
+    );
+  }
+};
+
+/**
+ * Sets public visibility only (does not change name, ui-spec, etc.).
+ */
+export const setTemplateVisibility = async (
+  templateId: string,
+  isPublic: boolean
+): Promise<ExistingTemplateDocument> => {
+  let existingTemplate;
+  try {
+    existingTemplate = await getTemplate(templateId);
+  } catch (e) {
+    throw new Exceptions.ItemNotFoundException(
+      'An error occurred while trying to fetch an existing template. Are you sure the ID is correct?'
+    );
+  }
+
+  const templateDb = getTemplatesDb();
+  const newDocument = {
+    ...existingTemplate,
+    _id: templateId,
+    _rev: existingTemplate._rev,
+    isPublic,
+  } satisfies TemplateDocument;
+
+  try {
+    await safeWriteDocument({db: templateDb, data: newDocument});
+  } catch (e) {
+    throw new Exceptions.InternalSystemError(
+      'An unexpected error occurred while trying to update template visibility.'
+    );
+  }
+
   try {
     return await templateDb.get(templateId);
   } catch (e) {

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -1068,6 +1068,39 @@ describe('template API tests', () => {
     );
   });
 
+  it('POST create rejects isPublic true without CREATE_PUBLIC_TEMPLATE', async () => {
+    const nb = getSampleNotebook();
+    await requestAuthAndType(
+      request(app)
+        .post(`${TEMPLATE_API_BASE}`)
+        .send({
+          ...nb,
+          name: 'no-public-without-ops',
+          isPublic: true,
+        } satisfies PostCreateTemplateInput),
+      notebookUserToken
+    )
+      .set('Content-Type', 'application/json')
+      .expect(401);
+  });
+
+  it('POST create allows omitting isPublic for general creator (private)', async () => {
+    const nb = getSampleNotebook();
+    const res = await requestAuthAndType(
+      request(app)
+        .post(`${TEMPLATE_API_BASE}`)
+        .send({
+          ...nb,
+          name: 'creator-private-template',
+        } satisfies PostCreateTemplateInput),
+      notebookUserToken
+    )
+      .set('Content-Type', 'application/json')
+      .expect(200);
+    const template = PostCreateTemplateResponseSchema.parse(res.body);
+    expect(template.isPublic !== true).to.equal(true);
+  });
+
   it('general user cannot read private template by id', async () => {
     const {template} = await createSampleTemplate(app, {
       name: 'private-only',

--- a/api/test/template.test.ts
+++ b/api/test/template.test.ts
@@ -41,6 +41,7 @@ import {
   PutUpdateTemplateInputSchema,
   PutUpdateTemplateResponse,
   PutUpdateTemplateResponseSchema,
+  TemplateApiDocumentSchema,
 } from '@faims3/data-model';
 import {expect} from 'chai';
 import {Express} from 'express';
@@ -54,6 +55,7 @@ import {
   adminUserName,
   beforeApiTests,
   localUserToken,
+  notebookUserToken,
   requestAuthAndType,
 } from './utils';
 import {createSampleTeam} from './teams.test';
@@ -217,6 +219,22 @@ const restoreTemplateFromArchive = async (
   )
     .expect(200)
     .then(res => PostRestoreTemplateResponseSchema.parse(res.body));
+};
+
+const putTemplateSetVisibility = async (
+  app: Express,
+  templateId: string,
+  isPublic: boolean,
+  token: string = adminToken
+) => {
+  return await requestAuthAndType(
+    request(app)
+      .put(`${TEMPLATE_API_BASE}/${templateId}/set-visibility`)
+      .send({isPublic}),
+    token
+  )
+    .expect(200)
+    .then(res => PutUpdateTemplateResponseSchema.parse(res.body));
 };
 
 /**
@@ -525,6 +543,106 @@ describe('template API tests', () => {
     });
   });
 
+  it('GET list and GET by id inject ownedByTeamDisplayName for team-owned templates', async () => {
+    const team = await createSampleTeam(app, {teamName: 'Acme Research'});
+    const {template} = await createSampleTemplate(app, {
+      teamId: team._id,
+      name: 'team-owned-for-display-name',
+    });
+
+    const listed = await listTemplates(app);
+    const fromList = listed.templates.find(t => t._id === template._id);
+    expect(fromList?.ownedByTeamDisplayName).to.equal('Acme Research');
+    if (fromList) {
+      TemplateApiDocumentSchema.parse(fromList);
+    }
+
+    const fetched = await getATemplate(app, template._id);
+    expect(fetched.ownedByTeamDisplayName).to.equal('Acme Research');
+    TemplateApiDocumentSchema.parse(fetched);
+
+    const {template: solo} = await createSampleTemplate(app, {
+      name: 'no-team-display-name',
+    });
+    const alone = await getATemplate(app, solo._id);
+    expect(alone.ownedByTeamDisplayName).to.be.undefined;
+    TemplateApiDocumentSchema.parse(alone);
+
+    await setTemplateArchived(app, template._id, true);
+    await deleteATemplate(app, template._id);
+    await setTemplateArchived(app, solo._id, true);
+    await deleteATemplate(app, solo._id);
+  });
+
+  it('GET list sets ownedByTeamDisplayName for multiple templates sharing one team (batch enrichment)', async () => {
+    const team = await createSampleTeam(app, {teamName: 'Shared Batch Team'});
+    const {template: a} = await createSampleTemplate(app, {
+      teamId: team._id,
+      name: 'batch-a',
+    });
+    const {template: b} = await createSampleTemplate(app, {
+      teamId: team._id,
+      name: 'batch-b',
+    });
+
+    const listed = await listTemplates(app);
+    for (const id of [a._id, b._id]) {
+      const row = listed.templates.find(t => t._id === id);
+      expect(row?.ownedByTeamDisplayName).to.equal('Shared Batch Team');
+    }
+
+    await setTemplateArchived(app, a._id, true);
+    await setTemplateArchived(app, b._id, true);
+    await deleteATemplate(app, a._id);
+    await deleteATemplate(app, b._id);
+  });
+
+  it('includeArchived list still injects ownedByTeamDisplayName', async () => {
+    const team = await createSampleTeam(app, {teamName: 'Archived Team Name'});
+    const {template} = await createSampleTemplate(app, {
+      teamId: team._id,
+      name: 'archived-with-team',
+    });
+    await setTemplateArchived(app, template._id, true);
+
+    const archivedOnly = await listTemplates(app, adminToken, {
+      includeArchived: true,
+    });
+    const row = archivedOnly.templates.find(t => t._id === template._id);
+    expect(row?.ownedByTeamDisplayName).to.equal('Archived Team Name');
+
+    await deleteATemplate(app, template._id);
+  });
+
+  it('POST create and PUT update responses do not include ownedByTeamDisplayName', async () => {
+    const team = await createSampleTeam(app, {teamName: 'No Echo Team'});
+    const nb = getSampleNotebook();
+
+    const createRes = await requestAuthAndType(
+      request(app)
+        .post(`${TEMPLATE_API_BASE}`)
+        .send({
+          ...nb,
+          name: 'create-no-display-name-field',
+          teamId: team._id,
+        } satisfies PostCreateTemplateInput),
+      adminToken
+    ).expect(200);
+    expect(createRes.body).to.not.have.property('ownedByTeamDisplayName');
+    const created = PostCreateTemplateResponseSchema.parse(createRes.body);
+
+    const updated = await updateATemplate(
+      app,
+      created._id,
+      {name: 'updated-name-without-display-field'},
+      adminToken
+    );
+    expect(updated).to.not.have.property('ownedByTeamDisplayName');
+
+    await setTemplateArchived(app, created._id, true);
+    await deleteATemplate(app, created._id);
+  });
+
   it('updates team ownership', async () => {
     const team1 = await createSampleTeam(app, {teamName: 'team1'});
     const team2 = await createSampleTeam(app, {teamName: 'team2'});
@@ -532,6 +650,10 @@ describe('template API tests', () => {
     // create a template
     const {template} = await createSampleTemplate(app, {
       teamId: team1._id,
+    });
+
+    await getATemplate(app, template._id).then(initial => {
+      expect(initial.ownedByTeamDisplayName).to.equal('team1');
     });
 
     // update team ownership
@@ -550,6 +672,7 @@ describe('template API tests', () => {
       // Check the new properties
       expect(newTemplate.version).to.equal(2);
       expect(newTemplate.ownedByTeamId).to.equal(team2._id);
+      expect(newTemplate.ownedByTeamDisplayName).to.equal('team2');
     });
   });
 
@@ -907,6 +1030,85 @@ describe('template API tests', () => {
           name: '12345',
         } satisfies CreateNotebookFromTemplate),
       localUserToken
+    ).expect(401);
+  });
+
+  it('persists isPublic on create and exposes visibility', async () => {
+    const {template} = await createSampleTemplate(app, {
+      name: 'public-flag',
+      payloadExtras: {isPublic: true},
+    });
+    expect(template.isPublic).to.equal(true);
+
+    const listed = await listTemplates(app, localUserToken);
+    expect(listed.templates.some(t => t._id === template._id)).to.equal(true);
+
+    await getATemplate(app, template._id, localUserToken).then(t =>
+      expect(t.isPublic).to.equal(true)
+    );
+  });
+
+  it('general user cannot read private template by id', async () => {
+    const {template} = await createSampleTemplate(app, {
+      name: 'private-only',
+    });
+    expect(template.isPublic !== true).to.equal(true);
+
+    await requestAuthAndType(
+      request(app).get(`${TEMPLATE_API_BASE}/${template._id}`),
+      localUserToken
+    ).expect(401);
+  });
+
+  it('PUT full template update does not change isPublic via stray body field', async () => {
+    const {template} = await createSampleTemplate(app, {
+      name: 'no-inline-visibility',
+    });
+    await requestAuthAndType(
+      request(app).put(`${TEMPLATE_API_BASE}/${template._id}`).send({
+        metadata: template.metadata,
+        'ui-specification': template['ui-specification'],
+        name: template.name,
+        isPublic: true,
+      } as PutUpdateTemplateInput & {isPublic: boolean})
+    ).expect(200);
+
+    const unchanged = await getATemplate(app, template._id);
+    expect(unchanged.isPublic !== true).to.equal(true);
+  });
+
+  it('PUT set-visibility updates isPublic and is forbidden without operations admin', async () => {
+    const {template} = await createSampleTemplate(app, {
+      name: 'visibility-endpoint',
+    });
+
+    const updated = await putTemplateSetVisibility(app, template._id, true);
+    expect(updated.isPublic).to.equal(true);
+
+    await requestAuthAndType(
+      request(app)
+        .put(`${TEMPLATE_API_BASE}/${template._id}/set-visibility`)
+        .send({isPublic: false}),
+      localUserToken
+    ).expect(401);
+
+    const afterDenied = await getATemplate(app, template._id);
+    expect(afterDenied.isPublic).to.equal(true);
+  });
+
+  it('notebook creator cannot instantiate another users private template', async () => {
+    const {template} = await createSampleTemplate(app, {
+      name: 'owned-by-admin',
+    });
+
+    await requestAuthAndType(
+      request(app)
+        .post(`${NOTEBOOKS_API_BASE}`)
+        .send({
+          name: 'clone attempt',
+          template_id: template._id,
+        } satisfies CreateNotebookFromTemplate),
+      notebookUserToken
     ).expect(401);
   });
 });

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -425,6 +425,8 @@ export const PostCreateTemplateInputSchema = TemplateDBFieldsSchema.pick({
 }).extend({
   // prefer to use a nicer team ID input field
   teamId: z.string().trim().min(1).optional(),
+  /** When true, template is visible in the public list for all users */
+  isPublic: z.boolean().optional(),
 });
 export type PostCreateTemplateInput = z.infer<
   typeof PostCreateTemplateInputSchema
@@ -458,16 +460,34 @@ export type PutUpdateTemplateResponse = z.infer<
   typeof PutUpdateTemplateResponseSchema
 >;
 
+/** PUT /api/templates/:id/set-visibility */
+export const PutTemplateSetVisibilityInputSchema = z.object({
+  isPublic: z.boolean(),
+});
+export type PutTemplateSetVisibilityInput = z.infer<
+  typeof PutTemplateSetVisibilityInputSchema
+>;
+
+/**
+ * Template document as returned by GET /templates and GET /templates/:id.
+ * Extends the stored document with optional server-injected fields (not persisted in CouchDB).
+ */
+export const TemplateApiDocumentSchema = ExistingTemplateDocumentSchema.extend({
+  /** Owning team's display name, looked up by the API when ownedByTeamId is set. */
+  ownedByTeamDisplayName: z.string().optional(),
+});
+export type TemplateApiDocument = z.infer<typeof TemplateApiDocumentSchema>;
+
 // GET list all templates response
 export const GetListTemplatesResponseSchema = z.object({
-  templates: z.array(ExistingTemplateDocumentSchema),
+  templates: z.array(TemplateApiDocumentSchema),
 });
 export type GetListTemplatesResponse = z.infer<
   typeof GetListTemplatesResponseSchema
 >;
 
 // GET a specific template by _id response
-export const GetTemplateByIdResponseSchema = ExistingTemplateDocumentSchema;
+export const GetTemplateByIdResponseSchema = TemplateApiDocumentSchema;
 export type GetTemplateByIdResponse = z.infer<
   typeof GetTemplateByIdResponseSchema
 >;

--- a/library/data-model/src/data_storage/migrations/migrations.ts
+++ b/library/data-model/src/data_storage/migrations/migrations.ts
@@ -31,6 +31,7 @@ import {
   TemplateV1Fields,
   TemplateV2Fields,
   TemplateV3Fields,
+  TemplateV4Fields,
 } from '../templatesDB/types';
 import {
   DBTargetVersions,
@@ -450,6 +451,28 @@ export const templatesV2toV3Migration: MigrationFunc = doc => {
 };
 
 /**
+ * Adds `isPublic` for visibility (default private for existing docs).
+ */
+export const templatesV3toV4Migration: MigrationFunc = doc => {
+  const inputDoc =
+    doc as unknown as PouchDB.Core.ExistingDocument<TemplateV3Fields>;
+
+  const outputDoc: PouchDB.Core.ExistingDocument<TemplateV4Fields> = {
+    _id: inputDoc._id,
+    _rev: inputDoc._rev,
+    name: inputDoc.name,
+    version: inputDoc.version,
+    metadata: inputDoc.metadata ?? {},
+    'ui-specification': inputDoc['ui-specification'],
+    ownedByTeamId: inputDoc.ownedByTeamId,
+    archived: inputDoc.archived ?? false,
+    isPublic: false,
+  };
+
+  return {action: 'update', updatedRecord: outputDoc};
+};
+
+/**
  * Adds the exchange token (fatuous) to mimic new format
  */
 export const authV1toV2Migration: MigrationFunc = doc => {
@@ -506,7 +529,7 @@ export const DB_TARGET_VERSIONS: DBTargetVersions = {
   [DatabaseType.PEOPLE]: {defaultVersion: 1, targetVersion: 5},
   // projects v3 (ARCHIVED status; v2→v3 model tracking migration)
   [DatabaseType.PROJECTS]: {defaultVersion: 1, targetVersion: 3},
-  [DatabaseType.TEMPLATES]: {defaultVersion: 1, targetVersion: 3},
+  [DatabaseType.TEMPLATES]: {defaultVersion: 1, targetVersion: 4},
   [DatabaseType.TEAMS]: {defaultVersion: 1, targetVersion: 1},
 };
 
@@ -588,6 +611,14 @@ export const DB_MIGRATIONS: MigrationDetails[] = [
     description:
       'Adds top-level archived flag; removes metadata.project_status (any value)',
     migrationFunction: templatesV2toV3Migration,
+  },
+  {
+    dbType: DatabaseType.TEMPLATES,
+    from: 3,
+    to: 4,
+    description:
+      'Adds isPublic flag for template visibility (existing templates default to private)',
+    migrationFunction: templatesV3toV4Migration,
   },
   {
     dbType: DatabaseType.AUTH,

--- a/library/data-model/src/data_storage/templatesDB/types.ts
+++ b/library/data-model/src/data_storage/templatesDB/types.ts
@@ -33,9 +33,16 @@ export const TemplateV3Schema = TemplateV2Schema.extend({
 export type TemplateV3Fields = z.infer<typeof TemplateV3Schema>;
 export type TemplateV3Document = PouchDB.Core.Document<TemplateV3Fields>;
 
-// Current (V3)
+// V4 — template visibility for all general users when true
+export const TemplateV4Schema = TemplateV3Schema.extend({
+  isPublic: z.boolean().default(false),
+});
+export type TemplateV4Fields = z.infer<typeof TemplateV4Schema>;
+export type TemplateV4Document = PouchDB.Core.Document<TemplateV4Fields>;
+
+// Current (V4)
 // Fields
-export const TemplateDBFieldsSchema = TemplateV3Schema;
+export const TemplateDBFieldsSchema = TemplateV4Schema;
 export type TemplateDBFields = z.infer<typeof TemplateDBFieldsSchema>;
 
 // Document

--- a/library/data-model/src/permission/functions.ts
+++ b/library/data-model/src/permission/functions.ts
@@ -113,6 +113,49 @@ export function isAuthorized({
 }
 
 /**
+ * True if any **global** role (including inherited actions) grants the action.
+ * Use when there is no resource id (e.g. list/table UI), including for actions
+ * that are resource-specific but granted only via global roles.
+ */
+export function globalRolesGrantAction(
+  decodedToken: DecodedTokenPermissions,
+  action: Action
+): boolean {
+  return roleGrantsAction({roles: decodedToken.globalRoles, action});
+}
+
+/**
+ * Whether the user may read a template (via private roles or the public list).
+ */
+export function userCanReadTemplateDocument({
+  decodedToken,
+  template,
+}: {
+  decodedToken: DecodedTokenPermissions;
+  template: {_id: string; isPublic?: boolean};
+}): boolean {
+  if (
+    isAuthorized({
+      decodedToken,
+      action: Action.READ_TEMPLATE_DETAILS,
+      resourceId: template._id,
+    })
+  ) {
+    return true;
+  }
+  if (
+    template.isPublic === true &&
+    isAuthorized({
+      decodedToken,
+      action: Action.READ_PUBLIC_TEMPLATE_DETAILS,
+    })
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Record owner comes from the record document's `created_by` / hydrated `createdBy`
  * — same identifier space as API `user_id` and JWT `sub` / app username.
  */

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -136,6 +136,12 @@ export enum Action {
   /** Set whether a template appears in the public list */
   CHANGE_TEMPLATE_VISIBILITY = 'CHANGE_TEMPLATE_VISIBILITY',
 
+  /**
+   * Create a new template that is initially visible to all users
+   * (`isPublic`). Granted alongside CHANGE_TEMPLATE_VISIBILITY.
+   */
+  CREATE_PUBLIC_TEMPLATE = 'CREATE_PUBLIC_TEMPLATE',
+
   /** Permanently remove a template document (API requires it to be archived first). */
   DELETE_TEMPLATE = 'DELETE_TEMPLATE',
 
@@ -728,6 +734,13 @@ export const actionDetails: Record<Action, ActionDetails> = {
     resourceSpecific: true,
     resource: Resource.TEMPLATE,
   },
+  [Action.CREATE_PUBLIC_TEMPLATE]: {
+    name: 'Create Public Template',
+    description:
+      'Create a new template that is visible to all users (operations or system administrators only)',
+    resourceSpecific: false,
+    resource: Resource.TEMPLATE,
+  },
   [Action.DELETE_TEMPLATE]: {
     name: 'Delete Template',
     description:
@@ -1239,8 +1252,9 @@ export const roleActions: Record<
       Action.EDIT_ANY_LONG_LIVED_TOKEN,
       Action.REVOKE_ANY_LONG_LIVED_TOKEN,
 
-      // Catalogue: only ops/system admins may publish templates to all users
+      // only ops/system admins may make templates visible to all users
       Action.CHANGE_TEMPLATE_VISIBILITY,
+      Action.CREATE_PUBLIC_TEMPLATE,
     ],
     inheritedRoles: [],
   },

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -121,6 +121,9 @@ export enum Action {
   // Read the high details of a template (e.g. description, title etc)
   READ_TEMPLATE_DETAILS = 'READ_TEMPLATE_DETAILS',
 
+  /** View templates marked public in the list (all general users) */
+  READ_PUBLIC_TEMPLATE_DETAILS = 'READ_PUBLIC_TEMPLATE_DETAILS',
+
   // Update the template high level details (e.g. description, title etc)
   UPDATE_TEMPLATE_DETAILS = 'UPDATE_TEMPLATE_DETAILS',
 
@@ -129,6 +132,9 @@ export enum Action {
 
   /** Archive or restore template */
   CHANGE_TEMPLATE_STATUS = 'CHANGE_TEMPLATE_STATUS',
+
+  /** Set whether a template appears in the public list */
+  CHANGE_TEMPLATE_VISIBILITY = 'CHANGE_TEMPLATE_VISIBILITY',
 
   /** Permanently remove a template document (API requires it to be archived first). */
   DELETE_TEMPLATE = 'DELETE_TEMPLATE',
@@ -690,6 +696,13 @@ export const actionDetails: Record<Action, ActionDetails> = {
     resourceSpecific: true,
     resource: Resource.TEMPLATE,
   },
+  [Action.READ_PUBLIC_TEMPLATE_DETAILS]: {
+    name: 'View public template',
+    description:
+      'View details of templates marked public in the list (available to all users)',
+    resourceSpecific: false,
+    resource: Resource.TEMPLATE,
+  },
   [Action.UPDATE_TEMPLATE_UISPEC]: {
     name: 'Update Template UI Specification',
     description: 'Modify the content/specification of a template',
@@ -705,6 +718,13 @@ export const actionDetails: Record<Action, ActionDetails> = {
   [Action.CHANGE_TEMPLATE_STATUS]: {
     name: 'Change Template Status',
     description: 'Archive or restore a template',
+    resourceSpecific: true,
+    resource: Resource.TEMPLATE,
+  },
+  [Action.CHANGE_TEMPLATE_VISIBILITY]: {
+    name: 'Change Template Visibility',
+    description:
+      'Set whether a template is listed in the public catalogue (operations or system administrators only)',
     resourceSpecific: true,
     resource: Resource.TEMPLATE,
   },
@@ -1148,6 +1168,7 @@ export const roleActions: Record<
     actions: [
       Action.LIST_PROJECTS,
       Action.LIST_TEMPLATES,
+      Action.READ_PUBLIC_TEMPLATE_DETAILS,
       Action.VERIFY_EMAIL,
 
       // Long-lived token actions for own tokens (CRUD)
@@ -1217,6 +1238,9 @@ export const roleActions: Record<
       Action.READ_ANY_LONG_LIVED_TOKENS,
       Action.EDIT_ANY_LONG_LIVED_TOKEN,
       Action.REVOKE_ANY_LONG_LIVED_TOKEN,
+
+      // Catalogue: only ops/system admins may publish templates to all users
+      Action.CHANGE_TEMPLATE_VISIBILITY,
     ],
     inheritedRoles: [],
   },

--- a/library/data-model/tests/migrations.test.ts
+++ b/library/data-model/tests/migrations.test.ts
@@ -31,6 +31,7 @@ import {
   TemplateV1Fields,
   TemplateV2Fields,
   TemplateV3Fields,
+  TemplateV4Fields,
 } from '../src/data_storage/templatesDB/types';
 import {areDocsEqual} from './utils';
 
@@ -484,6 +485,49 @@ const TEMPLATE_V2_TO_V3_MIGRATION_TEST_CASES: MigrationTestCase[] = [
         } satisfies EncodedProjectUIModel,
         archived: false,
       } as PouchDB.Core.ExistingDocument<TemplateV3Fields>,
+    },
+  },
+];
+
+const TEMPLATE_V3_TO_V4_MIGRATION_TEST_CASES: MigrationTestCase[] = [
+  {
+    name: 'templatesV3toV4Migration - adds isPublic false',
+    dbType: DatabaseType.TEMPLATES,
+    from: 3,
+    to: 4,
+    inputDoc: {
+      _id: 'tpl-v4',
+      _rev: '4-rev',
+      version: 2,
+      name: 'My tpl',
+      metadata: {pre_description: 'x'},
+      archived: false,
+      'ui-specification': {
+        fields: {},
+        fviews: {},
+        viewsets: {},
+        visible_types: [],
+      } satisfies EncodedProjectUIModel,
+      ownedByTeamId: 'team-z',
+    } as PouchDB.Core.ExistingDocument<TemplateV3Fields>,
+    expectedResult: {
+      action: 'update',
+      updatedRecord: {
+        _id: 'tpl-v4',
+        _rev: '4-rev',
+        version: 2,
+        name: 'My tpl',
+        metadata: {pre_description: 'x'},
+        archived: false,
+        'ui-specification': {
+          fields: {},
+          fviews: {},
+          viewsets: {},
+          visible_types: [],
+        } satisfies EncodedProjectUIModel,
+        ownedByTeamId: 'team-z',
+        isPublic: false,
+      } as PouchDB.Core.ExistingDocument<TemplateV4Fields>,
     },
   },
 ];
@@ -1871,6 +1915,7 @@ MIGRATION_TEST_CASES.push(...PROJECT_V2_TO_V3_MIGRATION_TEST_CASES);
 MIGRATION_TEST_CASES.push(...INVITES_MIGRATION_TEST_CASES);
 MIGRATION_TEST_CASES.push(...TEMPLATE_MIGRATION_TEST_CASES);
 MIGRATION_TEST_CASES.push(...TEMPLATE_V2_TO_V3_MIGRATION_TEST_CASES);
+MIGRATION_TEST_CASES.push(...TEMPLATE_V3_TO_V4_MIGRATION_TEST_CASES);
 MIGRATION_TEST_CASES.push(...AUTH_MIGRATION_TEST_CASES);
 MIGRATION_TEST_CASES.push(...PEOPLE_V3_TO_V4_MIGRATION_TEST_CASES);
 MIGRATION_TEST_CASES.push(...PEOPLE_V4_TO_V5_MIGRATION_TEST_CASES);

--- a/web/src/components/dialogs/template-visibility-dialog.tsx
+++ b/web/src/components/dialogs/template-visibility-dialog.tsx
@@ -1,0 +1,156 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {useAuth} from '@/context/auth-provider';
+import {useGetTemplate} from '@/hooks/queries';
+import {putTemplateSetVisibility} from '@/hooks/template-hooks';
+import {useQueryClient} from '@tanstack/react-query';
+import {AlertCircle, CheckCircle, Info} from 'lucide-react';
+import {useState} from 'react';
+import {Button} from '../ui/button';
+
+export function TemplateVisibilityDialog({templateId}: {templateId: string}) {
+  const {user} = useAuth();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+
+  const {data: template} = useGetTemplate({user, templateId});
+  const isPublic = template?.isPublic === true;
+
+  const onConfirmToggle = async () => {
+    if (!user) return;
+    await putTemplateSetVisibility({
+      user,
+      templateId,
+      isPublic: !isPublic,
+    });
+    await queryClient.invalidateQueries({queryKey: ['templates', templateId]});
+    await queryClient.invalidateQueries({queryKey: ['templates', undefined]});
+    setOpen(false);
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="mb-2">
+        <div className="flex items-center gap-1.5 mb-2">
+          <h3 className="text-base font-medium text-card-foreground">
+            Template visibility
+          </h3>
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="More about template visibility"
+              >
+                <Info className="h-4 w-4" aria-hidden />
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-lg">
+              <DialogHeader>
+                <DialogTitle className="text-foreground mb-4">
+                  Template visibility
+                </DialogTitle>
+                <DialogDescription asChild>
+                  <div className="space-y-3 text-left text-sm text-foreground">
+                    <p>
+                      <span className="font-medium text-emerald-600 dark:text-emerald-500">
+                        Public:
+                      </span>{' '}
+                      this template will be available to view and use for all
+                      users. Public permissions are read only.
+                    </p>
+                    <p>
+                      <span className="font-medium text-muted-foreground">
+                        Private:
+                      </span>{' '}
+                      Visible only to people with access to this template (for
+                      example your team and system administrators).
+                    </p>
+                  </div>
+                </DialogDescription>
+              </DialogHeader>
+            </DialogContent>
+          </Dialog>
+        </div>
+
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-sm font-medium text-card-foreground">
+            Current status:
+          </span>
+          {isPublic ? (
+            <div className="flex items-center gap-1.5 text-emerald-500">
+              <CheckCircle size={16} />
+              <span className="text-sm font-medium">Public</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <AlertCircle size={16} />
+              <span className="text-sm font-medium">Private</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {isPublic ? (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outline">
+              Make private
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle className="text-foreground">
+                Make template private
+              </DialogTitle>
+              <DialogDescription className="text-foreground">
+                This template will no longer appear in the available templates
+                list for all users. People who already have access (for example
+                your team and system administrators) will still see it.
+              </DialogDescription>
+            </DialogHeader>
+            <Button variant="default" onClick={onConfirmToggle}>
+              Yes, make private
+            </Button>
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outline">
+              Make public
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle className="text-foreground">
+                Make template public
+              </DialogTitle>
+              <DialogDescription asChild>
+                <p className="text-left text-sm text-foreground">
+                  This template will be available to view and use for all users.
+                  Public permissions are read only.
+                </p>
+              </DialogDescription>
+            </DialogHeader>
+            <Button variant="default" onClick={onConfirmToggle}>
+              Yes, make public
+            </Button>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/forms/add-template-to-team-form.tsx
+++ b/web/src/components/forms/add-template-to-team-form.tsx
@@ -13,10 +13,11 @@ interface AddTemplateToTeamFormProps {
 }
 
 /**
- * A form component that allows assigning a project to a team.
+ * A form component that allows assigning a template to a team (updates
+ * {@link ownedByTeamId} via PUT /api/templates/:id).
  *
  * @param setDialogOpen - A function to control the dialog's open state.
- * @param projectId - The ID of the project to be assigned to a team.
+ * @param templateId - The ID of the template to assign to a team.
  */
 export function AddTemplateToTeamForm({
   setDialogOpen,
@@ -69,7 +70,7 @@ export function AddTemplateToTeamForm({
     if (!response.ok)
       return {
         type: 'submit',
-        message: 'Error adding project to team: ' + response.statusText,
+        message: 'Error assigning template to team: ' + response.statusText,
       };
 
     QueryClient.invalidateQueries({

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -37,6 +37,10 @@ export function CreateTemplateForm({
     action: Action.CREATE_TEMPLATE,
   });
 
+  const canCreatePublicTemplate = useIsAuthorisedTo({
+    action: Action.CREATE_PUBLIC_TEMPLATE,
+  });
+
   // get the teams that we have permission to create
   // templates in
   const teamsAvailable =
@@ -74,7 +78,10 @@ export function CreateTemplateForm({
         })
         .optional(),
     },
-    {
+  ];
+
+  if (canCreatePublicTemplate) {
+    fields.push({
       name: 'visibility',
       label: 'Template visibility',
       description:
@@ -94,8 +101,8 @@ export function CreateTemplateForm({
         },
       ],
       schema: z.enum(['private', 'public']),
-    },
-  ];
+    });
+  }
 
   if (!justOneTeam) {
     fields.push({
@@ -113,11 +120,13 @@ export function CreateTemplateForm({
     name: string;
     file?: File;
     team?: string;
-    visibility: 'private' | 'public';
+    visibility?: 'private' | 'public';
   }) => {
     if (!user) return {type: 'submit', message: 'Not authenticated'};
 
     const {name, file, team, visibility} = values;
+    const isPublic =
+      canCreatePublicTemplate && visibility === 'public';
     let jsonPayload: Record<string, any> = {};
 
     if (file) {
@@ -158,7 +167,7 @@ export function CreateTemplateForm({
           body: JSON.stringify({
             teamId: chosenTeamId,
             name,
-            isPublic: visibility === 'public',
+            isPublic,
             ...jsonPayload,
           }),
         }
@@ -203,7 +212,7 @@ export function CreateTemplateForm({
           submitButtonText="Create Template"
           defaultValues={{
             team: defaultValues?.teamId,
-            visibility: 'private',
+            ...(canCreatePublicTemplate ? {visibility: 'private' as const} : {}),
           }}
         />
       </>

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -74,6 +74,27 @@ export function CreateTemplateForm({
         })
         .optional(),
     },
+    {
+      name: 'visibility',
+      label: 'Template visibility',
+      description:
+        'Public templates are available for all signed-in users who can browse templates.',
+      options: [
+        {
+          label: 'Private',
+          value: 'private',
+          description:
+            'Only people with access (for example your team) can view this template.',
+        },
+        {
+          label: 'Public',
+          value: 'public',
+          description:
+            'this template will be available to view and use for all users. Public permissions are read only.',
+        },
+      ],
+      schema: z.enum(['private', 'public']),
+    },
   ];
 
   if (!justOneTeam) {
@@ -92,10 +113,11 @@ export function CreateTemplateForm({
     name: string;
     file?: File;
     team?: string;
+    visibility: 'private' | 'public';
   }) => {
     if (!user) return {type: 'submit', message: 'Not authenticated'};
 
-    const {name, file, team} = values;
+    const {name, file, team, visibility} = values;
     let jsonPayload: Record<string, any> = {};
 
     if (file) {
@@ -136,6 +158,7 @@ export function CreateTemplateForm({
           body: JSON.stringify({
             teamId: chosenTeamId,
             name,
+            isPublic: visibility === 'public',
             ...jsonPayload,
           }),
         }
@@ -178,7 +201,10 @@ export function CreateTemplateForm({
           fields={fields}
           onSubmit={onSubmit}
           submitButtonText="Create Template"
-          defaultValues={{team: defaultValues?.teamId}}
+          defaultValues={{
+            team: defaultValues?.teamId,
+            visibility: 'private',
+          }}
         />
       </>
     );

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -97,7 +97,7 @@ export function CreateTemplateForm({
           label: 'Public',
           value: 'public',
           description:
-            'this template will be available to view and use for all users. Public permissions are read only.',
+            'This template will be available to view and use for all users. Public permissions are read only.',
         },
       ],
       schema: z.enum(['private', 'public']),

--- a/web/src/components/tables/archived-templates.tsx
+++ b/web/src/components/tables/archived-templates.tsx
@@ -176,11 +176,14 @@ export const archivedTemplateColumns: ColumnDef<ArchivedTemplateRow>[] = [
     ),
     cell: ({
       row: {
-        original: {ownedByTeamId},
+        original: {ownedByTeamId, ownedByTeamDisplayName},
       },
     }) => {
       return ownedByTeamId ? (
-        <TeamCellComponent teamId={ownedByTeamId} />
+        <TeamCellComponent
+          teamId={ownedByTeamId}
+          teamDisplayName={ownedByTeamDisplayName}
+        />
       ) : null;
     },
   },

--- a/web/src/components/tables/cells/team-cell.tsx
+++ b/web/src/components/tables/cells/team-cell.tsx
@@ -5,24 +5,50 @@ import {Link} from '@tanstack/react-router';
 
 interface TeamCellComponentProps {
   teamId: string;
+  /**
+   * When set (e.g. from GET /api/templates), skips fetching team details — avoids 401
+   * for users who can read a public template but not the owning team.
+   */
+  teamDisplayName?: string;
 }
 
 /**
  * Component: TeamCellComponent
  * Renders a team name as a clickable link in a table cell
  */
-export const TeamCellComponent = ({teamId}: TeamCellComponentProps) => {
+export const TeamCellComponent = ({
+  teamId,
+  teamDisplayName,
+}: TeamCellComponentProps) => {
   const {user} = useAuth();
+  const hasInjectedName =
+    teamDisplayName !== undefined && teamDisplayName.length > 0;
+
+  const {data: team, isLoading, isError} = useGetTeam({
+    user,
+    teamId,
+    enabled: !hasInjectedName,
+  });
 
   if (!user) {
     return <p>Unauthenticated</p>;
   }
 
-  const {data: team, isLoading, isError} = useGetTeam({user, teamId});
+  const displayLabel = hasInjectedName
+    ? teamDisplayName
+    : isLoading
+      ? undefined
+      : isError
+        ? teamId
+        : (team?.name ?? teamId);
 
-  return isLoading ? (
-    <Skeleton className="h-5 w-24" />
-  ) : (
+  const linkActive = hasInjectedName || !!team;
+
+  if (!hasInjectedName && isLoading) {
+    return <Skeleton className="h-5 w-24" />;
+  }
+
+  return (
     <div
       className="w-full h-full"
       onClick={e => {
@@ -32,15 +58,15 @@ export const TeamCellComponent = ({teamId}: TeamCellComponentProps) => {
     >
       <Link
         to="/teams/$teamId"
-        disabled={!team}
+        disabled={!linkActive}
         params={{teamId}}
         className={
-          'text-gray-700' + team
-            ? ' hover:text-gray-900 cursor-pointer transition-colors'
-            : ''
+          linkActive
+            ? 'cursor-pointer text-gray-700 transition-colors hover:text-gray-900'
+            : 'text-gray-700'
         }
       >
-        {isError ? teamId : isLoading ? 'Loading...' : (team?.name ?? teamId)}
+        {displayLabel ?? 'Loading...'}
       </Link>
     </div>
   );

--- a/web/src/components/tables/templates.tsx
+++ b/web/src/components/tables/templates.tsx
@@ -12,78 +12,118 @@ import {
 
 export type Column = any;
 
-export const columns: ColumnDef<Column>[] = [
-  {
-    accessorKey: 'name',
-    header: ({column}) => (
-      <DataTableColumnHeader column={column} title="Name" />
-    ),
-  },
-  {
-    id: 'team',
-    accessorKey: 'ownedByTeamId',
-    header: ({column}) => (
-      <DataTableColumnHeader column={column} title="Team" />
-    ),
-    cell: ({
-      row: {
-        original: {ownedByTeamId},
-      },
-    }) => {
-      return ownedByTeamId ? (
-        <TeamCellComponent teamId={ownedByTeamId} />
-      ) : null;
+const nameColumn: ColumnDef<Column> = {
+  accessorKey: 'name',
+  header: ({column}) => (
+    <DataTableColumnHeader column={column} title="Name" />
+  ),
+};
+
+const teamColumn: ColumnDef<Column> = {
+  id: 'team',
+  accessorKey: 'ownedByTeamId',
+  header: ({column}) => (
+    <DataTableColumnHeader column={column} title="Team" />
+  ),
+  cell: ({
+    row: {
+      original: {ownedByTeamId, ownedByTeamDisplayName},
     },
-  },
-  {
-    id: 'status',
-    header: ({column}) => (
-      <DataTableColumnHeader column={column} title="Status" />
-    ),
-    accessorFn: (row: Column & {archived?: boolean}) =>
-      row.archived === true ? 'Archived' : 'Active',
-    cell: ({row}: {row: {original: Column & {archived?: boolean}}}) => {
-      const label = row.original.archived === true ? 'Archived' : 'Active';
-      return <RoleCard>{label}</RoleCard>;
-    },
-  },
-  {
-    accessorKey: 'metadata.project_lead',
-    header: ({column}) => (
-      <DataTableColumnHeader
-        column={column}
-        title={`${NOTEBOOK_NAME_CAPITALIZED} Lead`}
+  }) => {
+    return ownedByTeamId ? (
+      <TeamCellComponent
+        teamId={ownedByTeamId}
+        teamDisplayName={ownedByTeamDisplayName}
       />
-    ),
+    ) : null;
   },
-  {
-    accessorKey: 'metadata.pre_description',
-    header: ({column}) => (
-      <DataTableColumnHeader column={column} title="Description" />
-    ),
-    cell: ({getValue}) => {
-      const description = getValue<string>();
-      if (!description) return null;
-      const maxLength = 100;
-      const isTruncated = description.length > maxLength;
-      const displayText = isTruncated
-        ? description.slice(0, maxLength) + '…'
-        : description;
+};
 
-      if (!isTruncated) return <span>{displayText}</span>;
-
-      return (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="cursor-help">{displayText}</span>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-sm">
-              <p>{description}</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      );
-    },
+const statusColumn: ColumnDef<Column> = {
+  id: 'status',
+  header: ({column}) => (
+    <DataTableColumnHeader column={column} title="Status" />
+  ),
+  accessorFn: (row: Column & {archived?: boolean}) =>
+    row.archived === true ? 'Archived' : 'Active',
+  cell: ({row}: {row: {original: Column & {archived?: boolean}}}) => {
+    const label = row.original.archived === true ? 'Archived' : 'Active';
+    return <RoleCard>{label}</RoleCard>;
   },
-];
+};
+
+const visibilityColumn: ColumnDef<Column> = {
+  id: 'visibility',
+  header: ({column}) => (
+    <DataTableColumnHeader column={column} title="Visibility" />
+  ),
+  accessorFn: (row: Column & {isPublic?: boolean}) =>
+    row.isPublic === true ? 'Public' : 'Private',
+  cell: ({row}: {row: {original: Column & {isPublic?: boolean}}}) => {
+    const label = row.original.isPublic === true ? 'Public' : 'Private';
+    return <RoleCard>{label}</RoleCard>;
+  },
+};
+
+const projectLeadColumn: ColumnDef<Column> = {
+  accessorKey: 'metadata.project_lead',
+  header: ({column}) => (
+    <DataTableColumnHeader
+      column={column}
+      title={`${NOTEBOOK_NAME_CAPITALIZED} Lead`}
+    />
+  ),
+};
+
+const descriptionColumn: ColumnDef<Column> = {
+  accessorKey: 'metadata.pre_description',
+  header: ({column}) => (
+    <DataTableColumnHeader column={column} title="Description" />
+  ),
+  cell: ({getValue}) => {
+    const description = getValue<string>();
+    if (!description) return null;
+    const maxLength = 100;
+    const isTruncated = description.length > maxLength;
+    const displayText = isTruncated
+      ? description.slice(0, maxLength) + '…'
+      : description;
+
+    if (!isTruncated) return <span>{displayText}</span>;
+
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-help">{displayText}</span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-sm">
+            <p>{description}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  },
+};
+
+/**
+ * Columns for the templates overview table. Visibility is omitted unless the
+ * user has global permission to change catalogue visibility (ops/system admin).
+ */
+export function getTemplatesTableColumns(options: {
+  includeVisibility: boolean;
+  /** When true, omit the team column (e.g. team tab where team is fixed). */
+  hideTeamColumn?: boolean;
+}): ColumnDef<Column>[] {
+  const {includeVisibility, hideTeamColumn} = options;
+  const team = hideTeamColumn ? [] : [teamColumn];
+  const visibility = includeVisibility ? [visibilityColumn] : [];
+  return [
+    nameColumn,
+    ...team,
+    statusColumn,
+    ...visibility,
+    projectLeadColumn,
+    descriptionColumn,
+  ];
+}

--- a/web/src/components/tabs/teams/team-templates.tsx
+++ b/web/src/components/tabs/teams/team-templates.tsx
@@ -1,11 +1,12 @@
 import {DataTable} from '@/components/data-table/data-table';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
-import {columns} from '@/components/tables/templates';
+import {getTemplatesTableColumns} from '@/components/tables/templates';
 import {useAuth} from '@/context/auth-provider';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {useGetTemplatesForTeam} from '@/hooks/queries';
-import {Action} from '@faims3/data-model';
+import {Action, globalRolesGrantAction} from '@faims3/data-model';
 import {useNavigate} from '@tanstack/react-router';
+import {useMemo} from 'react';
 
 const TeamTemplates = ({teamId}: {teamId: string}) => {
   const {user} = useAuth();
@@ -20,9 +21,24 @@ const TeamTemplates = ({teamId}: {teamId: string}) => {
 
   const navigate = useNavigate();
 
+  const columns = useMemo(
+    () =>
+      getTemplatesTableColumns({
+        hideTeamColumn: true,
+        includeVisibility: globalRolesGrantAction(
+          user?.decodedToken ?? {
+            globalRoles: [],
+            resourceRoles: [],
+          },
+          Action.CHANGE_TEMPLATE_VISIBILITY
+        ),
+      }),
+    [user?.decodedToken]
+  );
+
   return (
     <DataTable
-      columns={columns.filter(c => c.id !== 'team')}
+      columns={columns}
       data={data?.templates || []}
       loading={isPending}
       onRowClick={({_id}) => navigate({to: `/templates/${_id}`})}

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo, useState} from 'react';
 import {ArchiveTemplateDialog} from '@/components/dialogs/archive-template-dialog';
+import {TemplateVisibilityDialog} from '@/components/dialogs/template-visibility-dialog';
 import {List, ListDescription, ListItem, ListLabel} from '@/components/ui/list';
 import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
 import {ProjectFromTemplateDialog} from '@/components/dialogs/project-from-template';
@@ -72,6 +73,11 @@ const TemplateActions = () => {
     resourceId: templateId,
   });
 
+  const canChangeTemplateVisibility = useIsAuthorisedTo({
+    action: Action.CHANGE_TEMPLATE_VISIBILITY,
+    resourceId: templateId,
+  });
+
   const canCreateProject = useIsAuthorisedTo({
     action: Action.CREATE_PROJECT,
   });
@@ -82,15 +88,10 @@ const TemplateActions = () => {
       action: Action.CREATE_PROJECT_IN_TEAM,
     }).length > 0;
 
-  // per-team and global permissions for adding templates to a team
-  const canAddTemplateToTeam =
-    getUserResourcesForAction({
-      decodedToken: user?.decodedToken,
-      action: Action.CREATE_TEMPLATE_IN_TEAM,
-    }).length > 0;
-
-  const globalCanAddTemplateToTeam = useIsAuthorisedTo({
-    action: Action.CREATE_TEMPLATE,
+  /** Reassigning team is a template update (PUT /api/templates/:id), not create-template. */
+  const canAssignTemplateToTeam = useIsAuthorisedTo({
+    action: Action.UPDATE_TEMPLATE_DETAILS,
+    resourceId: templateId,
   });
 
   const archived = data?.archived === true;
@@ -138,13 +139,13 @@ const TemplateActions = () => {
           </Card>
         )}
 
-        {(canAddTemplateToTeam || globalCanAddTemplateToTeam) && (
+        {canAssignTemplateToTeam && (
           <Card className="flex-1">
             <List className="flex flex-col gap-4">
               <ListItem>
-                <ListLabel>Assign {NOTEBOOK_NAME} to a Team</ListLabel>
+                <ListLabel>Assign Template to Team</ListLabel>
                 <ListDescription>
-                  Assign this {NOTEBOOK_NAME} to a team.
+                  Assign this template to a team so its members can use it.
                 </ListDescription>
               </ListItem>
               <ListItem>
@@ -210,6 +211,11 @@ const TemplateActions = () => {
                 <ProjectFromTemplateDialog />
               </ListItem>
             </List>
+          </Card>
+        )}
+        {canChangeTemplateVisibility && (
+          <Card className="flex-1">
+            <TemplateVisibilityDialog templateId={templateId} />
           </Card>
         )}
         {canChangeTemplateArchiveStatus ? (

--- a/web/src/components/tabs/templates/details.tsx
+++ b/web/src/components/tabs/templates/details.tsx
@@ -4,6 +4,7 @@ import {List, ListDescription, ListItem, ListLabel} from '@/components/ui/list';
 import {Skeleton} from '@/components/ui/skeleton';
 import {useAuth} from '@/context/auth-provider';
 import {useGetTemplate} from '@/hooks/queries';
+import {GetTemplateByIdResponse} from '@faims3/data-model';
 
 const detailsFields = [
   {field: 'name', label: 'Name'},
@@ -13,12 +14,19 @@ const detailsFields = [
   {
     field: 'ownedByTeamId',
     label: 'Team',
-    render: (teamId: string | undefined) => {
+    render: (
+      teamId: string | undefined,
+      template: GetTemplateByIdResponse | undefined
+    ) => {
       if (!teamId) {
         return 'Not created in a team';
-      } else {
-        return <TeamCellComponent teamId={teamId} />;
       }
+      return (
+        <TeamCellComponent
+          teamId={teamId}
+          teamDisplayName={template?.ownedByTeamDisplayName}
+        />
+      );
     },
     isMetadata: false,
   },
@@ -55,7 +63,7 @@ const TemplateDetails = ({templateId}: TemplateDetailsProps) => {
                 <Skeleton />
               ) : (
                 <ListDescription>
-                  {render ? render(cellData) : cellData}
+                  {render ? render(cellData, data) : cellData}
                 </ListDescription>
               )}
             </ListItem>

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -154,14 +154,17 @@ export const useGetProjects = ({
 export const useGetTemplate = ({
   user,
   templateId,
+  enabled = true,
 }: {
   user: User | null;
   templateId: string;
+  enabled?: boolean;
 }) =>
   useQuery({
     queryKey: ['templates', templateId],
     queryFn: () =>
       get<GetTemplateByIdResponse>(`/api/templates/${templateId}`, user),
+    enabled: !!user && !!templateId && enabled,
   });
 
 /**
@@ -259,14 +262,17 @@ export const useGetUsersForTeam = ({
 export const useGetTeam = ({
   user,
   teamId,
+  enabled: enabledOption = true,
 }: {
   user: User | null;
   teamId: string | undefined;
+  /** When false, the team request is skipped (e.g. team label already provided by another API). */
+  enabled?: boolean;
 }) =>
   useQuery({
     queryKey: ['teams', teamId],
     queryFn: async () => get<GetTeamByIdResponse>(`/api/teams/${teamId}`, user),
-    enabled: !!user && !!teamId,
+    enabled: !!user && !!teamId && enabledOption,
   });
 
 /**

--- a/web/src/hooks/template-hooks.ts
+++ b/web/src/hooks/template-hooks.ts
@@ -128,3 +128,34 @@ export const updateTemplateRequest = async ({
     }
   );
 };
+
+/**
+ * PUT /api/templates/:templateId/set-visibility — public visibility only.
+ */
+export const putTemplateSetVisibility = async ({
+  user,
+  templateId,
+  isPublic,
+}: {
+  user: User;
+  templateId: string;
+  isPublic: boolean;
+}): Promise<void> => {
+  const response = await fetch(
+    `${import.meta.env.VITE_API_URL}/api/templates/${encodeURIComponent(templateId)}/set-visibility`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${user.token}`,
+      },
+      body: JSON.stringify({isPublic}),
+    }
+  );
+  const json: unknown = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    throw new Error(
+      errorMessageFromTemplateJsonBody(json, response.statusText)
+    );
+  }
+};

--- a/web/src/routes/_protected/templates/index.tsx
+++ b/web/src/routes/_protected/templates/index.tsx
@@ -1,13 +1,17 @@
 import {createFileRoute, useNavigate} from '@tanstack/react-router';
 import {DataTable} from '@/components/data-table/data-table';
-import {columns} from '@/components/tables/templates';
+import {getTemplatesTableColumns} from '@/components/tables/templates';
 import {useAuth} from '@/context/auth-provider';
 import {useGetTemplates} from '@/hooks/queries';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
 import {useMemo} from 'react';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
-import {Action, getUserResourcesForAction} from '@faims3/data-model';
+import {
+  Action,
+  getUserResourcesForAction,
+  globalRolesGrantAction,
+} from '@faims3/data-model';
 
 export const Route = createFileRoute('/_protected/templates/')({
   component: RouteComponent,
@@ -51,6 +55,20 @@ function RouteComponent() {
     isLoading: false,
     paths,
   });
+
+  const columns = useMemo(
+    () =>
+      getTemplatesTableColumns({
+        includeVisibility: globalRolesGrantAction(
+          user?.decodedToken ?? {
+            globalRoles: [],
+            resourceRoles: [],
+          },
+          Action.CHANGE_TEMPLATE_VISIBILITY
+        ),
+      }),
+    [user?.decodedToken]
+  );
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
### Summary

Adds **public/private template visibility** end to end: storage (`isPublic`), permissions for reading public templates vs private access, an API to toggle visibility, and UI to manage and explain it.

Motivation for this is to make the 'shared template' workflow easier to maintain and scale. Currently distributing templates to teams as starting points requires having duplicates created within each team. This then means that updating a 'shared template' requires updating every instance of the duplicated template. This allows ops admins to make templates shared so that users can access/use them directly, restricting the update space to one spot. There is still the issue where users create a customised template, and update that, which won't inherit the upstream changes - but that is out of scope for this PR.

**Requires DB migration - non-breaking**.

### Changes

- **Data model & migrations**: Persist `isPublic` on template documents; extend permissions with actions such as `READ_PUBLIC_TEMPLATE_DETAILS` and `CHANGE_TEMPLATE_VISIBILITY`, plus `userCanReadTemplateDocument` (private access or public + public-read permission). Adds `globalRolesGrantAction` for cases without a resource id.
- **API**: List/get/references use `userCanReadTemplateDocument` instead of only `READ_TEMPLATE_DETAILS` on the template id. New `PUT /api/templates/:id/set-visibility` updates `isPublic` only. Template responses can include `ownedByTeamDisplayName` for list/detail without extra team calls. Create template accepts optional `isPublic` (default false). Swagger updated.
- **Web**: Template visibility dialog (make public/private, copy, confirmations), hooks for `set-visibility`, and template tables/forms/team views updated for public state and display.
- **Tests**: API template tests and data-model migration tests expanded.

### Notes

- Public templates are intended as **read-only for general users**; changing visibility remains restricted to authorized roles.
- Our use case at the moment only wants operation admins to be able to access this feature, as making templates public is something that should be done with scrutiny. Users may accidentally leak IP or other sensitive materials. Open to discussion in opening this up moving forward, but would like time to treat this as 'admin only' for the time being.