### PR TITLE
feat: make record list search case insensitive (#2011)

### DIFF
--- a/app/src/gui/components/notebook/datagrid_toolbar.tsx
+++ b/app/src/gui/components/notebook/datagrid_toolbar.tsx
@@ -100,7 +100,7 @@ export function GridToolbarSearchRecordDataButton({
 
   return (
     <TextField
-      placeholder="Search record data (case sensitive)"
+      placeholder="Search record data"
       value={value}
       onChange={handleChange}
       onKeyDown={handleKeyPress}

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -512,6 +512,7 @@ export const useRecordList = ({
           regex: query,
           projectId,
           filterDeleted,
+          caseInsensitive: true,
           filterFunction: rec => {
             return shouldDisplayRecordMinimalMetadata({
               contents: token,

--- a/library/data-model/src/databaseEngine/engine.ts
+++ b/library/data-model/src/databaseEngine/engine.ts
@@ -2214,6 +2214,7 @@ class QueryOperations {
    * @param options.filterDeleted - Whether to exclude deleted records (default: false)
    * @param options.filterFunction - Custom optional filter function e.g. permissions
    * @param options.batchSize - Batch size for AVP queries (default: 100)
+   * @param options.caseInsensitive - Whether the regex match is case insensitive (default: false)
    *
    * @returns Search results with minimal record metadata
    */
@@ -2223,12 +2224,14 @@ class QueryOperations {
     filterDeleted = false,
     filterFunction,
     batchSize = 100,
+    caseInsensitive = false,
   }: {
     projectId: string;
     regex: string;
     filterDeleted?: boolean;
     filterFunction?: (rec: MinimalRecordMetadata) => boolean;
     batchSize?: number;
+    caseInsensitive?: boolean;
   }): Promise<RecordSearchResult> {
     const startTime = performance.now();
 
@@ -2236,6 +2239,7 @@ class QueryOperations {
     const matchingRecordIds = await this.findAvpRecordIdsByRegex({
       regex,
       batchSize,
+      caseInsensitive,
     });
 
     console.log(
@@ -2276,20 +2280,25 @@ class QueryOperations {
    *
    * @param options.regex - Regular expression pattern to match
    * @param options.batchSize - Batch size for queries (default: 100)
+   * @param options.caseInsensitive - Compile the regex with the 'i' flag (default: false)
    *
    * @returns Deduplicated record IDs and match count
    */
   private async findAvpRecordIdsByRegex({
     regex,
     batchSize = 100,
+    caseInsensitive = false,
   }: {
     regex: string;
     batchSize?: number;
+    caseInsensitive?: boolean;
   }): Promise<{recordIds: string[]; avpMatchCount: number}> {
     const recordIdSet = new Set<string>();
     let skip = 0;
     let totalAvpMatches = 0;
     let batchCount: number;
+
+    const pattern = caseInsensitive ? new RegExp(regex, 'i') : regex;
 
     // Query in batches since find requires a limit argument
     do {
@@ -2299,7 +2308,10 @@ class QueryOperations {
         selector: {
           avp_format_version: 1,
           // Handle both scalar and array data values
-          $or: [{data: {$regex: regex}}, {data: {$elemMatch: {$regex: regex}}}],
+          $or: [
+            {data: {$regex: pattern}},
+            {data: {$elemMatch: {$regex: pattern}}},
+          ],
         },
         // Only fetch the field we need
         fields: ['record_id'],


### PR DESCRIPTION
# feat: make record list search case insensitive (#2011)

## JIRA Ticket

N/A (GitHub issue #2011)

## Description

The search input in the app record list was case sensitive, which is awkward on mobile. Search is now case insensitive — typing `hello`, `HELLO`, or `HeLLo` all return the same matches.

## Proposed Changes

- Added an optional `caseInsensitive` parameter to `DataEngine.searchRecordsByRegex` and its private helper `findAvpRecordIdsByRegex` in `library/data-model/src/databaseEngine/engine.ts`. When set, the regex is compiled into a `RegExp` object with the `i` flag and used in the PouchDB `$regex` selector for both scalar and array AVP data values.
- Updated the call site in `app/src/utils/customHooks.tsx` to pass `caseInsensitive: true` from the record list search.
- Removed the "(case sensitive)" hint from the search input placeholder in `app/src/gui/components/notebook/datagrid_toolbar.tsx`.

The flag defaults to `false`, so existing callers (currently none other than the record list) are unaffected.

## How to Test

1. Start the local environment (CouchDB, API, app).
2. Log in and open or create a notebook with a couple of text fields.
3. Create a record containing mixed-case text, e.g. fields with values `Hello World`, `TESTING ONE TWO`, and `lowercase only`.
4. Open the record list and use the search input.
5. Confirm each of the following returns the record:
   - `hello`, `HELLO`, `HeLLo`, `world`, `WORLD`
   - `testing`, `TESTING`, `two`, `TWO`
   - `lowercase`, `LOWERCASE`, `only`, `ONLY`
6. Confirm partial substrings still match (e.g. `ell`, `EST`).
7. Confirm empty search shows all records and a non-matching term (`zzzzzz`) shows none.
8. Confirm the placeholder reads "Search record data" (no "(case sensitive)" hint).

## Additional Information

Closes #2011

Parent issue: #1652 (Improvements to record viewer and record navigation)

**Record containing different phrases with different cases:**
<img width="961" height="716" alt="record1" src="https://github.com/user-attachments/assets/9094ae0f-4d70-4c35-b409-ec970a096d3e" />


**Mixed-case searches returning the matching record:**
<img width="942" height="386" alt="record2" src="https://github.com/user-attachments/assets/67156d55-7820-4dd5-8a26-4bd71ecd2100" />
<img width="940" height="372" alt="record3" src="https://github.com/user-attachments/assets/5562aa7c-986b-4a31-91cb-b3f4f46a3477" />

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.