### PR TITLE
fix: wire migrateNotebooksOnStartup to API env

### DIFF
--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -109,7 +109,8 @@
       "scaleInCooldown": 300,
       "scaleOutCooldown": 60
     },
-    "localhostWhitelist": false
+    "localhostWhitelist": false,
+    "migrateNotebooksOnStartup": false
   },
   "authProviders": {
     "disableLocalLogin": false,

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -261,6 +261,9 @@ export class FaimsConductor extends Construct {
         AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
         NEW_CONDUCTOR_URL: props.webUrl,
         PROVISION_SSO_USERS_POLICY: props.config.provisionSSOUsersPolicy,
+        MIGRATE_NOTEBOOKS_ON_STARTUP: props.config.migrateNotebooksOnStartup
+          ? 'true'
+          : 'false',
 
         // Bugsnag (optional)
         ...(props.bugsnagApiKey ? {BUGSNAG_API_KEY: props.bugsnagApiKey} : {}),

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -435,6 +435,9 @@ const ConductorConfigSchema = z.object({
   /** Allow localhost typical addresses in the redirects for conductor? NOT
    * recommended for production use cases (for security reasons). */
   localhostWhitelist: z.boolean().default(false),
+  /** When true, sets MIGRATE_NOTEBOOKS_ON_STARTUP so the API runs notebook DB
+   * migrations on startup. */
+  migrateNotebooksOnStartup: z.boolean().default(false),
 });
 
 const WebConfigSchema = z.object({


### PR DESCRIPTION
The API reads MIGRATE_NOTEBOOKS_ON_STARTUP, but CDK stack JSON did not expose it and the Conductor task did not set it. This adds conductor.migrateNotebooksOnStartup (default false) and maps it to MIGRATE_NOTEBOOKS_ON_STARTUP on the ECS container.