### PR TITLE
feat: global cross-database migrations and migration docs

### DIFF
--- a/api/doc/DATABASE.md
+++ b/api/doc/DATABASE.md
@@ -75,6 +75,16 @@ here are used to locate the databases.
 `auth_mechanisms` is repeated here from the projects database. It doesn't seem to be
 used anywhere at all.
 
+## Migrations and schema versions
+
+Each **physical** Couch database that participates in automated upgrades has a row in a dedicated **migrations** database: `(DatabaseType, db_name)` → current **integer version**, **status** (`healthy` / `not-healthy`), and a **migration log**. Platform-wide DBs (directory, people, projects, …) each have one such document; every `data-{project}` and `metadata-{project}` pair has its own document keyed by that DB’s name.
+
+The conductor/API runs **`migrateDbs`** from the `@faims3/data-model` package (`library/data-model/src/data_storage/migrations/migrationService.ts`): it applies **individual** per-document migrations (`DB_MIGRATIONS` in `migrations.ts`) and, when needed, **global** coordinated steps (`GLOBAL_MIGRATIONS` in `globalMigrations.ts`). Developer-facing details, invariants, and how to add new steps are documented in `docs/developer/docs/source/markdown/CouchMigrations.md` (Sphinx developer docs).
+
+`initialiseAndMigrateDBs` in `api/src/couchdb/index.ts` calls **`getAllProjectsDirectory`** (see `api/src/couchdb/notebooks.ts`) **before** a **single** `migrateDbs` over every **platform** database (auth, directory, invites, people, projects, templates, **teams**) plus **each project’s `DATA` and `METADATA`**. That way **global** migrations always see one combined batch (`GlobalMigrationRunContext.allBatchHandles()` / `allHandlesForType()` in `run`). Because listing runs first, **project documents must stay backwards compatible** enough to enumerate projects and resolve data/metadata DB names at whatever Couch version is still on disk—see the `getAllProjectsDirectory` docstring.
+
+**Notebook JSON** (`schema_version`, UI spec shape) is migrated separately; see `docs/developer/docs/source/markdown/NotebookMigrations.md`.
+
 ## Individual project databases
 
 Two databases hold the data for a notebook: `data-{project name}` and `metadata-{project name}`.

--- a/api/src/couchdb/index.ts
+++ b/api/src/couchdb/index.ts
@@ -650,7 +650,15 @@ export const initialiseDbAndKeys = async ({
 };
 
 /**
- * Initialises and then migrates all databases!
+ * Initialises and then migrates all databases.
+ *
+ * Uses a **single** `migrateDbs` call over every platform handle (including
+ * teams), plus each project’s data and metadata DB, so global migrations and
+ * `allBatchHandles()` / `allHandlesForType()` in global `run`) always see one combined batch.
+ *
+ * `getAllProjectsDirectory` runs **before** any Couch migrations execute, so
+ * project documents on disk must stay **backwards compatible** enough to list
+ * projects and resolve `dataDb` / `metadataDb` (see docstring there).
  */
 export const initialiseAndMigrateDBs = async ({
   force = false,
@@ -662,7 +670,13 @@ export const initialiseAndMigrateDBs = async ({
 }) => {
   await initialiseDbAndKeys({force, pushKeys});
 
-  let dbs: {dbType: DATABASE_TYPE; dbName: string; db: DatabaseInterface}[] = [
+  const migrationsDb = getMigrationDb();
+
+  const platformDbs: {
+    dbType: DATABASE_TYPE;
+    dbName: string;
+    db: DatabaseInterface;
+  }[] = [
     {db: getAuthDB(), dbType: DatabaseType.AUTH, dbName: AUTH_DB_NAME},
     {
       db: getDirectoryDB(),
@@ -681,22 +695,22 @@ export const initialiseAndMigrateDBs = async ({
       dbType: DatabaseType.TEMPLATES,
       dbName: TEMPLATES_DB_NAME,
     },
+    {db: getTeamsDB(), dbType: DatabaseType.TEAMS, dbName: TEAMS_DB_NAME},
   ];
 
-  // Migrate these first
-  const migrationsDb = getMigrationDb();
-  await migrateDbs({dbs, migrationDb: migrationsDb, userId: 'system'});
 
-  // Now migrate all data/metadata DBs
   const projects = await getAllProjectsDirectory();
-  dbs = [];
+  const projectDbs: {
+    dbType: DATABASE_TYPE;
+    dbName: string;
+    db: DatabaseInterface;
+  }[] = [];
 
   for (const project of projects) {
-    // Project ID
     const projectId = project._id;
     const dataDb = (await getDataDb(projectId)) as DatabaseInterface;
     const metadataDb = (await getMetadataDb(projectId)) as DatabaseInterface;
-    dbs.concat([
+    projectDbs.push(
       {
         db: dataDb,
         dbType: DatabaseType.DATA,
@@ -706,10 +720,15 @@ export const initialiseAndMigrateDBs = async ({
         db: metadataDb,
         dbType: DatabaseType.METADATA,
         dbName: metadataDb.name,
-      },
-    ]);
+      }
+    );
   }
-  await migrateDbs({dbs, migrationDb: migrationsDb, userId: 'system'});
+
+  await migrateDbs({
+    dbs: [...platformDbs, ...projectDbs],
+    migrationDb: migrationsDb,
+    userId: 'system',
+  });
 
   // For users, we also establish an admin user, if not already present
   // do this after all migrations so we know the db is up to date

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -196,6 +196,15 @@ export const clearTemplateIdFromProjectsReferencingTemplate = async (
 /**
  * getAllProjects - get the internal project documents that reference
  * the project databases that the front end will connnect to
+ *
+ * **Startup / migrations:** `initialiseAndMigrateDBs` calls this **before**
+ * `migrateDbs` runs, to build the list of per-project `DATA` / `METADATA`
+ * handles. Project rows must therefore remain **backwards compatible** at every
+ * on-disk schema revision: `allDocs` filtering and fields used here (and by
+ * `getDataDb` / `getMetadataDb`, which read `dataDb` / `metadataDb` or legacy
+ * `data_db` / `metadata_db`) must still work until migrations have caught up.
+ * Prefer additive fields, keep connection info readable under old shapes, or
+ * use a short compatibility shim in this layer when changing project records.
  */
 export const getAllProjectsDirectory = async (): Promise<ProjectDocument[]> => {
   const projectsDb = localGetProjectsDb();

--- a/docs/developer/docs/source/markdown/CouchMigrations.md
+++ b/docs/developer/docs/source/markdown/CouchMigrations.md
@@ -2,18 +2,23 @@
 
 ## Overview
 
-In `library/data-model/src/data-storage/migration` is a structured framework for managing database schema evolution across multiple PouchDB databases in our application. It provides a systematic way to apply incremental changes to database structures while maintaining data integrity and tracking migration history.
+The Couch / Pouch migration framework lives under:
+
+`library/data-model/src/data_storage/migrations/`
+
+It manages **schema evolution** across the many CouchDB databases FAIMS uses (people, projects, per-project data and metadata, etc.). It tracks a **numeric version per physical database** in a dedicated **migrations** database, applies **per-document** transforms, and supports **global** steps that need several DB connections in one atomic operation.
 
 Includes:
 
-- Version-controlled database schemas
-- Incremental, one-way migrations
-- Comprehensive logging of migration activities
-- Batch processing to handle large datasets efficiently
-- Error handling with detailed issue reporting
-- Health status tracking for each database
+- Version-controlled database schemas (`DB_TARGET_VERSIONS` per `DatabaseType`)
+- **Individual** migrations: one step per physical DB (`DB_MIGRATIONS`, always `from → from+1`)
+- **Global** migrations: coordinated jumps across types (`GLOBAL_MIGRATIONS` in `globalMigrations.ts`)
+- Comprehensive logging (`migrationLog` on each DB’s migration document; globals may set `globalMigrationId`)
+- Batch processing inside each DB for large `allDocs` scans
+- Error handling with detailed issue reporting; `not-healthy` status when a DB’s migration fails
+- Static **network invariants** (`migrationNetworkInvariants.ts`) so there is a unique path from default to target version and globals cannot overlap individuals in conflicting ways
 
-The system maintains a separate migration metadata database that tracks the version and migration history of each application database, ensuring that migrations are applied exactly once and in the correct sequence.
+The migrations **metadata** database stores one document per `(DatabaseType, dbName)` pair, recording `version`, `status`, and `migrationLog` history.
 
 ## Core Concepts
 
@@ -31,6 +36,7 @@ export enum DatabaseType {
   PEOPLE = 'PEOPLE',
   PROJECTS = 'PROJECTS',
   TEMPLATES = 'TEMPLATES',
+  TEAMS = 'TEAMS',
 }
 ```
 
@@ -41,9 +47,25 @@ Each database type has:
 - A **default version**: The assumed starting point for new databases
 - A **target version**: The latest version that databases should be migrated to
 
-### Migration Path
+### Migration path (individual vs global)
 
-Migrations are defined as incremental steps from one version to the next (e.g., v1 to v2). The system ensures there are no gaps in migration paths.
+**Individual** migrations in `DB_MIGRATIONS` are always a **single version increment** (`to === from + 1`). For each database type, the path from `defaultVersion` to `targetVersion` may consist only of those steps, or include **global** jumps registered in `GLOBAL_MIGRATIONS`.
+
+**Global** migrations declare one or more **participants** (`dbType`, `from`, `to`, `multiplicity`). Each `dbType` appears at most once per global so matching is deterministic. Each participant is a version jump for that type (not limited to `+1`). A global’s `run(ctx)` receives matched handles via `GlobalMigrationRunContext.handles(dbType)` / `getUnique(dbType)`, and every physical DB in the batch by type via `allHandlesForType(dbType)` (see `globalMigrationTypes.ts` and `globalMigrationResolver.ts`).
+
+**`multiplicity`**
+
+- **`single`**: In the `migrateDbs` batch there must be exactly one physical DB of that type still behind target and at `from`. Use for server-wide singletons (directory, projects list, people, …) when the batch contains one handle of that type.
+- **`all-of-type`**: Every physical DB of that type in the **same batch** that is still behind target must be at `from`, and all are upgraded together. Use when the batch lists many `METADATA` or `DATA` DBs (one per project) and the step must apply to **all** of them in that call, not a subset.
+
+At runtime, `migrateDbs` (in `migrationService.ts`) **repeatedly**:
+
+1. Runs **consecutive individual** steps for each DB that still needs work (while a `DB_MIGRATIONS` row exists for `currentVersion → currentVersion+1`).
+2. If no individual progress is possible anywhere, tries the first matching **global** from `GLOBAL_MIGRATIONS` (see `findApplicableGlobalMigration`). Globals are rejected if they would only touch a **subset** of same-type DBs still needing work in the batch.
+
+### Static network checks
+
+`validateConfiguredMigrationNetwork()` in `migrationNetworkInvariants.ts` is used from tests (and should be kept green in CI): it checks duplicate individual edges, overlap between globals and individuals inside a global’s span, duplicate global ids, duplicate `dbType` rows within one global’s `participants`, and that each `DatabaseType` has a **unique** route from default to target using only allowed edges. See `tests/migrationNetworkInvariants.test.ts`.
 
 ### Migration Functions
 
@@ -66,7 +88,7 @@ To add a new migration, follow these steps:
 
 ### 1. Update Target Versions
 
-First, update the `DB_TARGET_VERSIONS` constant in `migrations.ts` to reflect the new target version:
+First, update the `DB_TARGET_VERSIONS` constant in `library/data-model/src/data_storage/migrations/migrations.ts` to reflect the new target version:
 
 ```typescript
 export const DB_TARGET_VERSIONS: {
@@ -118,7 +140,7 @@ Important guidelines for migration functions:
 
 ### 3. Register the Migration
 
-Add your migration to the `DB_MIGRATIONS` array in `migrations.ts`:
+Add your migration to the `DB_MIGRATIONS` array in the same `migrations.ts` file:
 
 ```typescript
 export const DB_MIGRATIONS: MigrationDetails[] = [
@@ -135,13 +157,19 @@ export const DB_MIGRATIONS: MigrationDetails[] = [
 
 Ensure that:
 
-- The `from` version matches the previous target version
-- The `to` version matches the new target version
+- `from` and `to` are consecutive (`to === from + 1`) for individual migrations
+- The chain from `defaultVersion` to `targetVersion` remains valid (run `validateConfiguredMigrationNetwork()` or the Jest suite)
 - The description clearly explains the purpose of the migration
 
 ### 4. Write Tests
 
-Add test cases to verify your migration works correctly. Tests should be added in `migrations/migrations.test.ts` as cases with the following format:
+Add test cases to verify your migration works correctly:
+
+- Per-function examples: `library/data-model/tests/migrations.test.ts` (`MIGRATION_TEST_CASES` pattern described below)
+- Service / `migrateDbs` behaviour: `library/data-model/tests/migrationService.test.ts`
+- Migration graph invariants: `library/data-model/tests/migrationNetworkInvariants.test.ts`
+
+Example structure for document-level migration tests:
 
 ```typescript
 /**
@@ -430,17 +458,262 @@ export const dataV2toV3Migration: MigrationFunc = doc => {
 };
 ```
 
-## Migration Process Workflow
+## Adding a global (cross-database) migration
 
-1. **Initialisation**: The system checks if migration documents exist for each database, creating them if needed
-2. **Version Check**: Each database's current version is compared to its target version
-3. **Migration Planning**: Required migration steps are identified in sequence
-4. **Execution**: Migrations are applied one at a time, with detailed logging
-5. **Completion**: Migration documents are updated with results and status
+Use this when a change **cannot** be expressed as “read one doc from one DB, return update/delete” (e.g. copying fields from a per-project `METADATA` DB into a row in `PROJECTS`).
 
-The migration system handles common challenges like:
+1. Add an entry to `GLOBAL_MIGRATIONS` in `library/data-model/src/data_storage/migrations/globalMigrations.ts` with a stable `id`, `description`, `participants`, and async `run(ctx)`.
+2. Implement `run` using `GlobalMigrationRunContext`: **`ctx.handles(DatabaseType.X)`** / **`ctx.getUnique(DatabaseType.X)`** for **participant** types; **`ctx.allHandlesForType(DatabaseType.X)`** for every physical DB of that type in the **`migrateDbs`** batch (including non-participants such as `PEOPLE`, or all `DATA` / `METADATA` notebook DBs when you are not matching them as participants). **`ctx.allBatchHandles()`** is still the full raw list if you need it. Each `dbType` may appear **at most once** in `participants`, so matched lookup is deterministic.
+3. Ensure **no** individual `DB_MIGRATIONS` row exists for any version **inside** a participant’s `[from, to)` for that `dbType` (enforced by `validateGlobalMigrationsAgainstIndividuals`).
+4. Choose `single` vs `all-of-type` per participant row (see **Migration path** above).
 
-- Batch processing for large databases
-- Graceful error handling with detailed logging
-- Preserving document metadata during transformation
-- Tracking migration history and database health
+After editing globals or targets, run the data-model tests so `validateConfiguredMigrationNetwork()` stays valid.
+
+## Migration process workflow (`migrateDbs`)
+
+1. **Load or create** migration documents for each `{ dbType, dbName }` in the `dbs` array (`migrationService.ts` / `getOrCreateMigrationDoc`).
+2. **Loop** until every handle is at its `DB_TARGET_VERSIONS[dbType].targetVersion` (or a DB is left `not-healthy` after a failed attempt):
+   - For each healthy DB behind target, apply **as many consecutive individual steps** as exist (`applyIndividualMigrationChain`).
+   - If nothing progressed, try the first **global** whose participants all match current versions; `run` then bumps each participant’s migration `version` and appends log lines (with `globalMigrationId` when present).
+3. **Logging**: Individual chains append one log entry per attempted chain; globals append one entry per participant DB.
+
+The system also:
+
+- Processes documents in batches per DB (`performMigration`)
+- Preserves `_id` / `_rev` on updates unless deliberately removing a doc
+- Records failures on the migration document and skips further automatic work on `not-healthy` DBs in the same run
+
+## Related documentation
+
+- **Notebook JSON migrations** (schema inside project/template payloads): `NotebookMigrations.md` — separate from Couch per-DB version numbers.
+- **Couch database layout** (what each DB stores): `api/doc/DATABASE.md` (includes a short note on migration metadata).
+
+---
+
+## Walkthrough: simple individual vs complex global
+
+The examples below are **illustrative** (version numbers and field names are made up). They show the shape of work you would do in `migrations.ts`, `globalMigrations.ts`, and the API that calls `migrateDbs`. Always align with real types in `projectsDB`, `templatesDB`, `peopleDB`, etc.
+
+### A. Simple change — individual migration (new field from an old one)
+
+**Goal:** On every document in the `templates` database, add a derived `slug` string from the existing `name` field when moving **v4 → v5** (illustrative next step after today’s `TemplateV4` wire shape in `templatesDB/types.ts`).
+
+Follow the same stacking pattern as existing `TemplateV1Schema` … `TemplateV4Schema`: each Couch version gets an explicit type; the **current** exported `TemplateDBFieldsSchema` / `TemplateDBFields` should match the latest version consumers expect **after** the migration has run everywhere.
+
+**1. Add the new wire type** in `library/data-model/src/data_storage/templatesDB/types.ts`:
+
+```typescript
+// V5 — URL-safe slug for listings (illustrative)
+export const TemplateV5Schema = TemplateV4Schema.extend({
+  slug: z.string().min(1),
+});
+export type TemplateV5Fields = z.infer<typeof TemplateV5Schema>;
+export type TemplateV5Document = PouchDB.Core.Document<TemplateV5Fields>;
+
+// Current (V5) — point “live” schema exports at the new version
+export const TemplateDBFieldsSchema = TemplateV5Schema;
+export type TemplateDBFields = z.infer<typeof TemplateDBFieldsSchema>;
+// …update TemplateDocumentSchema / ExistingTemplateDocumentSchema to extend
+// TemplateDBFieldsSchema.shape, same as for V4
+```
+
+Until production has caught up, some codebases keep the public `TemplateDBFields` on V4 and only switch after deploy; the important part is that the **migration function’s** input type is the **pre**-migration version (V4) and the written document matches V5.
+
+**2. Bump the Couch migration target** in `library/data-model/src/data_storage/migrations/migrations.ts`:
+
+```typescript
+[DatabaseType.TEMPLATES]: {defaultVersion: 1, targetVersion: 5}, // was 4 → now 5
+```
+
+**3. Implement the migration function** in `migrations.ts` (or imported from a small module), following `MigrationFunc`. Import the **previous** wire type from `templatesDB/types.ts` (e.g. `TemplateV4Fields`) and cast each `doc` to that shape so TypeScript matches what is still on disk **before** the step runs:
+
+```typescript
+import type {TemplateV4Fields} from '../templatesDB/types'; // adjust path
+
+const templatesV4toV5Migration: MigrationFunc = doc => {
+  const input = doc as unknown as TemplateV4Fields & PouchDB.Core.ExistingDocument<unknown>;
+
+  const slug = String(input.name ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+
+  return {
+    action: 'update',
+    updatedRecord: {
+      ...input,
+      slug,
+    },
+  };
+};
+```
+
+**4. Register the single-step edge** in `DB_MIGRATIONS` (must be exactly `from+1`):
+
+```typescript
+{
+  dbType: DatabaseType.TEMPLATES,
+  from: 4,
+  to: 5,
+  description: 'Adds slug derived from name',
+  migrationFunction: templatesV4toV5Migration,
+},
+```
+
+**5. Test** — add a row to `MIGRATION_TEST_CASES` in `library/data-model/tests/migrations.test.ts` (input v4-shaped doc, expected v5 doc with `slug`).
+
+**6. Run** — `migrateDbs` receives the templates Pouch handle; it runs `performMigration` so **each non-design document** is passed through the function. No other DB is involved.
+
+---
+
+### B. Complex change — global migration (projects + templates, read people for context)
+
+**Goal:** In **one** coordinated step, normalize audit fields on **both** the single `projects` Couch DB and the single `templates` Couch DB. Values such as `createdByUserId` / `createdAt` should be filled from a **conductor admin** id and timestamp **unless** the document already has a `last_updated_by_user_id` that matches a real person — in that case, copy display metadata from the **people** DB (read-only lookups). After the step, bump **projects** v10→v11 and **templates** v7→v8.
+
+This cannot be done as two independent per-document migrations if the rules depend on **cross-checking both DBs and people in one pass** (and you want one atomic migration log step per DB).
+
+The numbers below are **fictional**; in the real tree today projects are at **v3** and templates at **v4**—adapt the same steps to your actual `from` / `to`.
+
+**1. Add new document types for the post-migration wire shape**
+
+- **`library/data-model/src/data_storage/projectsDB/types.ts`** — Introduce the next version type the same way `ProjectV2Fields` / `ProjectV3Fields` are layered (manual `type` aliases today). Example:
+
+```typescript
+/** Projects DB v10 (before this global) — illustrative */
+export type ProjectV10Fields = ProjectV3Fields; // …or your real prior shape
+
+/** Projects DB v11 — adds audit fields written by the global */
+export type ProjectV11Fields = ProjectV10Fields & {
+  createdByUserId?: string;
+  createdAt?: string;
+  migratedAuditDisplayName?: string;
+};
+export type ProjectV11Document = PouchDB.Core.Document<ProjectV11Fields>;
+
+/** Current stored shape after rollout */
+export type ProjectDBFields = ProjectV11Fields;
+export type ProjectDocument = PouchDB.Core.Document<ProjectDBFields>;
+export type ExistingProjectDocument =
+  PouchDB.Core.ExistingDocument<ProjectDBFields>;
+```
+
+- **`library/data-model/src/data_storage/templatesDB/types.ts`** — Mirror the `TemplateV4Schema.extend` pattern:
+
+```typescript
+export const TemplateV8Schema = TemplateV7Schema.extend({
+  createdByUserId: z.string().optional(),
+  createdAt: z.string().optional(),
+  migratedAuditDisplayName: z.string().optional(),
+});
+export type TemplateV8Fields = z.infer<typeof TemplateV8Schema>;
+// Repoint current exports: TemplateDBFieldsSchema = TemplateV8Schema, etc.
+```
+
+Use **`ProjectV10Fields` / `TemplateV7Fields`** (whatever is *currently* last on disk) as the **input** shape when reading rows inside `run`; `put` payloads should satisfy **`ProjectV11Fields` / `TemplateV8Fields`**. After the global succeeds, the migration service bumps each participant’s **Couch migration** `version` (`10→11`, `7→8`)—that is separate from any per-document `version` counter your template schema may already define.
+
+**2. Bump Couch migration targets** in `migrations.ts` for **both** types (and do **not** add individual `DB_MIGRATIONS` rows for `10→11` or `7→8`—the **global** owns those spans; see `validateGlobalMigrationsAgainstIndividuals`).
+
+```typescript
+[DatabaseType.PROJECTS]: {defaultVersion: 1, targetVersion: 11},
+[DatabaseType.TEMPLATES]: {defaultVersion: 1, targetVersion: 8},
+```
+
+**3. Register a global migration** in `globalMigrations.ts`:
+
+**How matched handles relate to `participants`**
+
+- Each row in `definition.participants` uses a distinct `dbType` (validated at startup).
+- After a match, `ctx.matchedByDbType` maps each participant `dbType` to the `LoadedDbHandle[]` that satisfied that row (`from`, `multiplicity`). Use **`ctx.handles(DatabaseType.PROJECTS)`** or **`ctx.getUnique(DatabaseType.PROJECTS)`** when `multiplicity` is `single` (exactly one handle). For DB types that are **only** in the batch for context (e.g. `PEOPLE`), or when you want **every** notebook `DATA` handle regardless of participant matching, use **`ctx.allHandlesForType(DatabaseType.…)`** instead of manually filtering **`allBatchHandles()`**.
+- Each `LoadedDbHandle` carries **`db`** (the Pouch/Couch interface), **`dbName`**, **`dbType`**, and **`migrationDoc`** (the migration-tracking document for *that* physical DB). `run` uses `.db` to read and write documents. In TypeScript, **`db` is `DatabaseInterface`** (same type each `migrateDbs` `dbs` entry passes). Document payloads inside `allDocs` rows are still **per-DB shapes**—you normally cast or narrow those (e.g. to your `ProjectV10Fields`) rather than expecting a single global doc type.
+
+```typescript
+{
+  id: 'audit-fields-from-people-2026',
+  description:
+    'Fill audit fields on project and template docs using people DB lookups',
+  participants: [
+    {
+      dbType: DatabaseType.PROJECTS,
+      from: 10,
+      to: 11,
+      multiplicity: 'single',
+    },
+    {
+      dbType: DatabaseType.TEMPLATES,
+      from: 7,
+      to: 8,
+      multiplicity: 'single',
+    },
+  ],
+  run: async ctx => {
+    const projectsParticipant = ctx.getUnique(DatabaseType.PROJECTS);
+    const templatesParticipant = ctx.getUnique(DatabaseType.TEMPLATES);
+
+    const peopleInBatch = ctx.allHandlesForType(DatabaseType.PEOPLE);
+    if (peopleInBatch.length === 0) {
+      return {
+        status: 'failure',
+        issues: ['This global requires PEOPLE in the migrateDbs batch for lookups'],
+      };
+    }
+    const peopleDb = peopleInBatch[0].db;
+    const adminId = ctx.userId; // or resolve from env / config
+
+    type DocRow = PouchDB.Core.ExistingDocument<Record<string, unknown>>;
+    const enrich = async (
+      db: DatabaseInterface,
+      pickUserId: (doc: DocRow) => string | undefined
+    ) => {
+      const res = await db.allDocs({include_docs: true});
+      for (const row of res.rows) {
+        if (!row.doc || row.id.startsWith('_design/')) continue;
+        const doc = row.doc as DocRow;
+        const uid = pickUserId(doc);
+        let displayName = 'Unknown';
+        if (uid) {
+          try {
+            const person = (await peopleDb.get(uid)) as {name?: string};
+            displayName = person.name ?? displayName;
+          } catch {
+            /* missing person doc */
+          }
+        }
+        await db.put({
+          ...doc,
+          createdByUserId: doc.createdByUserId ?? adminId,
+          createdAt: doc.createdAt ?? new Date().toISOString(),
+          migratedAuditDisplayName: displayName,
+        });
+      }
+    };
+
+    try {
+      await enrich(projectsParticipant.db, d =>
+        typeof d.last_updated_by_user_id === 'string'
+          ? d.last_updated_by_user_id
+          : undefined
+      );
+      await enrich(templatesParticipant.db, d =>
+        typeof d.last_updated_by_user_id === 'string'
+          ? d.last_updated_by_user_id
+          : undefined
+      );
+      return {status: 'success'};
+    } catch (e: unknown) {
+      return {
+        status: 'failure',
+        issues: [e instanceof Error ? e.message : String(e)],
+      };
+    }
+  },
+},
+```
+
+In this example, **PEOPLE** is not listed under `participants`, so its migration version does **not** change when this global runs; it is only present so `run` can query it via `ctx.allHandlesForType(DatabaseType.PEOPLE)` (typically one handle). **PROJECTS** and **TEMPLATES** must each be the only healthy, not-yet-at-target DB of that type in this batch (`multiplicity: 'single'`), and both must sit exactly at `from` when the global fires.
+
+**5. Invariants** — after editing:
+
+- Run `pnpm test` in `library/data-model` so `validateConfiguredMigrationNetwork()` passes (unique path, no overlapping individuals inside global spans, no ambiguous edges).
+- Ensure the production `migrateDbs` invocation that should run this global actually includes **projects**, **templates**, and **people** in the same `dbs` array for that pass (subset checks apply only to **participant** types; you still must pass people if `run` reads it).
+
+This pattern — **participants = DBs whose migration version advances**, **other handles in the batch = read-only context** — is the usual way to “use people while upgrading projects and templates in one go.”

--- a/docs/developer/docs/source/markdown/DeployingAWSStack.md
+++ b/docs/developer/docs/source/markdown/DeployingAWSStack.md
@@ -737,6 +737,8 @@ In my case, deployment was successful in about 10 minutes.
 
 To get started, you'll need to run the DB migration.
 
+For how Couch migrations work (individual vs global steps, `migrateDbs`, and adding new versions), see [CouchMigrations.md](CouchMigrations.md).
+
 Before doing this, you'll need to find the auto generated DB credentials. Navigate to AWS Secrets Manager, and find the secret with a name such as `couchdbCouchDBAdminPassword-ABCD1234`. Click on it, and retrieve the secret value.
 
 **Warning**: This is the root credentials for the DB. Do NOT share this, or leave it in a vulnerable location.

--- a/docs/developer/docs/source/markdown/NotebookMigrations.md
+++ b/docs/developer/docs/source/markdown/NotebookMigrations.md
@@ -1,7 +1,9 @@
 # Notebook Migrations
 
-`data-model/src/data_storage/migrations/notebookMigrations` implements a basic
+`library/data-model/src/data_storage/migrations/notebookMigrations` implements a basic
 migration for notebooks.
+
+This is **not** the same system as **Couch per-database versioning** (people, projects, metadata DBs, etc.). For that, see [CouchMigrations.md](CouchMigrations.md).
 
 Each notebook has a property `schema_version` in metadata that records the
 schema version that it conforms to. In very early versions this was missing. In
@@ -19,3 +21,7 @@ but does so in an idempotent manner meaning multiple migrations would be safe.
 Future migrations will require some planning and design work to ensure that we
 can manage versions cleanly and migrate through different versions. This will
 need to be done when we make future updates to the notebook format.
+
+## See also
+
+- [CouchMigrations.md](CouchMigrations.md) — `migrateDbs`, `DB_MIGRATIONS`, `GLOBAL_MIGRATIONS`, migration metadata database.

--- a/library/data-model/src/data_storage/migrations/globalMigrationResolver.ts
+++ b/library/data-model/src/data_storage/migrations/globalMigrationResolver.ts
@@ -1,0 +1,235 @@
+import {
+  GlobalMigrationDefinition,
+  GlobalMigrationMatchedHandles,
+  GlobalMigrationRunContext,
+  LoadedDbHandle,
+} from './globalMigrationTypes';
+import {DB_TARGET_VERSIONS} from './migrations';
+import {DatabaseType} from './types';
+
+/**
+ * Determines if a migration document for a given database is up to date with its target version.
+ *
+ * @param doc - An object representing the migration document, containing the database type and its current version.
+ * @returns True if the document's version matches the target version for its database type; otherwise, false.
+ */
+function isMigrationDocUpToDate(doc: {
+  dbType: DatabaseType;
+  version: number;
+}): boolean {
+  return doc.version === DB_TARGET_VERSIONS[doc.dbType].targetVersion;
+}
+
+/**
+ * Ensures a matched global migration is not applied to only some databases of
+ * a participant type when other healthy, not-yet-at-target databases of that
+ * type exist in the same batch (non-idempotent / ambiguous runs).
+ */
+export function assertGlobalMigrationCoversEveryStaleParticipantDbInBatch(
+  handles: LoadedDbHandle[],
+  definition: GlobalMigrationDefinition,
+  matchedByDbType: GlobalMigrationMatchedHandles
+): void {
+  const handleKey = (h: LoadedDbHandle) => `${h.dbType}:${h.dbName}`;
+
+  for (const p of definition.participants) {
+    const matched = [...(matchedByDbType.get(p.dbType) ?? [])];
+
+    const staleHealthy = handles.filter(
+      h =>
+        h.dbType === p.dbType &&
+        h.migrationDoc.status === 'healthy' &&
+        !isMigrationDocUpToDate(h.migrationDoc)
+    );
+
+    if (p.multiplicity === 'single') {
+      if (staleHealthy.length !== 1) {
+        throw new Error(
+          `Global migration "${definition.id}" participant ${p.dbType} (single) requires exactly one healthy, not-up-to-date database in this batch; found ${staleHealthy.length}. ` +
+            `Refusing to run on a subset of databases for this type.`
+        );
+      }
+      if (staleHealthy[0].migrationDoc.version !== p.from) {
+        throw new Error(
+          `Global migration "${definition.id}" participant ${p.dbType} (single) requires that database at v${p.from}; found v${staleHealthy[0].migrationDoc.version} on ${staleHealthy[0].dbName}.`
+        );
+      }
+      if (
+        matched.length !== 1 ||
+        handleKey(matched[0]) !== handleKey(staleHealthy[0])
+      ) {
+        throw new Error(
+          `Global migration "${definition.id}" participant ${p.dbType} (single) internal match mismatch; refusing to run.`
+        );
+      }
+      continue;
+    }
+
+    // all-of-type
+    if (staleHealthy.length < 1) {
+      throw new Error(
+        `Global migration "${definition.id}" participant ${p.dbType} (all-of-type) expected at least one stale healthy database.`
+      );
+    }
+
+    for (const h of staleHealthy) {
+      if (h.migrationDoc.version !== p.from) {
+        throw new Error(
+          `Global migration "${definition.id}" participant ${p.dbType} (all-of-type) requires every not-up-to-date healthy database of this type in the batch to be at v${p.from}; ` +
+            `${h.dbName} is at v${h.migrationDoc.version}. Refusing to run on a subset.`
+        );
+      }
+    }
+
+    const matchedKeys = new Set(matched.map(handleKey));
+    const staleKeys = new Set(staleHealthy.map(handleKey));
+    if (matchedKeys.size !== staleKeys.size) {
+      throw new Error(
+        `Global migration "${definition.id}" participant ${p.dbType} (all-of-type): matched count (${matched.length}) differs from stale healthy count (${staleHealthy.length}).`
+      );
+    }
+    for (const k of staleKeys) {
+      if (!matchedKeys.has(k)) {
+        throw new Error(
+          `Global migration "${definition.id}" participant ${p.dbType} (all-of-type) must include every stale healthy database of this type in the batch. Refusing partial application.`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Removes duplicate LoadedDbHandles, keeping only the first instance of each unique (dbType, dbName) pair.
+ * Relies on the deduplication property of JavaScript Sets by stringifying keys.
+ * @param handles - Array of LoadedDbHandle objects (possibly with duplicates).
+ * @returns Array of unique LoadedDbHandle objects, preserving first occurrences.
+ */
+function dedupeHandles(handles: LoadedDbHandle[]): LoadedDbHandle[] {
+  const uniqueMap = new Map<string, LoadedDbHandle>();
+  for (const h of handles) {
+    const key = `${h.dbType}:${h.dbName}`;
+    if (!uniqueMap.has(key)) {
+      uniqueMap.set(key, h);
+    }
+  }
+  return Array.from(uniqueMap.values());
+}
+
+/**
+ * Builds the {@link GlobalMigrationRunContext} passed into
+ * {@link GlobalMigrationDefinition.run} after a global migration has been
+ * matched against the current batch.
+ *
+ * @param definition - The global migration being executed.
+ * @param matchedByDbType - Map from each participant `dbType` to the Couch
+ *   handle(s) that satisfied that participant row at match time.
+ * @param userId - Actor recorded on migration logs.
+ * @param migrationDb - Migrations Couch DB (same as `migrateDbs`).
+ * @param allBatchHandles - Every `{ dbType, dbName, db, migrationDoc }` from
+ *   the current `migrateDbs` call, including DBs not in this global step.
+ */
+export function createGlobalMigrationRunContext({
+  definition,
+  matchedByDbType,
+  userId,
+  migrationDb,
+  allBatchHandles,
+}: {
+  definition: GlobalMigrationDefinition;
+  matchedByDbType: GlobalMigrationMatchedHandles;
+  userId: string;
+  migrationDb: GlobalMigrationRunContext['migrationDb'];
+  allBatchHandles: LoadedDbHandle[];
+}): GlobalMigrationRunContext {
+  const flatMatched = dedupeHandles([...matchedByDbType.values()].flat());
+
+  return {
+    userId,
+    migrationDb,
+    definition,
+    matchedByDbType,
+
+    handles(dbType: DatabaseType) {
+      return matchedByDbType.get(dbType) ?? [];
+    },
+
+    allHandles() {
+      return flatMatched;
+    },
+
+    allBatchHandles() {
+      return allBatchHandles;
+    },
+
+    allHandlesForType(dbType: DatabaseType) {
+      return allBatchHandles.filter(h => h.dbType === dbType);
+    },
+
+    listByType(dbType: DatabaseType) {
+      return [...(matchedByDbType.get(dbType) ?? [])];
+    },
+
+    firstOfType(dbType: DatabaseType) {
+      const list = matchedByDbType.get(dbType);
+      return list?.[0];
+    },
+
+    getUnique(dbType: DatabaseType) {
+      const arr = matchedByDbType.get(dbType) ?? [];
+      if (arr.length !== 1) {
+        throw new Error(
+          `Global migration "${definition.id}" expected exactly one ${dbType} among matched handles, found ${arr.length}.`
+        );
+      }
+      return arr[0];
+    },
+  };
+}
+
+/**
+ * Returns the first global migration definition that matches the current batch,
+ * or null. Matching is order-dependent: earlier definitions win.
+ */
+export function findApplicableGlobalMigration(
+  handles: LoadedDbHandle[],
+  globalDefs: GlobalMigrationDefinition[]
+): {
+  definition: GlobalMigrationDefinition;
+  matchedByDbType: GlobalMigrationMatchedHandles;
+} | null {
+  for (const definition of globalDefs) {
+    const matchedByDbType = new Map<DatabaseType, LoadedDbHandle[]>();
+    let ok = true;
+
+    for (const p of definition.participants) {
+      const pool = handles.filter(
+        h => h.dbType === p.dbType && h.migrationDoc.version === p.from
+      );
+
+      if (p.multiplicity === 'single') {
+        if (pool.length !== 1) {
+          ok = false;
+          break;
+        }
+        matchedByDbType.set(p.dbType, [pool[0]]);
+      } else {
+        if (pool.length < 1) {
+          ok = false;
+          break;
+        }
+        matchedByDbType.set(p.dbType, pool);
+      }
+    }
+
+    if (ok) {
+      assertGlobalMigrationCoversEveryStaleParticipantDbInBatch(
+        handles,
+        definition,
+        matchedByDbType
+      );
+      return {definition, matchedByDbType};
+    }
+  }
+
+  return null;
+}

--- a/library/data-model/src/data_storage/migrations/globalMigrationTypes.ts
+++ b/library/data-model/src/data_storage/migrations/globalMigrationTypes.ts
@@ -1,0 +1,128 @@
+import {DatabaseInterface} from '../../types';
+import {MigrationsDB, MigrationsDBDocument} from '../migrationsDB';
+import {DATABASE_TYPE, DatabaseType} from './types';
+
+/**
+ * How a participant database is selected when matching a global migration.
+ *
+ * **Meaning**
+ *
+ * - `single`: In this `migrateDbs` batch there must be **exactly one** physical
+ *   Couch DB of that `dbType` that is still behind its target **and** sitting at
+ *   `from`. That one DB is the participant. If two (or zero) match, the global
+ *   does not apply—avoids “which directory did we mean?”.
+ * - `all-of-type`: **Every** physical DB of that `dbType` in the batch that is
+ *   still behind target must be at **the same** `from` version, and **all** of
+ *   them are upgraded together in this step. Use when the migration must run
+ *   once per logical “slice” of DBs (e.g. every `METADATA` DB in this batch).
+ *
+ * **How that maps to FAIMS `DatabaseType`**
+ *
+ * Types that are normally **one Couch DB per server** (directory, projects list,
+ * people, invites, templates, auth, …) almost always use `single` for that row:
+ * the batch for that `migrateDbs` call contains one handle of that type.
+ *
+ * Types where **many** Couch DBs exist (one **DATA** and one **METADATA** DB per
+ * project) use `all-of-type` when a global step must touch **every** project
+ * DB of that type **in the same batch** at once. If you only pass one project’s
+ * pair into `migrateDbs`, `all-of-type` means “all METADATA handles in *this*
+ * batch”, not literally every project on the server—batch composition defines
+ * the set.
+ */
+export type GlobalMigrationParticipantMultiplicity =
+  | 'single'
+  | 'all-of-type';
+
+export type GlobalMigrationParticipant = {
+  dbType: DATABASE_TYPE;
+  from: number;
+  to: number;
+  multiplicity: GlobalMigrationParticipantMultiplicity;
+};
+
+export type LoadedDbHandle = {
+  dbType: DatabaseType;
+  dbName: string;
+  db: DatabaseInterface;
+  migrationDoc: MigrationsDBDocument;
+};
+
+/**
+ * After a global matches, every {@link LoadedDbHandle} grouped by participant
+ * `dbType` (each type appears at most once in `definition.participants`).
+ */
+export type GlobalMigrationMatchedHandles = ReadonlyMap<
+  DatabaseType,
+  readonly LoadedDbHandle[]
+>;
+
+export type GlobalMigrationRunResult =
+  | {status: 'success'}
+  | {status: 'failure'; issues: string[]};
+
+/**
+ * Context passed to {@link GlobalMigrationDefinition.run} for one matched
+ * global migration step.
+ *
+ * Use {@link GlobalMigrationRunContext.handles} or {@link GlobalMigrationRunContext.getUnique}
+ * for **participant** types. For any type present in the `migrateDbs` batch
+ * (including non-participants such as `PEOPLE`, or every `DATA` / `METADATA`
+ * notebook DB), use {@link GlobalMigrationRunContext.allHandlesForType}.
+ * Each `dbType` may appear only once in `definition.participants`, so matched
+ * lookup is deterministic.
+ */
+export type GlobalMigrationRunContext = {
+  userId: string;
+  migrationDb: MigrationsDB;
+  definition: GlobalMigrationDefinition;
+  /** Matched Couch DBs for each participant `dbType` (same keys as participants). */
+  matchedByDbType: GlobalMigrationMatchedHandles;
+  /**
+   * Handles matched for this participant `dbType` (empty array if that type is
+   * not part of this global).
+   */
+  handles(dbType: DatabaseType): readonly LoadedDbHandle[];
+  /**
+   * Every {@link LoadedDbHandle} taking part in this global step, deduped by
+   * `(dbType, dbName)`.
+   */
+  allHandles(): LoadedDbHandle[];
+  /**
+   * The full list passed into `migrateDbs` for this invocation, including DBs
+   * that are not part of this global migration (e.g. other projects’ DBs).
+   */
+  allBatchHandles(): LoadedDbHandle[];
+  /**
+   * Every handle in the full `migrateDbs` batch with this `dbType` (zero, one,
+   * or many physical DBs — e.g. all `DATA` notebooks). Same filter as
+   * `allBatchHandles().filter(h => h.dbType === dbType)` with stable order.
+   * Use for read-only context DBs or updates that **do not** use that type as
+   * a global **participant** (participants use {@link handles} / {@link getUnique}).
+   */
+  allHandlesForType(dbType: DatabaseType): readonly LoadedDbHandle[];
+  /**
+   * Same as {@link handles} — retained for readability when filtering by type.
+   */
+  listByType(dbType: DatabaseType): LoadedDbHandle[];
+  /**
+   * First matched handle for this `dbType`, or `undefined` if none.
+   */
+  firstOfType(dbType: DatabaseType): LoadedDbHandle | undefined;
+  /**
+   * Exactly one matched handle for this `dbType`; throws if there are zero or
+   * several (e.g. `all-of-type` with multiple DBs — use {@link handles} instead).
+   */
+  getUnique(dbType: DatabaseType): LoadedDbHandle;
+};
+
+export type GlobalMigrationDefinition = {
+  /** Stable id stored on migration logs */
+  id: string;
+  description: string;
+  /**
+   * Each `dbType` may appear **at most once**. Order does not affect matching;
+   * use {@link GlobalMigrationRunContext.handles}(`dbType`) in `run`.
+   */
+  participants: GlobalMigrationParticipant[];
+  run: (ctx: GlobalMigrationRunContext) => Promise<GlobalMigrationRunResult>;
+};

--- a/library/data-model/src/data_storage/migrations/globalMigrations.ts
+++ b/library/data-model/src/data_storage/migrations/globalMigrations.ts
@@ -1,0 +1,12 @@
+import {GlobalMigrationDefinition} from './globalMigrationTypes';
+
+/**
+ * Cross-database migrations: each entry describes which database types move
+ * from which version to which, and a single `run` that receives every matched
+ * connection via {@link GlobalMigrationRunContext}.
+ *
+ * The migration service tries per-database individual steps first; only when no
+ * individual step can run for any database that still needs work will it
+ * consider entries here, in array order.
+ */
+export const GLOBAL_MIGRATIONS: GlobalMigrationDefinition[] = [];

--- a/library/data-model/src/data_storage/migrations/index.ts
+++ b/library/data-model/src/data_storage/migrations/index.ts
@@ -1,3 +1,7 @@
+export * from './globalMigrationTypes';
+export * from './globalMigrations';
+export * from './globalMigrationResolver';
+export * from './migrationNetworkInvariants';
 export * from './migrations';
 export * from './migrationService';
 export * from './types';

--- a/library/data-model/src/data_storage/migrations/migrationNetworkInvariants.ts
+++ b/library/data-model/src/data_storage/migrations/migrationNetworkInvariants.ts
@@ -1,0 +1,181 @@
+import {GLOBAL_MIGRATIONS} from './globalMigrations';
+import {DB_MIGRATIONS, DB_TARGET_VERSIONS} from './migrations';
+import {DATABASE_TYPES, DatabaseType, MigrationDetails} from './types';
+
+function individualStepAt(
+  dbType: DatabaseType,
+  fromVersion: number
+): MigrationDetails | undefined {
+  return DB_MIGRATIONS.find(
+    m =>
+      m.dbType === dbType &&
+      m.from === fromVersion &&
+      m.to === fromVersion + 1
+  );
+}
+
+type OutgoingKind = string;
+
+function outgoingFrom(
+  dbType: DatabaseType,
+  v: number
+): Array<{to: number; kind: OutgoingKind}> {
+  const out: Array<{to: number; kind: OutgoingKind}> = [];
+
+  const ind = individualStepAt(dbType, v);
+  if (ind) {
+    out.push({to: ind.to, kind: `individual(${ind.from}→${ind.to})`});
+  }
+
+  for (const g of GLOBAL_MIGRATIONS) {
+    for (const p of g.participants) {
+      if (p.dbType !== dbType || p.from !== v) {
+        continue;
+      }
+      out.push({to: p.to, kind: `global "${g.id}" (${p.from}→${p.to})`});
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Individual rows in {@link DB_MIGRATIONS}: each must be a single +1 step,
+ * and there must be no duplicate edges.
+ */
+export function validateIndividualMigrationNetwork(): void {
+  const seenKeys = new Set<string>();
+
+  for (const m of DB_MIGRATIONS) {
+    if (m.to !== m.from + 1) {
+      throw new Error(
+        `Individual migration must advance exactly one version (from=${m.from} to=${m.to}) for ${m.dbType}.`
+      );
+    }
+    const key = `${m.dbType}:${m.from}->${m.to}`;
+    if (seenKeys.has(key)) {
+      throw new Error(
+        `Duplicate individual migration edge ${key}; the migration network must have a unique path.`
+      );
+    }
+    seenKeys.add(key);
+  }
+}
+
+/**
+ * From each database type’s {@link DB_TARGET_VERSIONS} default to target, there
+ * must be exactly one acyclic route: at every version `v` with `v < target`,
+ * either zero outgoing edges would be unreachable, or more than one would be
+ * ambiguous. Outgoing edges are single-step individuals **or** global
+ * participant jumps registered in {@link GLOBAL_MIGRATIONS}.
+ */
+export function validateUniqueReachablePathPerDatabaseType(): void {
+  for (const dbType of DATABASE_TYPES) {
+    const {defaultVersion, targetVersion} = DB_TARGET_VERSIONS[dbType];
+    if (defaultVersion >= targetVersion) {
+      continue;
+    }
+
+    let v = defaultVersion;
+    const visited = new Set<number>();
+
+    while (v < targetVersion) {
+      if (visited.has(v)) {
+        throw new Error(
+          `Migration graph for ${dbType} returned to v${v}; edges must strictly increase version toward v${targetVersion}.`
+        );
+      }
+      visited.add(v);
+
+      const options = outgoingFrom(dbType, v);
+      if (options.length === 0) {
+        throw new Error(
+          `No migration edge from ${dbType} v${v} toward target v${targetVersion}. ` +
+            `Add an individual step or a global participant that starts at v${v}.`
+        );
+      }
+      if (options.length > 1) {
+        throw new Error(
+          `Ambiguous migration from ${dbType} v${v}: multiple outgoing edges (${options.map(o => o.kind).join('; ')}). ` +
+            `There must be only one unique path from default to target.`
+        );
+      }
+
+      const next = options[0].to;
+      if (next <= v) {
+        throw new Error(
+          `Invalid migration edge from ${dbType} v${v}: next version is v${next} (must be greater than v${v}).`
+        );
+      }
+      if (next > targetVersion) {
+        throw new Error(
+          `Migration from ${dbType} v${v} jumps to v${next}, past target v${targetVersion}.`
+        );
+      }
+      v = next;
+    }
+
+    if (v !== targetVersion) {
+      throw new Error(
+        `Internal error: ${dbType} migration walk ended at v${v} but target is v${targetVersion}.`
+      );
+    }
+  }
+}
+
+/**
+ * Each global migration must own the full version interval on every
+ * participant: no individual single-step may exist for any intermediate version,
+ * otherwise the resolver could take a non-unique route.
+ */
+export function validateGlobalMigrationsAgainstIndividuals(): void {
+  const seenIds = new Set<string>();
+
+  for (const g of GLOBAL_MIGRATIONS) {
+    if (seenIds.has(g.id)) {
+      throw new Error(`Duplicate global migration id "${g.id}".`);
+    }
+    seenIds.add(g.id);
+
+    const participantDbTypes = new Set<string>();
+    for (const p of g.participants) {
+      if (participantDbTypes.has(p.dbType)) {
+        throw new Error(
+          `Global migration "${g.id}" lists ${p.dbType} more than once in participants. Each database type may appear only once so matching is deterministic by type.`
+        );
+      }
+      participantDbTypes.add(p.dbType);
+    }
+
+    for (const p of g.participants) {
+      if (p.to <= p.from) {
+        throw new Error(
+          `Global migration "${g.id}" has invalid participant ${p.dbType} (${p.from} -> ${p.to}).`
+        );
+      }
+      for (let ver = p.from; ver < p.to; ver++) {
+        if (individualStepAt(p.dbType, ver)) {
+          throw new Error(
+            `Global migration "${g.id}" participant ${p.dbType} spans v${p.from}→v${p.to}, but an individual migration exists for v${ver}→v${ver + 1}. ` +
+              `Remove overlapping individuals or narrow the global range so the network has a unique path.`
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Validates {@link DB_MIGRATIONS} and {@link GLOBAL_MIGRATIONS} together:
+ * well-formed individual edges, no overlap between globals and individuals inside
+ * a global’s participant span, duplicate global ids, and a **unique** path from
+ * each type’s default version to its target using only those edges.
+ *
+ * Runtime subset checks for globals live in
+ * {@link assertGlobalMigrationCoversEveryStaleParticipantDbInBatch}.
+ */
+export function validateConfiguredMigrationNetwork(): void {
+  validateIndividualMigrationNetwork();
+  validateGlobalMigrationsAgainstIndividuals();
+  validateUniqueReachablePathPerDatabaseType();
+}

--- a/library/data-model/src/data_storage/migrations/migrationService.ts
+++ b/library/data-model/src/data_storage/migrations/migrationService.ts
@@ -6,6 +6,12 @@ import {
   MigrationsDBDocument,
   MigrationsDBFields,
 } from '../migrationsDB';
+import {
+  createGlobalMigrationRunContext,
+  findApplicableGlobalMigration,
+} from './globalMigrationResolver';
+import {GLOBAL_MIGRATIONS} from './globalMigrations';
+import {LoadedDbHandle} from './globalMigrationTypes';
 import {DB_MIGRATIONS, DB_TARGET_VERSIONS} from './migrations';
 import {
   DATABASE_TYPE,
@@ -144,6 +150,291 @@ export function identifyMigrations({
 }
 
 /**
+ * Returns the registered single-step individual migration (from → from+1), if any.
+ */
+export function findNextIndividualMigration(
+  dbType: DatabaseType,
+  fromVersion: number
+): MigrationDetails | null {
+  const next = DB_MIGRATIONS.find(
+    m =>
+      m.dbType === dbType &&
+      m.from === fromVersion &&
+      m.to === fromVersion + 1
+  );
+  return next ?? null;
+}
+
+async function getOrCreateMigrationDoc({
+  dbType,
+  dbName,
+  migrationDb,
+}: {
+  dbType: DATABASE_TYPE;
+  dbName: string;
+  migrationDb: MigrationsDB;
+}): Promise<MigrationsDBDocument> {
+  const migrationDocs = await migrationDb.query<MigrationsDBFields>(
+    MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+    {
+      key: [dbType, dbName],
+      include_docs: true,
+    }
+  );
+
+  if (migrationDocs.rows.length === 0) {
+    const defaultMigrationFields = buildDefaultMigrationDoc({
+      dbType,
+      dbName,
+    });
+    const response = await migrationDb.post(defaultMigrationFields);
+    return await migrationDb.get(response.id);
+  }
+
+  return migrationDocs.rows[0].doc!;
+}
+
+/**
+ * Applies zero or more consecutive individual (per-document) migrations until
+ * the next version step is missing or the database reaches its target version.
+ *
+ * @returns true if the migration document version changed.
+ */
+async function applyIndividualMigrationChain({
+  handle,
+  migrationDb,
+  userId,
+}: {
+  handle: LoadedDbHandle;
+  migrationDb: MigrationsDB;
+  userId: string;
+}): Promise<boolean> {
+  const {db, dbType, dbName, migrationDoc} = handle;
+
+  if (isDbUpToDate({migrationDoc})) {
+    return false;
+  }
+
+  const migrationStartTime = Date.now();
+  const initialVersion = migrationDoc.version;
+  let currentVersion = migrationDoc.version;
+  const targetVersion = DB_TARGET_VERSIONS[dbType].targetVersion;
+
+  const migrationLogEntry: MigrationLog = {
+    from: initialVersion,
+    to: targetVersion,
+    startedAtTimestampMs: migrationStartTime,
+    completedAtTimestampMs: 0,
+    launchedBy: userId,
+    status: 'success',
+    issues: [],
+    notes: `Migrating from v${initialVersion} to v${targetVersion}`,
+  };
+
+  let ranAtLeastOneMigrationStep = false;
+
+  while (currentVersion < targetVersion) {
+    const migrationDetail = findNextIndividualMigration(dbType, currentVersion);
+    if (!migrationDetail) {
+      break;
+    }
+
+    ranAtLeastOneMigrationStep = true;
+
+    if (!IS_TESTING) {
+      console.log(
+        `Applying migration for ${dbType} from v${migrationDetail.from} to v${migrationDetail.to}: ${migrationDetail.description}`
+      );
+    }
+
+    migrationLogEntry.notes += `\n- ${migrationDetail.description}`;
+
+    const result = await performMigration({
+      db,
+      migrationFunc: migrationDetail.migrationFunction,
+    });
+
+    if (!IS_TESTING) {
+      console.log(
+        `Migration step completed. Processed ${result.processedCount} documents, updated ${result.writtenCount} documents.`
+      );
+    }
+
+    if (result.issues.length > 0) {
+      migrationLogEntry.issues = [
+        ...(migrationLogEntry.issues || []),
+        ...result.issues,
+      ];
+      migrationLogEntry.status = 'failure';
+      break;
+    }
+
+    currentVersion = migrationDetail.to;
+  }
+
+  if (!ranAtLeastOneMigrationStep && currentVersion === initialVersion) {
+    return false;
+  }
+
+  migrationLogEntry.completedAtTimestampMs = Date.now();
+  migrationLogEntry.to = currentVersion;
+  migrationDoc.version = currentVersion;
+  migrationDoc.status =
+    migrationLogEntry.status === 'success' ? 'healthy' : 'not-healthy';
+  migrationDoc.migrationLog = [...migrationDoc.migrationLog, migrationLogEntry];
+
+  await migrationDb.put(migrationDoc);
+
+  if (migrationLogEntry.status === 'success') {
+    if (!IS_TESTING) {
+      console.log(
+        `Successfully migrated database ${dbName} (${dbType}) from version ${migrationLogEntry.from} to ${migrationLogEntry.to}`
+      );
+    }
+  } else if (!IS_TESTING) {
+    console.error(
+      `Migration of database ${dbName} (${dbType}) completed with issues. Check migration logs for details.`
+    );
+  }
+
+  return true;
+}
+
+async function recordUnexpectedMigrationFailure({
+  dbType,
+  dbName,
+  migrationDb,
+  migrationStartTime,
+  userId,
+  error,
+}: {
+  dbType: DatabaseType;
+  dbName: string;
+  migrationDb: MigrationsDB;
+  migrationStartTime: number;
+  userId: string;
+  error: unknown;
+}): Promise<void> {
+  try {
+    const migrationDocs = await migrationDb.query<MigrationsDBFields>(
+      MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+      {
+        key: [dbType, dbName],
+        include_docs: true,
+      }
+    );
+
+    if (migrationDocs.rows.length > 0) {
+      const migrationDoc = migrationDocs.rows[0].doc!;
+
+      const failureLogEntry: MigrationLog = {
+        from: migrationDoc.version,
+        to: DB_TARGET_VERSIONS[dbType].targetVersion,
+        startedAtTimestampMs: migrationStartTime,
+        completedAtTimestampMs: Date.now(),
+        launchedBy: userId,
+        status: 'failure',
+        notes: 'Migration failed due to an unexpected error',
+        issues: [error instanceof Error ? error.message : String(error)],
+      };
+
+      migrationDoc.status = 'not-healthy';
+      migrationDoc.migrationLog = [...migrationDoc.migrationLog, failureLogEntry];
+
+      await migrationDb.put(migrationDoc);
+    }
+  } catch (logError) {
+    console.error(
+      `Failed to log migration failure for ${dbName} (${dbType}):`,
+      logError
+    );
+  }
+}
+
+async function runGlobalMigrationStep({
+  match,
+  allHandles,
+  migrationDb,
+  userId,
+}: {
+  match: NonNullable<ReturnType<typeof findApplicableGlobalMigration>>;
+  allHandles: LoadedDbHandle[];
+  migrationDb: MigrationsDB;
+  userId: string;
+}): Promise<'success' | 'failure'> {
+  const {definition, matchedByDbType} = match;
+
+  const ctx = createGlobalMigrationRunContext({
+    definition,
+    matchedByDbType,
+    userId,
+    migrationDb,
+    allBatchHandles: allHandles,
+  });
+
+  const started = Date.now();
+
+  if (!IS_TESTING) {
+    console.log(`Applying global migration: ${definition.id} — ${definition.description}`);
+  }
+
+  const result = await definition.run(ctx);
+
+  if (result.status === 'failure') {
+    const issues = result.issues;
+    for (const h of ctx.allHandles()) {
+      const logEntry: MigrationLog = {
+        from: h.migrationDoc.version,
+        to: h.migrationDoc.version,
+        startedAtTimestampMs: started,
+        completedAtTimestampMs: Date.now(),
+        launchedBy: userId,
+        status: 'failure',
+        issues,
+        notes: `Global migration ${definition.id}`,
+        globalMigrationId: definition.id,
+      };
+      h.migrationDoc.status = 'not-healthy';
+      h.migrationDoc.migrationLog = [...h.migrationDoc.migrationLog, logEntry];
+      await migrationDb.put(h.migrationDoc);
+    }
+
+    if (!IS_TESTING) {
+      console.error(`Global migration ${definition.id} failed.`);
+    }
+    return 'failure';
+  }
+
+  for (const p of definition.participants) {
+    const toVersion = p.to;
+    for (const h of matchedByDbType.get(p.dbType) ?? []) {
+      const fromV = h.migrationDoc.version;
+      const logEntry: MigrationLog = {
+        from: fromV,
+        to: toVersion,
+        startedAtTimestampMs: started,
+        completedAtTimestampMs: Date.now(),
+        launchedBy: userId,
+        status: 'success',
+        issues: [],
+        notes: definition.description,
+        globalMigrationId: definition.id,
+      };
+      h.migrationDoc.version = toVersion;
+      h.migrationDoc.status = 'healthy';
+      h.migrationDoc.migrationLog = [...h.migrationDoc.migrationLog, logEntry];
+      await migrationDb.put(h.migrationDoc);
+    }
+  }
+
+  if (!IS_TESTING) {
+    console.log(`Global migration ${definition.id} completed successfully.`);
+  }
+
+  return 'success';
+}
+
+/**
  * Performs a migration on all non-design documents in a PouchDB database.
  *
  * This function:
@@ -264,11 +555,12 @@ export async function performMigration({
  *
  * This function handles the entire migration process for multiple databases:
  * 1. Retrieves or creates migration documents for each database
- * 2. Checks if each database is up to date
- * 3. Identifies required migrations
- * 4. Executes migrations in the correct order
- * 5. Updates migration logs with results
- * 6. Updates the migration documents in the migration database
+ * 2. Repeatedly applies consecutive individual (per-document) migrations per
+ *    database whenever the next single-step migration exists
+ * 3. When no database can advance via an individual step but some are still
+ *    behind their target version, applies the first matching **global**
+ *    migration from {@link GLOBAL_MIGRATIONS} (cross-database, full-connection context)
+ * 4. Updates migration logs with results
  *
  * @param dbs - Array of database objects to migrate.
  * @param migrationDb - The database that stores migration documents.
@@ -283,196 +575,104 @@ export async function migrateDbs({
   migrationDb: MigrationsDB;
   userId?: string;
 }): Promise<void> {
-  // Process each database one by one
+  const handles: LoadedDbHandle[] = [];
+
   for (const {dbType, dbName, db} of dbs) {
-    // Track migration start time
-    const migrationStartTime = Date.now();
-
     try {
-      // Try to find an existing migration document for this database
-      const migrationDocs = await migrationDb.query<MigrationsDBFields>(
-        MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
-        {
-          key: [dbType, dbName],
-          include_docs: true,
-        }
+      const migrationDoc = await getOrCreateMigrationDoc({
+        dbType,
+        dbName,
+        migrationDb,
+      });
+      handles.push({dbType, dbName, db, migrationDoc});
+
+      if (isDbUpToDate({migrationDoc}) && !IS_TESTING) {
+        console.log(
+          `Database ${dbName} (${dbType}) is already up to date at version ${migrationDoc.version}`
+        );
+      }
+    } catch (error) {
+      console.error(
+        `Failed to load migration document for ${dbName} (${dbType}):`,
+        error
       );
+    }
+  }
 
-      // Determine if we have an existing migration document or need to create one
-      let migrationDoc: MigrationsDBDocument;
+  while (handles.some(h => !isDbUpToDate({migrationDoc: h.migrationDoc}))) {
+    let progressed = false;
 
-      if (migrationDocs.rows.length === 0) {
-        // No existing migration document found, create a new one
-        const defaultMigrationFields = buildDefaultMigrationDoc({
-          dbType,
-          dbName,
-        });
-
-        // Save the new migration document
-        const response = await migrationDb.post(defaultMigrationFields);
-
-        // Retrieve the created document with its _id and _rev
-        migrationDoc = await migrationDb.get(response.id);
-      } else {
-        // Use the existing migration document
-        migrationDoc = migrationDocs.rows[0].doc!;
-      }
-
-      // Check if the database is already up to date
-      if (isDbUpToDate({migrationDoc})) {
-        if (!IS_TESTING) {
-          console.log(
-            `Database ${dbName} (${dbType}) is already up to date at version ${migrationDoc.version}`
-          );
-        }
-        continue; // Skip to the next database
-      }
-
-      // Database needs migration - identify required migration details
-      const migrationsToApply = identifyMigrations({migrationDoc});
-
-      // If no migrations are needed (this should not happen due to isDbUpToDate check, but as a safeguard)
-      if (migrationsToApply.length === 0) {
+    for (const handle of handles) {
+      if (isDbUpToDate({migrationDoc: handle.migrationDoc})) {
         continue;
       }
 
-      // Create a migration log entry to track this migration process
-      const migrationLogEntry: MigrationLog = {
-        from: migrationDoc.version,
-        to: DB_TARGET_VERSIONS[dbType].targetVersion,
-        startedAtTimestampMs: migrationStartTime,
-        completedAtTimestampMs: 0, // Will be updated when migration completes
-        launchedBy: userId,
-        status: 'success', // Optimistic, will be updated if there are issues
-        issues: [],
-        notes: `Migrating from v${migrationDoc.version} to v${DB_TARGET_VERSIONS[dbType].targetVersion}`,
-      };
-
-      // Apply each migration in sequence
-      let currentVersion = migrationDoc.version;
-
-      for (const migrationDetail of migrationsToApply) {
-        // Start migration for this step
-        if (!IS_TESTING) {
-          console.log(
-            `Applying migration for ${dbType} from v${migrationDetail.from} to v${migrationDetail.to}: ${migrationDetail.description}`
-          );
-        }
-
-        // Add the migration description to the notes
-        if (!migrationLogEntry.notes) {
-          migrationLogEntry.notes = '';
-        }
-        migrationLogEntry.notes += `\n- ${migrationDetail.description}`;
-
-        // Perform the migration
-        const result = await performMigration({
-          db,
-          migrationFunc: migrationDetail.migrationFunction,
-        });
-
-        // Log stats about this migration step
-        if (!IS_TESTING) {
-          console.log(
-            `Migration step completed. Processed ${result.processedCount} documents, updated ${result.writtenCount} documents.`
-          );
-        }
-
-        // Check for issues during migration
-        if (result.issues.length > 0) {
-          // Add these issues to the migration log
-          migrationLogEntry.issues = [
-            ...(migrationLogEntry.issues || []),
-            ...result.issues,
-          ];
-
-          // If we have issues, mark the migration as failed
-          migrationLogEntry.status = 'failure';
-
-          // Don't continue running subsequent migrations if there were issues!
-          break;
-        } else {
-          // Update the current version
-          currentVersion = migrationDetail.to;
-        }
+      if (handle.migrationDoc.status === 'not-healthy') {
+        continue;
       }
 
-      // Complete the migration log entry
-      migrationLogEntry.completedAtTimestampMs = Date.now();
+      const migrationStartTime = Date.now();
 
-      // Update the migration document (only to successful spot)
-      migrationDoc.version = currentVersion;
-      migrationDoc.status =
-        migrationLogEntry.status === 'success' ? 'healthy' : 'not-healthy';
-      migrationDoc.migrationLog = [
-        ...migrationDoc.migrationLog,
-        migrationLogEntry,
-      ];
-
-      // Save the updated migration document
-      await migrationDb.put(migrationDoc);
-
-      // Log completion status
-      if (migrationLogEntry.status === 'success') {
-        if (!IS_TESTING) {
-          console.log(
-            `Successfully migrated database ${dbName} (${dbType}) from version ${migrationLogEntry.from} to ${migrationLogEntry.to}`
-          );
-        }
-      } else {
-        if (!IS_TESTING) {
-          console.error(
-            `Migration of database ${dbName} (${dbType}) completed with issues. Check migration logs for details.`
-          );
-        }
-      }
-    } catch (error) {
-      // Handle any unexpected errors in the migration process
-      console.error(`Failed to migrate database ${dbName} (${dbType}):`, error);
-
-      // Try to update the migration document to reflect the failure if possible
       try {
-        // Try to find the migration document
-        const migrationDocs = await migrationDb.query<MigrationsDBFields>(
-          MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
-          {
-            key: [dbType, dbName],
-            include_docs: true,
-          }
-        );
-
-        if (migrationDocs.rows.length > 0) {
-          const migrationDoc = migrationDocs.rows[0].doc!;
-
-          // Create a failure log entry
-          const failureLogEntry: MigrationLog = {
-            from: migrationDoc.version,
-            to: DB_TARGET_VERSIONS[dbType].targetVersion,
-            startedAtTimestampMs: migrationStartTime,
-            completedAtTimestampMs: Date.now(),
-            launchedBy: userId,
-            status: 'failure',
-            notes: 'Migration failed due to an unexpected error',
-            issues: [error instanceof Error ? error.message : String(error)],
-          };
-
-          // Update the migration document
-          migrationDoc.status = 'not-healthy';
-          migrationDoc.migrationLog = [
-            ...migrationDoc.migrationLog,
-            failureLogEntry,
-          ];
-
-          // Save the updated migration document
-          await migrationDb.put(migrationDoc);
+        const did = await applyIndividualMigrationChain({
+          handle,
+          migrationDb,
+          userId,
+        });
+        if (did) {
+          progressed = true;
         }
-      } catch (logError) {
-        // At this point, we've failed to migrate and also failed to log the failure
+      } catch (error) {
         console.error(
-          `Failed to log migration failure for ${dbName} (${dbType}):`,
-          logError
+          `Failed to migrate database ${handle.dbName} (${handle.dbType}):`,
+          error
         );
+        await recordUnexpectedMigrationFailure({
+          dbType: handle.dbType,
+          dbName: handle.dbName,
+          migrationDb,
+          migrationStartTime,
+          userId,
+          error,
+        });
       }
     }
+
+    if (progressed) {
+      continue;
+    }
+
+    const globalMatch = findApplicableGlobalMigration(handles, GLOBAL_MIGRATIONS);
+    if (globalMatch) {
+      const globalOutcome = await runGlobalMigrationStep({
+        match: globalMatch,
+        allHandles: handles,
+        migrationDb,
+        userId,
+      });
+      if (globalOutcome === 'failure') {
+        throw new Error(
+          `Global migration "${globalMatch.definition.id}" failed. See migration logs on participating databases.`
+        );
+      }
+      continue;
+    }
+
+    const stuckHealthy = handles.filter(
+      h =>
+        !isDbUpToDate({migrationDoc: h.migrationDoc}) &&
+        h.migrationDoc.status === 'healthy'
+    );
+    if (stuckHealthy.length === 0) {
+      break;
+    }
+
+    const detail = stuckHealthy
+      .map(
+        h =>
+          `${h.dbName} (${h.dbType}) is at v${h.migrationDoc.version} but target is v${DB_TARGET_VERSIONS[h.dbType].targetVersion}; no individual step from v${h.migrationDoc.version} to v${h.migrationDoc.version + 1} and no applicable global migration.`
+      )
+      .join('\n');
+    throw new Error(`Cannot complete database migrations:\n${detail}`);
   }
 }

--- a/library/data-model/src/data_storage/migrationsDB/types.ts
+++ b/library/data-model/src/data_storage/migrationsDB/types.ts
@@ -4,6 +4,8 @@ export type MigrationLog = {
   // from and to version ID
   from: number;
   to: number;
+  /** When set, this entry records a cross-database global migration step */
+  globalMigrationId?: string;
   // Any notes about this migration?
   notes?: string;
   // MS timestamp started at

--- a/library/data-model/tests/migrationNetworkInvariants.test.ts
+++ b/library/data-model/tests/migrationNetworkInvariants.test.ts
@@ -1,0 +1,305 @@
+import PouchDB from 'pouchdb';
+import PouchDBMemoryAdapter from 'pouchdb-adapter-memory';
+import {
+  DB_MIGRATIONS,
+  DB_TARGET_VERSIONS,
+  DatabaseType,
+  GLOBAL_MIGRATIONS,
+  MigrationsDB,
+  MigrationsDBDocument,
+  MigrationsDBFields,
+  couchInitialiser,
+  findApplicableGlobalMigration,
+  initMigrationsDB,
+  migrateDbs,
+  validateConfiguredMigrationNetwork,
+  validateGlobalMigrationsAgainstIndividuals,
+  validateIndividualMigrationNetwork,
+  validateUniqueReachablePathPerDatabaseType,
+} from '../src/data_storage';
+import type {LoadedDbHandle} from '../src/data_storage';
+import {DatabaseInterface} from '../src';
+
+PouchDB.plugin(PouchDBMemoryAdapter);
+
+describe('migration network invariants', () => {
+  it('passes for the configured DB_MIGRATIONS and GLOBAL_MIGRATIONS', () => {
+    expect(() => validateConfiguredMigrationNetwork()).not.toThrow();
+  });
+
+  it('rejects duplicate individual migration edges', () => {
+    const dup = {...DB_MIGRATIONS[0]};
+    DB_MIGRATIONS.push(dup);
+    expect(() => validateIndividualMigrationNetwork()).toThrow(
+      /Duplicate individual migration edge/
+    );
+    DB_MIGRATIONS.pop();
+  });
+
+  it('allows default→target via a global jump when no individuals exist for that type', () => {
+    const originalGlobals = GLOBAL_MIGRATIONS.slice();
+    const originalDirTarget =
+      DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion;
+
+    GLOBAL_MIGRATIONS.length = 0;
+    GLOBAL_MIGRATIONS.push({
+      id: 'test-directory-only-global',
+      description: 'DIRECTORY v1→v2 without individuals',
+      participants: [
+        {
+          dbType: DatabaseType.DIRECTORY,
+          from: 1,
+          to: 2,
+          multiplicity: 'single' as const,
+        },
+      ],
+      run: async () => ({status: 'success' as const}),
+    });
+    DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion = 2;
+
+    try {
+      expect(() => validateUniqueReachablePathPerDatabaseType()).not.toThrow();
+    } finally {
+      GLOBAL_MIGRATIONS.length = 0;
+      GLOBAL_MIGRATIONS.push(...originalGlobals);
+      DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion =
+        originalDirTarget;
+    }
+  });
+
+  it('rejects ambiguous outgoing edges (two globals from the same version)', () => {
+    const originalGlobals = GLOBAL_MIGRATIONS.slice();
+    const originalDirTarget =
+      DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion;
+
+    GLOBAL_MIGRATIONS.length = 0;
+    GLOBAL_MIGRATIONS.push(
+      {
+        id: 'test-dir-global-a',
+        description: 'a',
+        participants: [
+          {
+            dbType: DatabaseType.DIRECTORY,
+            from: 1,
+            to: 2,
+            multiplicity: 'single' as const,
+          },
+        ],
+        run: async () => ({status: 'success' as const}),
+      },
+      {
+        id: 'test-dir-global-b',
+        description: 'b',
+        participants: [
+          {
+            dbType: DatabaseType.DIRECTORY,
+            from: 1,
+            to: 2,
+            multiplicity: 'single' as const,
+          },
+        ],
+        run: async () => ({status: 'success' as const}),
+      }
+    );
+    DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion = 2;
+
+    try {
+      expect(() => validateUniqueReachablePathPerDatabaseType()).toThrow(
+        /Ambiguous migration from DIRECTORY v1/
+      );
+    } finally {
+      GLOBAL_MIGRATIONS.length = 0;
+      GLOBAL_MIGRATIONS.push(...originalGlobals);
+      DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion =
+        originalDirTarget;
+    }
+  });
+
+  it('rejects duplicate dbType rows in a single global participants array', () => {
+    const bad = {
+      id: 'test-dup-participant-dbtype',
+      description: 'duplicate TEAMS rows',
+      participants: [
+        {
+          dbType: DatabaseType.TEAMS,
+          from: 1,
+          to: 2,
+          multiplicity: 'single' as const,
+        },
+        {
+          dbType: DatabaseType.TEAMS,
+          from: 2,
+          to: 3,
+          multiplicity: 'single' as const,
+        },
+      ],
+      run: async () => ({status: 'success' as const}),
+    };
+    GLOBAL_MIGRATIONS.push(bad);
+    expect(() => validateGlobalMigrationsAgainstIndividuals()).toThrow(
+      /lists TEAMS more than once/
+    );
+    GLOBAL_MIGRATIONS.pop();
+  });
+
+  it('rejects a global migration whose participant range overlaps individual steps', () => {
+    const bad = {
+      id: 'test-overlap-global',
+      description: 'invalid overlap',
+      participants: [
+        {
+          dbType: DatabaseType.PEOPLE,
+          from: 1,
+          to: 3,
+          multiplicity: 'single' as const,
+        },
+      ],
+      run: async () => ({status: 'success' as const}),
+    };
+    GLOBAL_MIGRATIONS.push(bad);
+    expect(() => validateGlobalMigrationsAgainstIndividuals()).toThrow(
+      /individual migration exists/
+    );
+    GLOBAL_MIGRATIONS.pop();
+  });
+
+  it('rejects findApplicableGlobalMigration when only a subset of same-type DBs match from', async () => {
+    const migrationDb = new PouchDB('test-subset-migrations', {
+      adapter: 'memory',
+    }) as DatabaseInterface;
+    await couchInitialiser({
+      db: migrationDb,
+      content: initMigrationsDB({}),
+      config: {applyPermissions: false, forceWrite: true},
+    });
+
+    const teamsA = new PouchDB('teams-a', {adapter: 'memory'}) as DatabaseInterface;
+    const teamsB = new PouchDB('teams-b', {adapter: 'memory'}) as DatabaseInterface;
+
+    const originalTarget = DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion;
+    DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion = 3;
+
+    const teamsDocBase = {
+      dbType: DatabaseType.TEAMS,
+      status: 'healthy' as const,
+      migrationLog: [] as MigrationsDBFields['migrationLog'],
+    };
+
+    const postA = await migrationDb.post({
+      ...teamsDocBase,
+      dbName: 'teams-a',
+      version: 1,
+    });
+    const postB = await migrationDb.post({
+      ...teamsDocBase,
+      dbName: 'teams-b',
+      version: 2,
+    });
+    const docA = (await migrationDb.get(postA.id)) as MigrationsDBDocument;
+    const docB = (await migrationDb.get(postB.id)) as MigrationsDBDocument;
+
+    const globalDef = {
+      id: 'test-teams-subset-global',
+      description: 'TEAMS v1->2 single',
+      participants: [
+        {
+          dbType: DatabaseType.TEAMS,
+          from: 1,
+          to: 2,
+          multiplicity: 'single' as const,
+        },
+      ],
+      run: async () => ({status: 'success' as const}),
+    };
+
+    const handles: LoadedDbHandle[] = [
+      {
+        dbType: DatabaseType.TEAMS,
+        dbName: 'teams-a',
+        db: teamsA,
+        migrationDoc: docA,
+      },
+      {
+        dbType: DatabaseType.TEAMS,
+        dbName: 'teams-b',
+        db: teamsB,
+        migrationDoc: docB,
+      },
+    ];
+
+    GLOBAL_MIGRATIONS.push(globalDef);
+
+    try {
+      expect(() =>
+        findApplicableGlobalMigration(handles, GLOBAL_MIGRATIONS)
+      ).toThrow(/exactly one healthy/);
+    } finally {
+      GLOBAL_MIGRATIONS.pop();
+      DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion = originalTarget;
+      await migrationDb.destroy();
+      await teamsA.destroy();
+      await teamsB.destroy();
+    }
+  });
+
+  it('migrateDbs throws when a global would apply to a subset (mixed TEAMS versions)', async () => {
+    const migrationDb = new PouchDB('test-subset-migrate-dbs', {
+      adapter: 'memory',
+    }) as DatabaseInterface;
+    await couchInitialiser({
+      db: migrationDb,
+      content: initMigrationsDB({}),
+      config: {applyPermissions: false, forceWrite: true},
+    });
+
+    const teamsA = new PouchDB('teams-a-md', {adapter: 'memory'}) as DatabaseInterface;
+    const teamsB = new PouchDB('teams-b-md', {adapter: 'memory'}) as DatabaseInterface;
+
+    const originalTarget = DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion;
+    DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion = 3;
+
+    const teamsDocBase = {
+      dbType: DatabaseType.TEAMS,
+      status: 'healthy' as const,
+      migrationLog: [] as MigrationsDBFields['migrationLog'],
+    };
+
+    const postA = await migrationDb.post({...teamsDocBase, dbName: 'teams-a-md', version: 1});
+    const postB = await migrationDb.post({...teamsDocBase, dbName: 'teams-b-md', version: 2});
+    const docA = await migrationDb.get(postA.id);
+    const docB = await migrationDb.get(postB.id);
+
+    const globalDef = {
+      id: 'test-teams-subset-migratedbs',
+      description: 'TEAMS v1->2',
+      participants: [
+        {
+          dbType: DatabaseType.TEAMS,
+          from: 1,
+          to: 2,
+          multiplicity: 'single' as const,
+        },
+      ],
+      run: async () => ({status: 'success' as const}),
+    };
+    GLOBAL_MIGRATIONS.push(globalDef);
+
+    try {
+      await expect(
+        migrateDbs({
+          dbs: [
+            {dbType: DatabaseType.TEAMS, dbName: 'teams-a-md', db: teamsA},
+            {dbType: DatabaseType.TEAMS, dbName: 'teams-b-md', db: teamsB},
+          ],
+          migrationDb: migrationDb as unknown as MigrationsDB,
+        })
+      ).rejects.toThrow(/exactly one healthy/);
+    } finally {
+      GLOBAL_MIGRATIONS.pop();
+      DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion = originalTarget;
+      await migrationDb.destroy();
+      await teamsA.destroy();
+      await teamsB.destroy();
+    }
+  });
+});

--- a/library/data-model/tests/migrationService.test.ts
+++ b/library/data-model/tests/migrationService.test.ts
@@ -1,11 +1,13 @@
 import PouchDB from 'pouchdb';
 import PouchDBMemoryAdapter from 'pouchdb-adapter-memory';
+import type {GlobalMigrationRunContext} from '../src/data_storage';
 import {
   DATABASE_TYPE,
   DATABASE_TYPES,
   DB_MIGRATIONS,
   DB_TARGET_VERSIONS,
   DatabaseType,
+  GLOBAL_MIGRATIONS,
   MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
   MigrationFunc,
   MigrationsDB,
@@ -20,6 +22,7 @@ import {
   isDbUpToDate,
   migrateDbs,
   performMigration,
+  validateConfiguredMigrationNetwork,
 } from '../src/data_storage';
 import {DatabaseInterface} from '../src';
 
@@ -43,33 +46,8 @@ describe('Migration System Tests', () => {
       });
     });
 
-    it('should have a complete migration path for each database that needs migration', () => {
-      // For each database type where target > default
-      Object.entries(DB_TARGET_VERSIONS).forEach(
-        ([dbType, {defaultVersion, targetVersion}]) => {
-          // Skip if no migration needed
-          if (defaultVersion === targetVersion) {
-            return;
-          }
-
-          // Check if we have migrations for each version step
-          let version = defaultVersion;
-          while (version < targetVersion) {
-            const migration = DB_MIGRATIONS.find(
-              m =>
-                m.dbType === dbType &&
-                m.from === version &&
-                m.to === version + 1
-            );
-
-            expect(migration).toBeDefined();
-            expect(migration?.migrationFunction).toBeDefined();
-            expect(migration?.description).toBeDefined();
-
-            version++;
-          }
-        }
-      );
+    it('should have a unique individual migration path and consistent globals', () => {
+      expect(() => validateConfiguredMigrationNetwork()).not.toThrow();
     });
   });
 
@@ -858,6 +836,581 @@ describe('Migration System Tests', () => {
       } finally {
         // Clean up
         await testProjectsDb.destroy();
+      }
+    });
+
+    it('runs a global migration when no individual step is registered', async () => {
+      const directoryDb = new PouchDB('test-directory-global', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+
+      const originalDirectoryTarget =
+        DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion;
+      DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion = 2;
+
+      const globalDef = {
+        id: 'test-directory-global-1-to-2',
+        description: 'Test-only global migration for DIRECTORY',
+        participants: [
+          {
+            dbType: DatabaseType.DIRECTORY,
+            from: 1,
+            to: 2,
+            multiplicity: 'single' as const,
+          },
+        ],
+        run: async () => ({status: 'success' as const}),
+      };
+      GLOBAL_MIGRATIONS.push(globalDef);
+
+      try {
+        await migrateDbs({
+          dbs: [
+            {
+              dbType: DatabaseType.DIRECTORY,
+              dbName: 'test-directory-global',
+              db: directoryDb,
+            },
+          ],
+          migrationDb: testMigrationDb as unknown as MigrationsDB,
+          userId: 'system',
+        });
+
+        const migrationDocs = await testMigrationDb.query<MigrationsDBFields>(
+          MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+          {
+            key: [DatabaseType.DIRECTORY, 'test-directory-global'],
+            include_docs: true,
+          }
+        );
+        const migrationDoc = migrationDocs.rows[0].doc as MigrationsDBDocument;
+        expect(migrationDoc.version).toBe(2);
+        expect(
+          migrationDoc.migrationLog.some(
+            e => e.globalMigrationId === 'test-directory-global-1-to-2'
+          )
+        ).toBe(true);
+      } finally {
+        GLOBAL_MIGRATIONS.pop();
+        DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion =
+          originalDirectoryTarget;
+        await directoryDb.destroy();
+      }
+    });
+
+    it('passes all matched connections to the global migration run context', async () => {
+      const directoryDb = new PouchDB('test-dir-multi-global', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+      const teamsDb = new PouchDB('test-teams-multi-global', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+
+      const originalDirectoryTarget =
+        DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion;
+      const originalTeamsTarget =
+        DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion;
+      DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion = 2;
+      DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion = 2;
+
+      const globalDef = {
+        id: 'test-dual-global',
+        description: 'Coordinated DIRECTORY + TEAMS bump',
+        participants: [
+          {
+            dbType: DatabaseType.DIRECTORY,
+            from: 1,
+            to: 2,
+            multiplicity: 'single' as const,
+          },
+          {
+            dbType: DatabaseType.TEAMS,
+            from: 1,
+            to: 2,
+            multiplicity: 'single' as const,
+          },
+        ],
+        run: async (ctx: GlobalMigrationRunContext) => {
+          const d = ctx.getUnique(DatabaseType.DIRECTORY);
+          const t = ctx.getUnique(DatabaseType.TEAMS);
+          expect(d.dbName).toBe('test-dir-multi-global');
+          expect(t.dbName).toBe('test-teams-multi-global');
+          expect(ctx.allBatchHandles().length).toBe(2);
+          return {status: 'success' as const};
+        },
+      };
+      GLOBAL_MIGRATIONS.push(globalDef);
+
+      try {
+        await migrateDbs({
+          dbs: [
+            {
+              dbType: DatabaseType.DIRECTORY,
+              dbName: 'test-dir-multi-global',
+              db: directoryDb,
+            },
+            {
+              dbType: DatabaseType.TEAMS,
+              dbName: 'test-teams-multi-global',
+              db: teamsDb,
+            },
+          ],
+          migrationDb: testMigrationDb as unknown as MigrationsDB,
+        });
+
+        const dirDoc = (
+          await testMigrationDb.query<MigrationsDBFields>(
+            MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+            {
+              key: [DatabaseType.DIRECTORY, 'test-dir-multi-global'],
+              include_docs: true,
+            }
+          )
+        ).rows[0].doc as MigrationsDBDocument;
+        const teamsDoc = (
+          await testMigrationDb.query<MigrationsDBFields>(
+            MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+            {
+              key: [DatabaseType.TEAMS, 'test-teams-multi-global'],
+              include_docs: true,
+            }
+          )
+        ).rows[0].doc as MigrationsDBDocument;
+
+        expect(dirDoc.version).toBe(2);
+        expect(teamsDoc.version).toBe(2);
+      } finally {
+        GLOBAL_MIGRATIONS.pop();
+        DB_TARGET_VERSIONS[DatabaseType.DIRECTORY].targetVersion =
+          originalDirectoryTarget;
+        DB_TARGET_VERSIONS[DatabaseType.TEAMS].targetVersion =
+          originalTeamsTarget;
+        await directoryDb.destroy();
+        await teamsDb.destroy();
+      }
+    });
+
+    /**
+     * Mirrors the CouchMigrations walkthrough: coordinated PROJECTS + TEMPLATES
+     * jump with PEOPLE for lookups, plus **two** `DATA` DBs (`all-of-type`) where
+     * the global stamps **every** observation record whose `created_by_id` matches
+     * a known person (multi-document updates per physical data DB).
+     */
+    it('walkthrough-style global: PROJECTS + TEMPLATES + multi-notebook DATA with PEOPLE lookups', async () => {
+      const projectsDb = new PouchDB('test-wt-projects', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+      const templatesDb = new PouchDB('test-wt-templates', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+      const dataDbA = new PouchDB('test-wt-data-notebook-a', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+      const dataDbB = new PouchDB('test-wt-data-notebook-b', {
+        adapter: 'memory',
+      }) as DatabaseInterface;
+
+      const projectsDbName = 'test-wt-projects';
+      const templatesDbName = 'test-wt-templates';
+      const dataDbAName = 'test-wt-data-notebook-a';
+      const dataDbBName = 'test-wt-data-notebook-b';
+      const peopleDbName = 'test-people-db';
+
+      const originalProjectsTarget =
+        DB_TARGET_VERSIONS[DatabaseType.PROJECTS].targetVersion;
+      const originalTemplatesTarget =
+        DB_TARGET_VERSIONS[DatabaseType.TEMPLATES].targetVersion;
+      const originalDataTarget =
+        DB_TARGET_VERSIONS[DatabaseType.DATA].targetVersion;
+
+      DB_TARGET_VERSIONS[DatabaseType.PROJECTS].targetVersion = 4;
+      DB_TARGET_VERSIONS[DatabaseType.TEMPLATES].targetVersion = 5;
+      DB_TARGET_VERSIONS[DatabaseType.DATA].targetVersion = 2;
+
+      const logSeed = (
+        from: number,
+        to: number
+      ): MigrationsDBFields['migrationLog'][0] => ({
+        from,
+        to,
+        startedAtTimestampMs: Date.now(),
+        completedAtTimestampMs: Date.now(),
+        launchedBy: 'system',
+        status: 'success',
+        issues: [],
+        notes: 'seed',
+      });
+
+      await projectsDb.put({
+        _id: 'nb-1',
+        name: 'Notebook',
+        last_updated_by_user_id: 'person1',
+      });
+      await templatesDb.put({
+        _id: 'tpl-1',
+        name: 'Template',
+        last_updated_by_user_id: 'person1',
+      });
+
+      // Two project "data" DBs: multiple records per DB; only those with
+      // created_by_id === person1 get stamped (exercises bulk updates per DATA).
+      await dataDbA.bulkDocs([
+        {
+          _id: 'obs-a1',
+          type: 'data_record',
+          created_by_id: 'person1',
+          sample_field: 'alpha',
+        },
+        {
+          _id: 'obs-a2',
+          type: 'data_record',
+          created_by_id: 'person2',
+          sample_field: 'beta',
+        },
+        {
+          _id: 'obs-a3',
+          type: 'data_record',
+          created_by_id: 'person1',
+          sample_field: 'gamma',
+        },
+        {
+          _id: 'obs-a4',
+          type: 'data_record',
+          created_by_id: 'no-such-person',
+          sample_field: 'unresolved',
+        },
+      ]);
+      await dataDbB.bulkDocs([
+        {
+          _id: 'obs-b1',
+          type: 'data_record',
+          created_by_id: 'person1',
+          sample_field: 'delta',
+        },
+      ]);
+
+      await testMigrationDb.post({
+        dbType: DatabaseType.PROJECTS,
+        dbName: projectsDbName,
+        version: 3,
+        status: 'healthy',
+        migrationLog: [
+          logSeed(0, 1),
+          logSeed(1, 2),
+          logSeed(2, 3),
+        ],
+      });
+      await testMigrationDb.post({
+        dbType: DatabaseType.TEMPLATES,
+        dbName: templatesDbName,
+        version: 4,
+        status: 'healthy',
+        migrationLog: [
+          logSeed(0, 1),
+          logSeed(1, 2),
+          logSeed(2, 3),
+          logSeed(3, 4),
+        ],
+      });
+      await testMigrationDb.post({
+        dbType: DatabaseType.PEOPLE,
+        dbName: peopleDbName,
+        version: 5,
+        status: 'healthy',
+        migrationLog: [
+          logSeed(0, 1),
+          logSeed(1, 2),
+          logSeed(2, 3),
+          logSeed(3, 4),
+          logSeed(4, 5),
+        ],
+      });
+      await testMigrationDb.post({
+        dbType: DatabaseType.DATA,
+        dbName: dataDbAName,
+        version: 1,
+        status: 'healthy',
+        migrationLog: [logSeed(0, 1)],
+      });
+      await testMigrationDb.post({
+        dbType: DatabaseType.DATA,
+        dbName: dataDbBName,
+        version: 1,
+        status: 'healthy',
+        migrationLog: [logSeed(0, 1)],
+      });
+
+      const globalId = 'test-global-walkthrough-audit-coord';
+      const globalDef = {
+        id: globalId,
+        description:
+          'Coordinated audit on projects, templates, and all DATA DBs using people (test)',
+        participants: [
+          {
+            dbType: DatabaseType.PROJECTS,
+            from: 3,
+            to: 4,
+            multiplicity: 'single' as const,
+          },
+          {
+            dbType: DatabaseType.TEMPLATES,
+            from: 4,
+            to: 5,
+            multiplicity: 'single' as const,
+          },
+          {
+            dbType: DatabaseType.DATA,
+            from: 1,
+            to: 2,
+            multiplicity: 'all-of-type' as const,
+          },
+        ],
+        run: async (ctx: GlobalMigrationRunContext) => {
+          const peopleInBatch = ctx.allHandlesForType(DatabaseType.PEOPLE);
+          if (peopleInBatch.length === 0) {
+            return {
+              status: 'failure' as const,
+              issues: ['Expected PEOPLE in migrateDbs batch for lookups'],
+            };
+          }
+          const peopleHandle = peopleInBatch[0];
+
+          const projectsHandle = ctx.getUnique(DatabaseType.PROJECTS);
+          const templatesHandle = ctx.getUnique(DatabaseType.TEMPLATES);
+          expect(projectsHandle.dbName).toBe(projectsDbName);
+          expect(templatesHandle.dbName).toBe(templatesDbName);
+          expect(ctx.allBatchHandles().length).toBe(5);
+          expect(ctx.allHandlesForType(DatabaseType.PEOPLE).length).toBe(1);
+
+          const dataHandles = ctx.handles(DatabaseType.DATA);
+          expect(dataHandles.length).toBe(2);
+          const dataNames = new Set(dataHandles.map(h => h.dbName));
+          expect(dataNames.has(dataDbAName)).toBe(true);
+          expect(dataNames.has(dataDbBName)).toBe(true);
+
+          const enrichProjectLike = async (db: DatabaseInterface) => {
+            const res = await db.allDocs({include_docs: true});
+            for (const row of res.rows) {
+              if (!row.doc || row.id.startsWith('_design')) continue;
+              const doc = row.doc as Record<string, unknown> & {
+                _id: string;
+                _rev: string;
+              };
+              const uid = doc.last_updated_by_user_id;
+              let displayName = 'Unknown';
+              if (typeof uid === 'string') {
+                try {
+                  const person = (await peopleHandle.db.get(uid)) as {
+                    name?: string;
+                  };
+                  if (typeof person.name === 'string') {
+                    displayName = person.name;
+                  }
+                } catch {
+                  /* missing person */
+                }
+              }
+              await db.put({
+                ...doc,
+                migratedAuditDisplayName: displayName,
+                auditFilledByGlobalId: globalId,
+              });
+            }
+          };
+
+          /**
+           * Realistic pattern: backfill `creator_display_name` on every **data
+           * record** attributed to a user we can resolve in PEOPLE (multiple
+           * `put`s per DATA DB, two physical DATA DBs in this batch).
+           */
+          const stampDataRecordsForKnownCreators = async (
+            db: DatabaseInterface
+          ) => {
+            const res = await db.allDocs({include_docs: true});
+            for (const row of res.rows) {
+              if (!row.doc || row.id.startsWith('_design')) continue;
+              const doc = row.doc as Record<string, unknown> & {
+                _id: string;
+                _rev: string;
+              };
+              const creatorId = doc.created_by_id;
+              if (typeof creatorId !== 'string') continue;
+              let creatorDisplay: string | undefined;
+              try {
+                const person = (await peopleHandle.db.get(creatorId)) as {
+                  name?: string;
+                };
+                if (typeof person.name === 'string') {
+                  creatorDisplay = person.name;
+                }
+              } catch {
+                continue;
+              }
+              await db.put({
+                ...doc,
+                creator_display_name: creatorDisplay,
+                creator_display_filled_by_global: globalId,
+              });
+            }
+          };
+
+          await enrichProjectLike(projectsHandle.db);
+          await enrichProjectLike(templatesHandle.db);
+          for (const h of dataHandles) {
+            await stampDataRecordsForKnownCreators(h.db);
+          }
+          return {status: 'success' as const};
+        },
+      };
+      GLOBAL_MIGRATIONS.push(globalDef);
+
+      try {
+        expect(() => validateConfiguredMigrationNetwork()).not.toThrow();
+
+        await migrateDbs({
+          dbs: [
+            {
+              dbType: DatabaseType.PEOPLE,
+              dbName: peopleDbName,
+              db: testPeopleDb,
+            },
+            {
+              dbType: DatabaseType.PROJECTS,
+              dbName: projectsDbName,
+              db: projectsDb,
+            },
+            {
+              dbType: DatabaseType.TEMPLATES,
+              dbName: templatesDbName,
+              db: templatesDb,
+            },
+            {
+              dbType: DatabaseType.DATA,
+              dbName: dataDbAName,
+              db: dataDbA,
+            },
+            {
+              dbType: DatabaseType.DATA,
+              dbName: dataDbBName,
+              db: dataDbB,
+            },
+          ],
+          migrationDb: testMigrationDb as unknown as MigrationsDB,
+          userId: 'walkthrough-test-user',
+        });
+
+        const projRow = await testMigrationDb.query<MigrationsDBFields>(
+          MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+          {
+            key: [DatabaseType.PROJECTS, projectsDbName],
+            include_docs: true,
+          }
+        );
+        const tplRow = await testMigrationDb.query<MigrationsDBFields>(
+          MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+          {
+            key: [DatabaseType.TEMPLATES, templatesDbName],
+            include_docs: true,
+          }
+        );
+        const projMig = projRow.rows[0].doc as MigrationsDBDocument;
+        const tplMig = tplRow.rows[0].doc as MigrationsDBDocument;
+
+        const dataAMig = (
+          await testMigrationDb.query<MigrationsDBFields>(
+            MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+            {
+              key: [DatabaseType.DATA, dataDbAName],
+              include_docs: true,
+            }
+          )
+        ).rows[0].doc as MigrationsDBDocument;
+        const dataBMig = (
+          await testMigrationDb.query<MigrationsDBFields>(
+            MIGRATIONS_BY_DB_TYPE_AND_NAME_INDEX,
+            {
+              key: [DatabaseType.DATA, dataDbBName],
+              include_docs: true,
+            }
+          )
+        ).rows[0].doc as MigrationsDBDocument;
+
+        expect(projMig.version).toBe(4);
+        expect(tplMig.version).toBe(5);
+        expect(dataAMig.version).toBe(2);
+        expect(dataBMig.version).toBe(2);
+        expect(
+          projMig.migrationLog.some(e => e.globalMigrationId === globalId)
+        ).toBe(true);
+        expect(
+          tplMig.migrationLog.some(e => e.globalMigrationId === globalId)
+        ).toBe(true);
+        expect(
+          dataAMig.migrationLog.some(e => e.globalMigrationId === globalId)
+        ).toBe(true);
+        expect(
+          dataBMig.migrationLog.some(e => e.globalMigrationId === globalId)
+        ).toBe(true);
+
+        const nb = (await projectsDb.get('nb-1')) as {
+          migratedAuditDisplayName?: string;
+          auditFilledByGlobalId?: string;
+        };
+        const tpl = (await templatesDb.get('tpl-1')) as {
+          migratedAuditDisplayName?: string;
+          auditFilledByGlobalId?: string;
+        };
+        expect(nb.migratedAuditDisplayName).toBe('Alice');
+        expect(tpl.migratedAuditDisplayName).toBe('Alice');
+        expect(nb.auditFilledByGlobalId).toBe(globalId);
+        expect(tpl.auditFilledByGlobalId).toBe(globalId);
+
+        const obsA1 = (await dataDbA.get('obs-a1')) as {
+          creator_display_name?: string;
+          creator_display_filled_by_global?: string;
+        };
+        const obsA2 = (await dataDbA.get('obs-a2')) as {
+          creator_display_name?: string;
+          creator_display_filled_by_global?: string;
+        };
+        const obsA3 = (await dataDbA.get('obs-a3')) as {
+          creator_display_name?: string;
+          creator_display_filled_by_global?: string;
+        };
+        const obsB1 = (await dataDbB.get('obs-b1')) as {
+          creator_display_name?: string;
+          creator_display_filled_by_global?: string;
+        };
+
+        expect(obsA1.creator_display_name).toBe('Alice');
+        expect(obsA1.creator_display_filled_by_global).toBe(globalId);
+        expect(obsA3.creator_display_name).toBe('Alice');
+        expect(obsA3.creator_display_filled_by_global).toBe(globalId);
+        expect(obsB1.creator_display_name).toBe('Alice');
+        expect(obsB1.creator_display_filled_by_global).toBe(globalId);
+
+        // person2 exists in the fixture as "Bob" — same code path, different user
+        expect(obsA2.creator_display_name).toBe('Bob');
+        expect(obsA2.creator_display_filled_by_global).toBe(globalId);
+
+        const obsA4 = (await dataDbA.get('obs-a4')) as {
+          creator_display_name?: string;
+          creator_display_filled_by_global?: string;
+        };
+        expect(obsA4.creator_display_name).toBeUndefined();
+        expect(obsA4.creator_display_filled_by_global).toBeUndefined();
+      } finally {
+        GLOBAL_MIGRATIONS.pop();
+        DB_TARGET_VERSIONS[DatabaseType.PROJECTS].targetVersion =
+          originalProjectsTarget;
+        DB_TARGET_VERSIONS[DatabaseType.TEMPLATES].targetVersion =
+          originalTemplatesTarget;
+        DB_TARGET_VERSIONS[DatabaseType.DATA].targetVersion =
+          originalDataTarget;
+        await projectsDb.destroy();
+        await templatesDb.destroy();
+        await dataDbA.destroy();
+        await dataDbB.destroy();
       }
     });
   });

--- a/metadata-design.md
+++ b/metadata-design.md
@@ -1,0 +1,481 @@
+# FAIMS metadata redesign — design doc (draft)
+
+## Summary
+
+FAIMS metadata is spread across JSON notebook files, a dedicated metadata database, and project/template/survey entities in other databases. The current setup mixes **design/spec documentation** with **runtime survey instantiation**, uses loosely typed or untyped key value pairs, and has known data-quality gaps (for example, survey ownership cannot be trusted because values were inherited from free-text project fields rather than real user records).
+
+This initiative aims to: **fully type and validate** metadata where possible; **separate** “what the design is” from “who instantiated what and when”; remove redundant storage (notably removing the metadata DB in favour of nested, typed structures on first-class entities); **document** project and template properties consistently; and **support migrations** that may span multiple databases—not a single “doc in, doc out” scope.
+
+Near-term emphasis is **structural cleanup, typing, and code quality** rather than expanding into full standards like RAID immediately; the shape should remain **extensible** so RAID-aligned project metadata and archive publishing can follow.
+
+## Goals
+
+### Product and data
+
+- Clarify and fully type the **`metadata` portion of notebook JSON** so it describes the **design/spec** (forms, purpose, scope, bundled design documentation)—not the live survey instance.
+- Ensure **survey (and template) database objects** carry **instantiation and ownership** fields (`createdBy`, timestamps, name, description, etc.) with **real database references** where the domain requires them—not free-text stand-ins.
+- **Remove the metadata database** entirely after data is migrated or duplicated where still relevant; prefer **nested JSON** on project/template (and related) objects, **fully typed** in application and persistence layers.
+- **Standardised, documented** properties for projects and templates (naming, descriptions, audit fields)—used **consistently** across the app and APIs.
+- **Clear update workflows** in `/web` for non-consequential properties (name, description, etc.) versus operations that imply design or data integrity constraints.
+
+### Standards
+
+- Support **standardised metadata for projects** over time (discussion referenced [RAID](https://metadata.raid.org/en/v1.6/) as a target); enable **publishing project metadata with data into an archive**. Manage after this overhaul structural baseline unless low-effort compatibility wins emerge from the field mapping.
+
+### Engineering
+
+- **Fully typed interfaces** end-to-end; only **sandboxed untyped** regions where user-defined custom metadata cannot be predicted.
+- **Categorised** metadata where it helps (e.g. settings, display, user, system)—exact groupings to follow a **stocktake** of current fields.
+- **Migrations** for all affected entities: project DB, metadata DB (move then remove), template DB, and **notebook JSON** (designer + batch/custom migration to the new spec).
+- Introduce a **global migration** concept: **versioned**, scoped to the **full set of databases** for a deployment—not a single DB scope—because the current per-DB migration model is insufficient for this change.
+
+## Current state (inventory — codebase, May 2026)
+
+This section documents **what exists today** in CouchDB-shaped stores, API payloads, designer state, and app usage. Types are generally **`z.record(z.any())` / `{[key: string]: any}`** for notebook `metadata` unless noted.
+
+**Column legend (where tables include sourcing):**
+
+- **Sourced from (initial)** — how the value first appears (API body, server-generated, copied from template, etc.).
+- **Changed by** — how it is updated later (specific HTTP routes, designer save, server jobs, manual Couch edit, or **immutable** / **not written by current server paths**).
+
+Unless stated otherwise, **Control Centre** means the `/web` app; **designer save** means `PUT` JSON to `/api/notebooks/:id` or `/api/templates/:id` (see `web/src/designer/integration/useDesignerSaveMutation.ts`).
+
+### Terminology in this repo
+
+| User language        | Typical storage / code name                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| Survey / notebook    | **Project**: document in **`projects`** DB (`ProjectDocument`); API routes under `/api/notebooks/…`.    |
+| Template             | Document in **templates** DB (`TemplateDocument`).                                                      |
+| Design / JSON export | Object with top-level **`metadata`** + **`ui-specification`** (same keys as API PUT/GET notebook body). |
+
+---
+
+### 1. Projects database (`projects` DB)
+
+**Type:** `ProjectDocument` — `library/data-model/src/data_storage/projectsDB/types.ts` (`ProjectV3Fields`).
+
+| Property        | Type / notes                                                                            | Used for                                                                                                                                      | Sourced from (initial)                                                                                               | Changed by                                                                                                                                                                                                                        |
+| --------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_id`           | Couch id; **also the system project / notebook id** (`ProjectID`).                      | Routing, DB naming, permissions `resourceId`.                                                                                                 | **Server-generated** in `createNotebook` (`api/src/couchdb/notebooks.ts`): timestamp + slugified name.               | **Immutable** for the life of the survey; deleting the survey removes the project doc and destroys DBs.                                                                                                                           |
+| `_rev`          | Couch revision.                                                                         | Sync / updates.                                                                                                                               | Couch on first `put`.                                                                                                | Updated automatically on every successful `put` to this document.                                                                                                                                                                 |
+| `name`          | `string` — human-readable survey name.                                                  | Directory listing, `createNotebook` / `changeNotebookName` keeps this in sync with `metadata.name`.                                           | **POST `/api/notebooks`** `name` when creating; also overwritten to `metadata.name.trim()` inside `createNotebook`.  | **`changeNotebookName`** after **`PUT /api/notebooks/:id`** if `metadata.name` differs; otherwise only via the same PUT (metadata + project name stay aligned in `updateNotebook`).** Not** exposed as its own PATCH field today. |
+| `status`        | `ProjectStatus`: `OPEN`, `CLOSED`, `ARCHIVED`.                                          | Lifecycle, filters (e.g. hide archived from default lists).                                                                                   | Defaults to **`OPEN`** in `createNotebook` project doc.                                                              | **`PUT /api/notebooks/:id/status`** (`web` / `project-hooks.ts`). Logic in `applyNotebookLifecycleStatus` (`notebooks.ts`).                                                                                                       |
+| `dataDb`        | `PossibleConnectionInfo` (`db_name`, optional `base_url`, …).                           | Resolves **data** DB for records.                                                                                                             | **`createNotebook`**: sets `db_name: data-${projectId}`; `base_url` filled when listing (`getAllProjectsDirectory`). | **Not changed** by normal notebook update APIs; creation-time only unless ops/migrations edit Couch.                                                                                                                              |
+| `metadataDb`    | `PossibleConnectionInfo`. Legacy alias **`metadata_db`** still read in `getMetadataDb`. | Resolves **metadata** DB for UI spec + notebook metadata docs.                                                                                | Same pattern: **`metadata-${projectId}`** at `createNotebook`.                                                       | **Not changed** by normal APIs after creation.                                                                                                                                                                                    |
+| `ownedByTeamId` | `string \| undefined`.                                                                  | Team ownership; Couch view `PROJECTS_BY_TEAM_ID`.                                                                                             | Optional **`teamId`** on **POST `/api/notebooks`** (from scratch or template).                                       | **`PUT /api/notebooks/:projectId/team`** with body `{ teamId }` (`changeNotebookTeam` in `notebooks.ts`).                                                                                                                         |
+| `templateId`    | `string \| undefined` — survey created from template.                                   | Web tables, “template used”; cleared when template deleted. **Distinct** from optional `metadata.template_id` inside metadata DB (see below). | Set when **POST `/api/notebooks`** with **`template_id`** (from-template branch). Omitted for from-scratch.          | **Cleared** by `clearTemplateIdFromProjectsReferencingTemplate` when a template is permanently deleted (`notebooks.ts`). **Not** updated by `PUT /api/notebooks/:id` body today (no field in `PutUpdateNotebookInputSchema`).     |
+
+**Removed from current project shape (v2+):** V1-only fields such as `description`, `last_updated`, `created` on the project document — see migrations in `library/data-model/src/data_storage/migrations/migrations.ts`.
+
+**Not on project document today:** `createdBy`, rich description, RAID fields — those live elsewhere or not at all.
+
+---
+
+### 2. Per-project metadata database (`metadata-{projectId}`)
+
+**Naming:** Default `metadata-${projectId}` at creation (`api/src/couchdb/notebooks.ts`); actual connection comes from **`project.metadataDb`** (or legacy `metadata_db`).
+
+**Security:** `_security` from `MetadataDBSecurityDocument` — `library/data-model/src/data_storage/metadataDB/security.ts` (members get roles derived from `Action.READ_PROJECT_METADATA` for that `projectId`).
+
+**Initialisation:** `initMetadataDB` only sets security (no design docs): `library/data-model/src/data_storage/metadataDB/init.ts`.
+
+#### 2.1 Document types stored in this database
+
+| Role                             | Couch `_id` pattern             | Shape (conceptual)                                                                                                                                                        | Notes                                                                                                                                        | Sourced from (initial)                                                                                                             | Changed by                                                                                                                                                                                                                     |
+| -------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **UI specification**             | `ui-specification`              | `EncodedProjectUIModel`: `fields`, `fviews`, `viewsets`, `visible_types` (+ `_id` / `_rev` on read).                                                                      | Single doc; **not** under `project-metadata-*`. `decodeUiSpec` maps `fviews` → runtime `views` (`library/data-model/src/datamodel/core.ts`). | **POST `/api/notebooks`** supplies `ui-specification` (from scratch) or copies from **template**; `createNotebook` writes one doc. | **`PUT /api/notebooks/:id`** replaces whole doc (`updateNotebook`). Optional **`migrateNotebook`** on server startup (`validateDatabases` + `MIGRATE_NOTEBOOKS_ON_STARTUP`). Designer save uses same PUT.                      |
+| **Per-key metadata**             | `project-metadata-<key>`        | `EncodedProjectMetadata`: `{ is_attachment, metadata }` where the **value** for that key is in `.metadata`.                                                               | Prefix constant `PROJECT_METADATA_PREFIX = 'project-metadata'` (`library/data-model/src/datamodel/database.ts`).                             | **`writeProjectMetadata`** after create/update: one doc per enumerable key on the **`metadata`** object passed from API.           | Any **`PUT /api/notebooks/:id`** that includes a new `metadata` object rewrites all keys present in that object (missing keys are **not** deleted unless absent from the loop’s input — see `writeProjectMetadata` iteration). |
+| **Aggregated blob (write path)** | `project-metadata-projectvalue` | **Entire** metadata object written as the document body (with `_id` / `_rev`).                                                                                            | See **quirk** below.                                                                                                                         | Same **`writeProjectMetadata`** call as per-key docs.                                                                              | Same as per-key (every PUT that calls `writeProjectMetadata`).                                                                                                                                                                 |
+| **Optional / legacy types**      | Other ids                       | `ProjectMetaObject` union in `types.ts` also allows `ProjectSchema` (`namespace`, `constants`, `types`) — not created by current `createNotebook` path in `notebooks.ts`. | May exist in old deployments; not part of standard create flow reviewed here.                                                                | Historical / manual / other tooling.                                                                                               | Not defined by current API surface.                                                                                                                                                                                            |
+
+**`writeProjectMetadata` behaviour** (`api/src/couchdb/notebooks.ts`):
+
+1. For each enumerable key `field` on the incoming `metadata` object, upserts `project-metadata-<field>` with `{ metadata: metadata[field] }`.
+2. Then mutates the same object to set `_id` to `project-metadata-projectvalue` and upserts that as a **second** representation of the full bag.
+
+**`getNotebookMetadata` behaviour (read path):** Iterates all docs whose id starts with `project-metadata-`; for each, sets `result[key] = doc.doc.metadata` where `key` is the substring after the prefix. **Quirk:** the `project-metadata-projectvalue` document is stored as a **flat** document (not wrapped in `.metadata`), so **`result.projectvalue` is typically `undefined`** and the blob doc is **not** a reliable round-trip for consumers of the merged object. Consumers rely on the per-field docs.
+
+After merge, **`result.project_id`** is set to the queried id (not necessarily stored as a Couch doc).
+
+#### 2.2 Metadata keys — designer defaults and migrations
+
+**Designer initial `metadata`** (`web/src/designer/state/initial.ts`): `notebook_version`, `schema_version`, `name`, `filenames`, `lead_institution`, `showQRCodeButton`, `pre_description`, `project_lead`, `sections` (object).
+
+**Notebook migration pipeline** (`library/data-model/src/data_storage/migrations/notebookMigrations/index.ts`):
+
+- Driven by **`metadata.schema_version`**: missing / `null` / `'1.0'` → `migrateToV2`; `'2.0'` → `migrateToV3`.
+- **V2** (`migrateV2.ts`): large normalisation of `ui-specification` (labels, components, conditions, etc.); sets `schema_version` to **`'2.0'`**; can move legacy form descriptions from **`metadata.sections`** into **`fviews[].description`**.
+- **V3** (`migrateV3.ts`): removes **`metadata.project_status`**; sets **`schema_version`** to **`'3.0'`** (template archive moves to template DB `archived` flag).
+
+**Example file** `library/forms/src/sample-notebook.json` metadata includes: `filenames`, `lead_institution`, `meta`, `name`, `pre_description`, `project_id`, `project_lead`, `project_status`, `sections` — shows drift vs current v3 expectations (`project_status` legacy).
+
+**Historical / doc-listed keys** (`api/doc/DATABASE.md` lists examples): `access`, `accesses`, `behavious` (typo in doc), `filenames`, `forms`, `ispublic`, `isrequest`, `lead_institution`, `meta`, `pre_description`, `project_lead`, `project_status`, `projectvalue`, `sections`. Several appear only in old UI or designer tests, not in active field app paths.
+
+#### 2.3 Metadata keys — where the app reads them
+
+| Key / pattern                                | Where used                                                                                                                                                                 | Notes                                                                                                                                                                                                                                         | Sourced from (initial)                                                                                                                                                          | Changed by                                                                                                                                                                                                                                                                        |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`name`**                                   | Project doc + metadata; designer; API overwrites project name from `metadata.name` on update.                                                                              | Canonical display often `project.name` with fallback `metadata.name` (e.g. `app/.../workspace/notebooks.tsx`).                                                                                                                                | **POST `/api/notebooks`** body `metadata.name` (from scratch) or **template `metadata.name`** copy; **server forces** `metadata.name = projectName.trim()` in `createNotebook`. | **Designer save** or **PUT `/api/notebooks/:id`** or **Control Centre “Update project” JSON upload** — any path that calls `updateNotebook` → `writeProjectMetadata` + `changeNotebookName`.                                                                                      |
+| **`pre_description`**                        | Designer info panel (markdown); web Control Centre project/template **details** tables; app `MetadataDisplay` / `MetadataRenderer` (rich text).                            | Primary “long description” for humans.                                                                                                                                                                                                        | Client **POST** / template copy / designer defaults (`''`).                                                                                                                     | **Designer** (`propertyUpdated` / MDX editor) then **PUT** notebook; or JSON file PUT from Control Centre.                                                                                                                                                                        |
+| **`project_lead`**                           | Designer; web tables (labelled “Created by” — **misleading** vs DB user); app metadata display.                                                                            | Free text, not a user id.                                                                                                                                                                                                                     | Same as other metadata keys: request body at create or template copy.                                                                                                           | **Designer** or **PUT** notebook / JSON upload.                                                                                                                                                                                                                                   |
+| **`lead_institution`**                       | Designer; app metadata display.                                                                                                                                            |                                                                                                                                                                                                                                               | Create / template / defaults.                                                                                                                                                   | **Designer** or **PUT** notebook / JSON upload.                                                                                                                                                                                                                                   |
+| **`showQRCodeButton`**                       | Designer (stored as string `'true'`/`'false'` in test notebooks); **`app/.../add_record_by_type.tsx`**: `!!metadata['showQRCodeButton']`.                                  | **Bug / quirk:** boolean `false` in JSON is still truthy for `!!`; string `'false'` is also truthy. Only empty / `undefined` / `null` / `0` disable. Legacy notebooks use string `'true'`.                                                    | Designer default `false` or template copy; tests use string `'true'`.                                                                                                           | **Designer** checkbox writes string via `setProp`; persisted on **PUT** notebook.                                                                                                                                                                                                 |
+| **`notebook_version`**, **`schema_version`** | Designer info panel; migration engine.                                                                                                                                     | `schema_version` gates `migrateNotebook`.                                                                                                                                                                                                     | Defaults in designer (`web/.../initial.ts`) or inherited JSON.                                                                                                                  | **Manual** in designer fields; **`migrateNotebook`** may set **`schema_version`** to `2.0` / `3.0` on server when migration runs; then **`updateNotebook`** persists.                                                                                                             |
+| **`template_id`**                            | Inside **metadata** when supplied from **template** payloads (`api/.../templates.ts` injects on create/update); optional duplicate of linkage vs **`project.templateId`**. | Web “template used” uses **`template_id`** from **list** API (`project.templateId`). App `notebook/index.tsx` also reads `metadata['template_id']`. Metadata doc removed by `removeTemplateIdFromNotebookMetadata` when clearing reference.   | **Copied from template** `metadata` on survey create; template CRUD **re-injects** `metadata.template_id` on server.                                                            | For **surveys**: doc removed when template reference cleared from projects (`removeTemplateIdFromNotebookMetadata`). Otherwise changes only if **PUT** sends a new `metadata` object containing it. **Project** `templateId` is the authoritative link for list UI, not this key. |
+| **`accesses`**                               | Designer `rolesUpdated` reducer; protected from casual `propertyUpdated`.                                                                                                  | **Not found** in permission middleware as the source of truth — **Couch roles** come from people / token / `resourceRoles`; this is designer-local role labels unless wired elsewhere. Treat as **legacy / UI-only** unless proven otherwise. | Test fixtures / optional client payload on create.                                                                                                                              | **Designer** role UI → Redux → saved with notebook **PUT**. **No** known server-side consumer for auth decisions.                                                                                                                                                                 |
+| **`filenames`**                              | Protected in designer reducer; API export flows use a **local** `filenames` **array variable** for attachments — not the same as persisting this metadata key.             | Unclear that `metadata.filenames` is read for runtime behaviour.                                                                                                                                                                              | Designer default `[]`.                                                                                                                                                          | Not meaningfully updated by server; could appear via **PUT** if client sends it.                                                                                                                                                                                                  |
+| **`sections`**                               | Legacy; V2 migration reads **`metadata.sections`** for descriptions then removes key. Designer still initialises `{}`.                                                     |                                                                                                                                                                                                                                               | Legacy notebooks; designer `{}`.                                                                                                                                                | **`migrateToV2`** may **delete** key after moving content to `fviews`; otherwise **PUT** overwrites if still present.                                                                                                                                                             |
+| **`meta`**                                   | Protected in designer; sample JSON `{}`.                                                                                                                                   |                                                                                                                                                                                                                                               | Defaults / imports.                                                                                                                                                             | Typically untouched; could be updated via **PUT** if included in payload.                                                                                                                                                                                                         |
+| **`ispublic`**, **`isrequest`**              | Present in designer test notebook / V1 test fixtures.                                                                                                                      | **No grep hits** in app or API business logic beyond metadata reducer / info-panel “extra fields”. Likely **unused** for current conductor stack.                                                                                             | Fixtures / old JSON.                                                                                                                                                            | Only via **PUT** if ever sent; **no** dedicated API.                                                                                                                                                                                                                              |
+| **`derived-from`**                           | Designer: when `VITE_TEMPLATE_PROTECTIONS`, shows provenance; `field-editor` blocks edits if set.                                                                          | Template / copy workflow only.                                                                                                                                                                                                                | Set by whatever workflow seeds the notebook (not standard server create path in isolation).                                                                                     | Persists with **PUT**; designer treats as read-only signal when protections on.                                                                                                                                                                                                   |
+| **`description`**                            | `app/.../workspace/notebooks.tsx` shows `row.metadata.description` under name.                                                                                             | **Not** in designer default metadata; likely **legacy** or manually added; often empty.                                                                                                                                                       | Manual JSON / old exports.                                                                                                                                                      | **PUT** notebook if client adds the key.                                                                                                                                                                                                                                          |
+| **`last_updated`**                           | `MetadataDisplay` “Last Updated” row reads **`metadata.last_updated`**.                                                                                                    | **Not** set by current `createNotebook` / `writeProjectMetadata` flow reviewed; often blank. Project **v1** had `last_updated` on **project doc** — different field, also gone in v3.                                                         | Would only appear if client or migration wrote it into `metadata`.                                                                                                              | **Not** maintained automatically today; only **PUT** or manual Couch.                                                                                                                                                                                                             |
+| **`project_id`**                             | Injected on **read** by `getNotebookMetadata`; may also appear inside stored JSON in samples.                                                                              | Informational.                                                                                                                                                                                                                                | **Not stored** as a normal per-key write from `writeProjectMetadata` merge (added in code on read).                                                                             | N/A on write path from server; could exist in JSON from samples / **PUT** if someone includes it.                                                                                                                                                                                 |
+| **Ad-hoc keys**                              | Designer “extra fields” panel for keys outside the known list (`info-panel.tsx`).                                                                                          | Arbitrary `metadata` keys allowed by schema (`z.record(z.any())`).                                                                                                                                                                            | **POST** / template / designer user-added pairs.                                                                                                                                | **Designer** custom field UI + **PUT**; or **Control Centre** JSON upload.                                                                                                                                                                                                        |
+
+**Short-code / QR “add notebook” UI** (`notebooks.tsx`): uses **`allowQr` from build config**, **not** `metadata.showQRCodeButton`. Separate from record-list QR behaviour.
+
+**Other code paths touching merged metadata:**
+
+- **`validateDatabases`** (`api/src/couchdb/notebooks.ts`): loads metadata + UI spec per project; optional `migrateNotebook` when `MIGRATE_NOTEBOOKS_ON_STARTUP`.
+- **POST notebook user role** (`api/src/api/notebooks.ts`): calls `getNotebookMetadata` mainly to assert the notebook exists and to read **`project_id`** for `removeProjectRole` — redundant with route `id` but documents coupling to metadata fetch.
+- **Designer `info-panel.tsx`**: renders a fixed set of fields, then dumps any **other** metadata keys (not in an exclude list) as “extra” read-only properties for debugging / ad-hoc data.
+
+**`DATABASE.md` note on `local_autoincrementers`:** the developer doc suggests autoincrement state may live in the **metadata** Couch DB. In the **mobile app**, autoincrementer persistence uses **`local_state`** (IndexedDB / `local-autoincrement-state-*` doc ids in `app/src/local-data/autoincrement.ts`) — **not** the per-project metadata database. Treat the doc statement as **historical or inaccurate** unless server-side incrementers are found elsewhere.
+
+---
+
+### 3. Templates database (`templates` DB)
+
+**Type:** `TemplateDocument` / `TemplateDBFields` — `library/data-model/src/data_storage/templatesDB/types.ts` (current **v4**).
+
+| Property           | Schema                                                | Purpose                                                                                                                                                         | Sourced from (initial)                                                         | Changed by                                                                                                                                                                                                                                                                       |
+| ------------------ | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_id`              | string                                                | Template id (time-based slug).                                                                                                                                  | **Server-generated** in `createTemplate` (`generateTemplateId`).               | **Immutable.**                                                                                                                                                                                                                                                                   |
+| `_rev`             | Couch                                                 |                                                                                                                                                                 | Couch on first `put`.                                                          | Auto-updated on each successful document `put`.                                                                                                                                                                                                                                  |
+| `version`          | number ≥ 1                                            | Incremented on each update.                                                                                                                                     | **`1`** on **POST `/api/templates`**.                                          | **Server**: `existingTemplate.version + 1` on every **`updateExistingTemplate`** (any **PUT `/api/templates/:id`** that persists a change).                                                                                                                                      |
+| `name`             | string (required from v2)                             | Template title (distinct from `metadata.name` if both exist).                                                                                                   | **POST `/api/templates`** body **`name`** (required by create flow).           | **PUT `/api/templates/:id`** optional **`name`** (`PutUpdateTemplateInputSchema` — partial). Omitted fields keep previous values (`updateExistingTemplate`). **Not** changed by **PUT `/api/templates/:id/visibility`** (visibility only).                                       |
+| `metadata`         | `z.record(z.any())` **required**                      | Same open-ended bag as notebook metadata; **always** gets **`metadata.template_id`** injected to match `_id` on create/update (`api/src/couchdb/templates.ts`). | **POST** body `metadata`; server sets **`metadata.template_id`** to new `_id`. | **PUT `/api/templates/:id`** optional **`metadata`** — if omitted, existing metadata retained; if sent, merged server-side and **`template_id` re-injected**. Designer save sends full JSON file = full replace of `metadata` + `ui-specification` when user exports that way.   |
+| `ui-specification` | Encoded UI spec (Zod `EncodedUISpecificationSchema`). | Full design.                                                                                                                                                    | **POST** body.                                                                 | **PUT `/api/templates/:id`** optional; designer **PUT** same as notebooks. **Not** updated by visibility-only endpoint.                                                                                                                                                          |
+| `ownedByTeamId`    | optional string                                       | Team ownership.                                                                                                                                                 | **POST** optional **`teamId`** → stored as `ownedByTeamId`.                    | **PUT** optional **`teamId`**; falls back to existing if omitted.                                                                                                                                                                                                                |
+| `archived`         | boolean (v3+, default false)                          | Replaces old **`metadata.project_status`** for archive.                                                                                                         | **`false`** on create.                                                         | **POST `/api/templates/:id/archive`** with `{ archive: boolean }` (`archiveTemplate`). **POST `/api/templates/:id/restore`** clears archive. **Not** in normal PUT template body schema.                                                                                         |
+| `isPublic`         | boolean (v4+, default false)                          | Visibility API.                                                                                                                                                 | **POST** optional **`isPublic`** (defaults **false** in `createTemplate`).     | **Only** **`PUT /api/templates/:id/visibility`**. Generic **`PUT /api/templates/:id`** (`updateExistingTemplate`) **always copies** `existingTemplate.isPublic` — it is **not** in `PutUpdateTemplateInputSchema`, so content updates **cannot** flip visibility via that route. |
+
+**Web Control Centre** template tables / details iterate **`metadata`** keys like `pre_description`, `project_lead`, `notebook_version` for display — same loose convention as surveys.
+
+---
+
+### 4. Notebook JSON / `ui-specification` (wire + designer)
+
+**Wire format (API, files, Couch `ui-specification` doc):** keys **`fields`**, **`fviews`**, **`viewsets`**, **`visible_types`**.
+
+**Designer internal state** (`web/src/designer/state/initial.ts`): same logical layout; undo history wraps **`ui-specification`** only.
+
+**Per-field object** (`FieldType` in `initial.ts`): includes **`component-namespace`**, **`component-name`**, **`type-returned`**, **`component-parameters`**, optional **`condition`**, **`access`**, **`meta`** (annotation/uncertainty), **`humanReadableName`**, **`category`**, etc. — largely **`any`**-friendly in `ProjectUIFields` in `types.ts`.
+
+**Sections (“views”):** each **`fviews[id]`** may have `label`, `fields`, `uidesign`, `description`, `condition`, `next_label`, `is_logic`, …
+
+**Forms (“viewsets”):** `viewsets[id]` has `views`, `label`, optional `summary_fields`, `layout` (`inline` \| `tabs`), `hridField`, `submit_label`, `is_visible`, etc. (see `ProjectUIViewset` in `types.ts`).
+
+**`QRCodeFormField`:** defined in designer `fields.tsx` as a **form field** component — separate from **`metadata.showQRCodeButton`** (which toggles **record search by QR** on the record list).
+
+| Part of `ui-specification`                                       | Sourced from (initial)                                                                            | Changed by                                                                                                                                                                                                                                                                                               |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Whole document (`fields`, `fviews`, `viewsets`, `visible_types`) | **POST `/api/notebooks`** (scratch payload or template copy); same for **POST `/api/templates`**. | **PUT** survey or template with full **`ui-specification`** body; **designer** export file; optional **`migrateNotebook`** + **`updateNotebook`** on server when `MIGRATE_NOTEBOOKS_ON_STARTUP`. **Control Centre** survey update: JSON file → **PUT `/api/notebooks/:id`** (`update-project-form.tsx`). |
+| Individual field / section / form definitions                    | Authored in **designer** (Redux), then serialised into the JSON sent on PUT.                      | Same as row above; no granular PATCH — typically **replace whole spec** with each save.                                                                                                                                                                                                                  |
+
+---
+
+### 5. API contracts (notebook)
+
+Relevant schemas in `library/data-model/src/api.ts`:
+
+- **GET `/api/notebooks/:id`** → `GetNotebookResponse`: `name`, `metadata` (record), `ui-specification`, `ownedByTeamId`, `status`, optional `recordCount`.
+- **PUT `/api/notebooks/:id`** → body `NotebookEditableDetailsSchema`: `ui-specification` + `metadata` (any record). **Both are required** by the schema; server **`updateNotebook`** rewrites the **`ui-specification`** doc and calls **`writeProjectMetadata`** with the **entire** `metadata` object — keys **not** present in the payload are **not** iterated for per-field doc updates (so stale keys can **remain** in Couch unless overwritten by a key in the new object; deletions are not modelled as explicit tombstones).
+- **POST `/api/notebooks`** → from scratch: `name`, `metadata`, `ui-specification`, optional `teamId`; from template: `name`, `template_id`, optional `teamId` (metadata/ui spec copied from template).
+- **GET list** (`getUserProjectsDetailed`): each item includes `metadata: projectMeta` from **`getNotebookMetadata`**, plus **`template_id: project.templateId`** from **project document** (not from metadata bag).
+
+---
+
+### 6. Data database (`data-{projectId}`) — not “notebook metadata” but often confused
+
+Record docs (`EncodedRecord`), revisions, AVPs include **`created_by`**, **`created`** as **strings** (usernames from auth at write time). This is **per-record**, not the survey’s “created by”.
+
+---
+
+### 7. Summary: likely unused or legacy today
+
+| Item                                                               | Assessment                                                                                                   |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| **`metadataDb` → `project-metadata-projectvalue`** merged read     | **Broken / useless** for `projectvalue` key due to missing nested `.metadata` on that doc shape.             |
+| **`metadata.accesses` / `ispublic` / `isrequest`**                 | Present in fixtures; **no** current server enforcement path found in grep.                                   |
+| **`metadata.description`**                                         | Used in one app list caption; **not** part of typed defaults; often empty.                                   |
+| **`metadata.last_updated`**                                        | Shown in UI if present; **not** populated by standard server writes reviewed.                                |
+| **API list `last_updated` / `created`** on `APINotebookListSchema` | **Optional**; **`getUserProjectsDetailed`** does **not** populate them — likely **unused** on that response. |
+| **`ProjectSchema` in metadata DB**                                 | Allowed by type union; **not** created in current `createNotebook` path.                                     |
+| **`api/doc/DATABASE.md` `auth_mechanisms` on project**             | Doc notes **not used**.                                                                                      |
+| **Doc typo `behavious`**                                           | Listed in DATABASE.md; **no code references**.                                                               |
+| **`DATABASE.md` id `ui_specification` vs underscore**              | Doc says `ui_specification`; code uses **`ui-specification`**.                                               |
+
+---
+
+### 8. Discussion snapshot (qualitative, still valid)
+
+These motivated the redesign but are not a second inventory: mixed **design** vs **instantiation** semantics; **`project_lead`** vs real **user** ids; desire to fold **render toggles** (e.g. QR) into clearer **spec** vs **metadata**; naming drift across web (“Created by”) vs domain (“project lead”).
+
+---
+
+## Proposed state
+
+### Design principles
+
+1. **Surveys (`Project` in the `projects` DB) and templates (`Template`)** are Couch documents with **two layers**: (a) **resource / lifecycle / instantiation** at the root (ids, status, data DB pointer, team, template link, **audit user ids**), and (b) a nested **`uiSpecification`** object shaped as **`{ uiSpec, metadata }`**: **`uiSpec`** is **today’s encoded UI body** (`fields`, `fviews`, `viewsets`, `visible_types`, and all legacy inner keys) **plus** a new **`settings`** object; **`metadata`** holds **`information`** (typed non-functional design prose) and optional **`custom`**.
+2. **No per-project metadata database** — former `ui-specification` + `project-metadata-*` docs are **inlined** into that **`uiSpecification`** value on the parent document.
+3. **camelCase** only for **new** persistence/API keys (`uiSpec`, `metadata`, `settings`, `information`, `showQrCodeButton`, root `createdAt`, etc.). **Do not** rename legacy keys inside the form graph (`fviews`, `visible_types`, `component-namespace`, `type-returned`, …) in this pass — avoids a massive designer/forms rewrite. Couch **`_id`**, **`_rev`**, **`_deleted`** stay as-is.
+4. **Intentionally removed** from the typed core: `accesses`, `ispublic`, `isrequest`, legacy `sections` bag, unused `filenames`, empty `meta`, `project_status` in arbitrary metadata, duplicate `template_id` inside nested bags, `projectvalue` aggregate pattern, ad hoc `last_updated` strings, typo keys (`behavious`). **Survey/template `description`** is a **single typed root field** (what this survey or template _is_ for operators), distinct from **`metadata.information.purposeMarkdown`** (design documentation inside the UI spec bundle). **No** denormalised display names on audit fields (privacy).
+
+---
+
+### Shared primitives
+
+```typescript
+/** ISO-8601 timestamp string, UTC recommended */
+type Timestamp = string;
+```
+
+**Project connection and lifecycle** — reuse existing types unchanged: **`PossibleConnectionInfo`** (with `db_name`, `base_url`, etc.) and **`ProjectStatus`** (`OPEN`, `CLOSED`, `ARCHIVED`) from `library/data-model` (`ProjectDocument` / `projectsDB/types.ts`). **No** renaming of connection fields or status enum values.
+
+---
+
+### `uiSpecification` — `{ uiSpec, metadata }`
+
+| Partition                  | Responsibility                                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`uiSpec`**               | **Same top-level structure as today’s** Couch `ui-specification` / `EncodedProjectUIModel`: **`fields`**, **`fviews`**, **`viewsets`**, **`visible_types`**. Inner field definitions keep existing keys (`component-namespace`, `type-returned`, `component-parameters`, …). **Only addition:** sibling **`settings`** (camelCase, new). |
+| **`uiSpec.settings`**      | Typed toggles / numbers that affect **how** the app renders or behaves (e.g. QR on record list).                                                                                                                                                                                                                                         |
+| **`metadata.information`** | Human-facing **design documentation** only — no user ids, no auth.                                                                                                                                                                                                                                                                       |
+| **`metadata.custom`**      | Optional org-specific bag, **untyped** by design.                                                                                                                                                                                                                                                                                        |
+
+```typescript
+/**
+ * UI behaviour toggles (moved out of the old loose metadata bag).
+ * Only **new** keys here use camelCase; the rest of `uiSpec` stays legacy-shaped.
+ */
+interface NotebookUiSettings {
+  /** When true, show “search by QR” on the record list for this survey */
+  showQrCodeButton: boolean;
+}
+
+/**
+ * Non-functional **design** documentation bundled with the form definition.
+ * Not the same as the survey/template root **`description`** (operational blurb).
+ */
+interface NotebookInformation {
+  /** Notebook / designer semver or similar */
+  notebookVersion: string;
+  /** Drives notebook migration / compatibility */
+  schemaVersion: string;
+  /** Long-form design intent — former `pre_description` */
+  purposeMarkdown: string;
+  /** Responsible person label for the design — former `project_lead`; not a user id */
+  projectLeadLabel: string;
+  leadInstitution: string;
+}
+
+/** Typed design metadata + optional org extensions */
+interface NotebookMetadataPartition {
+  information: NotebookInformation;
+  /** Optional key/value bag for org-specific tagging; not for settings or user ids */
+  custom?: Record<string, unknown>;
+}
+
+/**
+ * Inlined former notebook JSON + metadata DB merge.
+ * `uiSpec` base type = existing **`EncodedProjectUIModel`** (`fields`, `fviews`, `viewsets`, `visible_types`; legacy keys inside `fields` unchanged) + **`settings`**.
+ */
+interface SurveyNotebookDefinition {
+  uiSpec: EncodedProjectUIModel & {settings: NotebookUiSettings};
+  metadata: NotebookMetadataPartition;
+}
+```
+
+_In implementation, import **`EncodedProjectUIModel`** from `@faims3/data-model` / `library/data-model`._
+
+---
+
+### Survey document — `Project` (`projects` DB)
+
+Instantiation + lifecycle at **root**; **definition** nested under **`uiSpecification: SurveyNotebookDefinition`**. **`metadataDb` removed** once migration completes.
+
+**`description`** (root) is the **short description of this survey** (listing, admin UI, “what we are collecting”). **`metadata.information.purposeMarkdown`** remains the **design / notebook purpose** inside the bundled UI spec.
+
+```typescript
+/** One Couch document in the `projects` database — a deployed project */
+interface Project {
+  /** Stable survey id (also Couch `_id`) */
+  _id: string;
+  _rev?: string;
+
+  /** Display title of this survey */
+  name: string;
+  /** Survey description — **not** the same as `uiSpecification.metadata.information.purposeMarkdown` */
+  description: string;
+  /** Same values as today: `ProjectStatus` (`OPEN`, `CLOSED`, `ARCHIVED`) */
+  status: ProjectStatus;
+
+  /** Same shape as today’s `ProjectDocument.dataDb` (`PossibleConnectionInfo`, e.g. `db_name`) */
+  dataDb: PossibleConnectionInfo;
+  /** Owning team, if any */
+  ownedByTeamId?: string;
+  /** Source template id when created from a template */
+  templateId?: string;
+
+  /** Who instantiated this survey — people/auth user id only */
+  createdByUserId: string;
+  /** Creation time */
+  createdAt: Timestamp;
+  /** Last updated */
+  updatedAt: Timestamp;
+
+  /** Inlined former metadata DB + `ui-specification` Couch doc */
+  uiSpecification: SurveyNotebookDefinition;
+}
+```
+
+_Import **`ProjectStatus`**, **`PossibleConnectionInfo`** from `@faims3/data-model` / `library/data-model`._
+
+---
+
+### Template document — `Template` (`templates` DB)
+
+Same pattern as **`Project`**: root holds **identity, description, audit, flags**; **`uiSpecification`** uses the same **`SurveyNotebookDefinition`** shape. **`description`** is what this **template** is for in listings and admin UI; design prose stays under **`metadata.information`**.
+
+```typescript
+/** One Couch document in the `templates` database */
+interface Template {
+  /** Stable template id */
+  _id: string;
+  _rev?: string;
+
+  /** Bumped on each persisted content change */
+  version: number;
+  /** Listing / editor title */
+  name: string;
+  /** Short description of this template — **not** `purposeMarkdown` on the design side */
+  description: string;
+
+  /** section same as survey */
+  createdByUserId: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  ownedByTeamId?: string;
+
+  /** Whether this template was derived from another */
+  derivedFromTemplateId?: string;
+
+  /** Lifecycle and permission (same) */
+  archived: boolean;
+  isPublic: boolean;
+
+  /** Inlined spec and design metadata */
+  uiSpecification: SurveyNotebookDefinition;
+}
+```
+
+---
+
+### Metadata DB (target)
+
+All former Couch **`metadata-{projectId}`** documents are **replaced** by **`Project.uiSpecification`** (the **`metadata`** partition + **`uiSpec`** other than former per-key docs) plus root audit fields. **`data-{projectId}`** is unchanged conceptually.
+
+---
+
+### Zod implementation sketch
+
+- **`SurveyNotebookDefinitionSchema`**: `z.object({ uiSpec: EncodedProjectUIModelSchema.and(SettingsShape), metadata: MetadataPartitionSchema })` where **`EncodedProjectUIModelSchema`** is the existing (or tightened) Zod for the current wire shape, and **`SettingsShape`** is `z.object({ showQrCodeButton: z.boolean() })`.
+- **`NotebookInformationSchema`**: required strings per product rules for `notebookVersion` / `schemaVersion` / etc.
+- **`ProjectSchema`**: strict root keys; **`status`**: `z.nativeEnum(ProjectStatus)` (same **`OPEN` / `CLOSED` / `ARCHIVED`** strings as today); **`dataDb`**: reuse / refine **`PossibleConnectionInfo`** schema (keep `db_name`, `base_url`, …); **`description: z.string()`** (or `.min(1)` if required); `createdByUserId: z.string().min(1)`; timestamps as `z.string().datetime()` (or branded **`Timestamp`**). Same for **`TemplateSchema`** with **`description`** and template-only flags.
+- **`metadata.custom`**: `z.record(z.string(), z.unknown()).optional()` only.
+
+---
+
+## Mapping of fields
+
+Maps **legacy** locations (projects row, metadata DB, merged notebook `metadata`, `ui-specification` doc, template document) to the **proposed** shapes: **`Project`** / **`Template`** root and **`uiSpecification: { uiSpec, metadata }`**. Paths use **`Project`** / **`Template`** as the persisted document root.
+
+### Project (`projects` DB) — top-level
+
+| Legacy source | Legacy field / path | New location | Migration / typing notes |
+| ------------- | -------------------- | ------------ | ------------------------- |
+| Project doc | `_id` | `Project._id` | Unchanged Couch id. |
+| Project doc | `_rev` | `Project._rev` | Unchanged. |
+| Project doc | `name` | `Project.name` | Prefer **`project.name`**; if only **`metadata.name`** existed historically, copy that string. |
+| Project doc | `status` (`ProjectStatus`: `OPEN` / `CLOSED` / `ARCHIVED`) | `Project.status` | **Unchanged** enum values and type — no casing migration. |
+| Project doc | `dataDb` (`PossibleConnectionInfo`, `db_name`, `base_url`, …) | `Project.dataDb` | **Unchanged** shape and property name. |
+| Project doc | `metadataDb` | _removed_ | No pointer after inline spec; metadata Couch DB destroyed after cutover. |
+| Project doc | `ownedByTeamId` | `Project.ownedByTeamId` | Same semantics. |
+| Project doc | `templateId` | `Project.templateId` | Same; drop duplicate **`metadata.template_id`** inside inlined bundle. |
+| — | _(missing today)_ | `Project.description` | **New required field:** derive from first non-empty of legacy **`metadata.description`**, truncated **`metadata.pre_description`**, or `''` then prompt ops to fill. |
+| — | _(missing today)_ | `Project.createdByUserId` | **New required field:** no trustworthy legacy value — use migration policy (e.g. creating admin JWT `user_id`, or sentinel) — see gap note below. |
+| — | _(missing today)_ | `Project.createdAt` | Use first-write timestamp from Couch, export audit, or migration run time if unknown. |
+| — | _(missing today)_ | `Project.updatedAt` | Use `Project._rev` history, last PUT audit, or migration run time. |
+
+### Notebook / metadata DB → `Project.uiSpecification`
+
+| Legacy source | Legacy field / path | New location | Migration / typing notes |
+| ------------- | -------------------- | ------------ | ------------------------- |
+| Metadata DB doc `_id` = `ui-specification` | whole `EncodedProjectUIModel` | `Project.uiSpecification.uiSpec` (minus `settings`) | Copy **`fields`**, **`fviews`**, **`viewsets`**, **`visible_types`** verbatim; run existing **`migrateNotebook`** first if needed. |
+| Metadata DB / merged `metadata` | `showQRCodeButton` | `Project.uiSpecification.uiSpec.settings.showQrCodeButton` | Coerce string **`'true'`** / **`'false'`** and legacy boolean to **boolean**; treat any other non-empty string as **`true`** only if product agrees, else default **`false`**. |
+| Merged `metadata` | `pre_description` | `Project.uiSpecification.metadata.information.purposeMarkdown` | Rename key; content unchanged. |
+| Merged `metadata` | `project_lead` | `Project.uiSpecification.metadata.information.projectLeadLabel` | Free text preserved; not a user id. |
+| Merged `metadata` | `lead_institution` | `Project.uiSpecification.metadata.information.leadInstitution` | Same. |
+| Merged `metadata` | `notebook_version` | `Project.uiSpecification.metadata.information.notebookVersion` | Rename to camelCase. |
+| Merged `metadata` | `schema_version` | `Project.uiSpecification.metadata.information.schemaVersion` | After **`migrateNotebook`**, expect **`3.0`** (or current target). |
+| Merged `metadata` | `name` | _see `Project.name`_ | Do not duplicate as canonical title; optional copy into **`metadata.custom.legacyMetadataName`** only if audits need it. |
+| Merged `metadata` | `template_id` | _drop_ | Authoritative link is **`Project.templateId`**; remove per-key doc / merged key. |
+| Merged `metadata` | `project_id` | _drop_ | Same as **`Project._id`**; remove from stored payload. |
+| Merged `metadata` | `derived-from` | `Project.uiSpecification.metadata.custom.derivedFrom` _or_ drop | Only if surveys carry provenance strings today; else omit. |
+| Merged `metadata` | arbitrary extra keys (designer “extra fields”) | `Project.uiSpecification.metadata.custom.<key>` | Preserve unknown keys under **`custom`** for forward compatibility. |
+| Merged `metadata` | `accesses`, `ispublic`, `isrequest`, `filenames`, `meta`, `forms`, `access` | _drop_ | No typed home; not used by server auth path today. |
+| Merged `metadata` | `sections` | _drop_ (after V2) | **`migrateToV2`** already moved content into **`fviews`**; if still present, run V2 then strip. |
+| Merged `metadata` | `project_status` | _drop_ | Use **`Project.status`**; removed from metadata in V3 for surveys. |
+| Merged `metadata` | `last_updated` | _drop_ | Prefer **`Project.updatedAt`** instead of a parallel string. |
+| Merged `metadata` | `description` | `Project.description` | Move to **root** survey description (not design `purposeMarkdown`). |
+| Metadata DB | `project-metadata-projectvalue` blob doc | _ignore on read_ | Rebuild from per-key docs + `ui-specification` merge; blob shape is unreliable today. |
+
+### Template (`templates` DB)
+
+| Legacy source | Legacy field / path | New location | Migration / typing notes |
+| ------------- | -------------------- | ------------ | ------------------------- |
+| Template doc | `_id`, `_rev`, `version`, `name`, `ownedByTeamId`, `archived`, `isPublic` | `Template.*` same names | **`description`** new: from first non-empty legacy **`metadata.description`**, truncated **`metadata.pre_description`**, or `''`. |
+| Template doc | `metadata.*` (informational keys) | `Template.uiSpecification.metadata.information.*` | Same key mapping as **`Project`** table above (`pre_description` → **`purposeMarkdown`**, etc.). |
+| Template doc | `metadata.template_id` | _drop_ | Always equals **`Template._id`**; server injection removed in new model. |
+| Template doc | `ui-specification` | `Template.uiSpecification.uiSpec` | Same as survey: copy body then attach **`settings`**. |
+| — | _(missing today)_ | `Template.createdByUserId`, `createdAt`, `updatedAt`, `updatedByUserId?` | Same migration policy as surveys for **`createdByUserId`**; timestamps from Couch or migration run. |
+| Loose `metadata` / designer | `derived-from` (survey-style) | `Template.derivedFromTemplateId` | Parse id string only if format is a single template id; else stash in **`metadata.custom`**. |
+
+### Cross-cutting
+
+| Legacy concept | New location | Notes |
+| -------------- | ------------ | ----- |
+| “Notebook JSON” export `{ metadata, 'ui-specification' }` | `Project` or `Template` document | Split: wire **`ui-specification`** → **`uiSpecification.uiSpec`**; metadata bag → **`information`** + **`settings`** + **`custom`** + root **`description`** / **`name`**. |
+| Record `created_by` / `created` (data DB) | _unchanged_ | Still **per-record**; do not map to **`Project.createdByUserId`**. |
+
+**Known gap (unchanged):** historical surveys have **no** trustworthy **creator** in DB — **`Project.createdByUserId`** must come from an explicit migration policy (e.g. conductor admin, first project admin role holder, or sentinel), not from **`project_lead`** text.
+
+---
+
+## Migration approach
+
+**Entity migrations**
+
+- **Project DB**: new properties populated from old sources.
+- **Template DB**: same.
+- **Metadata DB**: read-only migration path → new stores → decommission.
+- **Notebook JSON**: update structure to meet new spec; support **designer** migration and a **batch migrator**.
+
+**Global migration**
+
+- New **cross-database migration** type, **versioned**, applied in a defined order across **all** relevant DBs for an environment. **Cannot** rely solely on single-DB “doc in doc out” migration within one scope.
+
+## Other issues / notes

--- a/metadata-design.md
+++ b/metadata-design.md
@@ -477,5 +477,6 @@ Maps **legacy** locations (projects row, metadata DB, merged notebook `metadata`
 **Global migration**
 
 - New **cross-database migration** type, **versioned**, applied in a defined order across **all** relevant DBs for an environment. **Cannot** rely solely on single-DB “doc in doc out” migration within one scope.
+- **Implementation** lives in `@faims3/data-model` (`GLOBAL_MIGRATIONS`, `migrationService.migrateDbs`, invariants). Maintainer-oriented documentation: `docs/developer/docs/source/markdown/CouchMigrations.md`.
 
 ## Other issues / notes


### PR DESCRIPTION
This change adds **global migrations** that can coordinate upgrades across **more than one Couch DB in a single batch** (e.g. per-project **metadata** and **data** DBs, or other typed participants), with explicit **participant multiplicity** (`single` vs `all-of-type`) and supporting **resolver / registry / network invariant** helpers plus tests.

**`migrationService`** is extended so **`migrateDbs`** can run these global steps safely alongside existing per-DB behaviour; **`migrationsDB` types** and **API/Couch wiring** (`index`, `notebooks`) are updated where needed.

**Documentation** is expanded: **`CouchMigrations.md`** (global flow, batch semantics, operator guidance), smaller updates to **`DATABASE.md`**, **`NotebookMigrations.md`**, and **`DeployingAWSStack.md`**. **`metadata-design.md`** is kept aligned with the direction to use **global migrations** for metadata/UI layout cutover.

**Tests** cover the new global paths and invariants (`migrationService`, `migrationNetworkInvariants`).