### PR TITLE
feat: improved handling of digest algorithms

### DIFF
--- a/api/src/auth/strategies/strategyTypes.ts
+++ b/api/src/auth/strategies/strategyTypes.ts
@@ -118,8 +118,11 @@ export const SAMLAuthProviderConfigSchema = BaseAuthProviderConfigSchema.extend(
     // Signature configuration
     /** Signature algorithm: 'sha1', 'sha256', or 'sha512' (default: sha256) */
     signatureAlgorithm: z.enum(['sha1', 'sha256', 'sha512']).optional(),
-    /** Digest algorithm: 'sha1', 'sha256', or 'sha512' */
-    digestAlgorithm: z.enum(['sha1', 'sha256', 'sha512']).optional(),
+    /** Digest for signed request references; passport-saml defaults to sha1 if omitted here */
+    digestAlgorithm: z
+      .enum(['sha1', 'sha256', 'sha512'])
+      .optional()
+      .default('sha256'),
     /** Request signed assertions from IdP (default: true) */
     wantAssertionsSigned: z.boolean().optional(),
     // SAML behavior options

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -145,6 +145,7 @@
         "authnRequestBinding": "HTTP-POST",
         "callbackURL": "https://faims.example.com/auth/saml/callback",
         "signatureAlgorithm": "sha256",
+        "digestAlgorithm": "sha256",
         "wantAssertionsSigned": true
       }
     }

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -175,7 +175,13 @@ const SAMLAuthProviderConfigSchema = BaseAuthProviderConfigSchema.extend({
     .enum(['sha1', 'sha256', 'sha512'])
     .optional()
     .default('sha256'),
-  digestAlgorithm: z.enum(['sha1', 'sha256', 'sha512']).optional(),
+  digestAlgorithm: z
+    .enum(['sha1', 'sha256', 'sha512'])
+    .optional()
+    .default('sha256')
+    .describe(
+      'XML digest for signed SAML requests (passport-saml; default sha256). Use sha1 only if your IdP requires it.'
+    ),
   wantAssertionsSigned: z.boolean().optional().default(true),
   // SAML behavior options
   identifierFormat: z


### PR DESCRIPTION
**Problem:** VANguard (and similar IdPs) reject AuthnRequests whose `DigestMethod` is SHA-1. `signatureAlgorithm: sha256` only affects the signature algorithm; passport-saml still defaults **digest** references to SHA-1 unless `digestAlgorithm` is set.

**Change:** Default `digestAlgorithm` to `sha256` in the API auth provider schema and in the AWS CDK SAML config schema. Document the field in `dev.json` and `sample.json`.