### PR TITLE
Fix vite dependency issue in web development server

### DIFF
--- a/web/src/designer/theme/index.tsx
+++ b/web/src/designer/theme/index.tsx
@@ -19,7 +19,8 @@
  *   Amended to fit this project.
  */
 
-import {createTheme, colors} from '@mui/material';
+import {createTheme} from '@mui/material/styles';
+import {colors} from '@mui/material';
 
 const theme = createTheme({
   palette: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,9 +13,8 @@ export default defineConfig({
     react(),
   ],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
+    alias: {'@': path.resolve(__dirname, './src')},
+    dedupe: ['@mui/material', '@emotion/react', '@emotion/styled'],
   },
   server: {
     port: 3001,
@@ -25,6 +24,7 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@mui/material',
+      '@mui/material/styles',
       '@mui/icons-material',
       '@emotion/react',
       '@emotion/styled',


### PR DESCRIPTION
# Fix vite dependency issue in web development server

## JIRA Ticket

None

## Description

We have a frequent issue with starting web/ where there is an in browser error with createTheme.   Claude advises
that this is due to mixing barrel imports and deep imports from @mui/material, which sounds convincing.  

## Proposed Changes

Updates one import of createTheme and adjusts vite configuration.  

## How to Test

`pnpm dev` in web/ should not show the browser createTheme error that we've seen before.


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
