### PR TITLE
enhancements for location map buttons

### DIFF
--- a/app/src/gui/themes/bssTheme/index.tsx
+++ b/app/src/gui/themes/bssTheme/index.tsx
@@ -41,6 +41,10 @@ const theme = createTheme({
       main: '#12B0FB',
       contrastText: '#F4F4F4',
     },
+    success: {
+      main: bssBrand.successMain,
+      contrastText: '#FFFFFF',
+    },
     alert: {
       warningBackground: '#FFFFFF',
       warningText: '#EA0E0EFF',

--- a/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
@@ -560,50 +560,64 @@ function MapWrapper(props: MapProps) {
           </DialogActions>
         </Dialog>
 
-        <Dialog
-          open={showCloseConfirm}
-          onClose={() => setShowCloseConfirm(false)}
-          aria-labelledby="map-close-confirm-title"
-          aria-describedby="map-close-confirm-description"
-          fullWidth
-          maxWidth="sm"
-        >
-          <DialogTitle
-            id="map-close-confirm-title"
-            sx={{textAlign: 'center', fontSize: '1.35rem', fontWeight: 600}}
-          >
-            Are you sure you want to discard the location?
-          </DialogTitle>
-          <DialogContent>
-            <Stack spacing={2} id="map-close-confirm-description">
-              <Typography variant="body2">
-                You have selected a location on the map but haven't saved it.
-                If you close now, your selection will be lost.
-              </Typography>
-            </Stack>
-          </DialogContent>
-          <DialogActions sx={{justifyContent: 'space-between', px: 3, pb: 2}}>
-            <Button
-              onClick={() => {
-                setShowCloseConfirm(false);
-                setMapOpen(false);
-              }}
-              color="error"
-              variant="contained"
-              disableElevation
+        {(() => {
+          // Use the right noun for the shape the user is drawing
+          // ("location" for points, "polygon" for polygons, "line" for lines).
+          const shapeNoun =
+            props.featureType === 'Polygon'
+              ? 'polygon'
+              : props.featureType === 'LineString'
+                ? 'line'
+                : 'location';
+          return (
+            <Dialog
+              open={showCloseConfirm}
+              onClose={() => setShowCloseConfirm(false)}
+              aria-labelledby="map-close-confirm-title"
+              aria-describedby="map-close-confirm-description"
+              fullWidth
+              maxWidth="sm"
             >
-              Discard
-            </Button>
-            <Button
-              onClick={() => setShowCloseConfirm(false)}
-              color="primary"
-              variant="contained"
-              disableElevation
-            >
-              Keep editing
-            </Button>
-          </DialogActions>
-        </Dialog>
+              <DialogTitle
+                id="map-close-confirm-title"
+                sx={{textAlign: 'center', fontSize: '1.35rem', fontWeight: 600}}
+              >
+                Are you sure you want to discard the {shapeNoun}?
+              </DialogTitle>
+              <DialogContent>
+                <Stack spacing={2} id="map-close-confirm-description">
+                  <Typography variant="body2">
+                    You have selected a {shapeNoun} on the map but haven't
+                    saved it. If you close now, your selection will be lost.
+                  </Typography>
+                </Stack>
+              </DialogContent>
+              <DialogActions
+                sx={{justifyContent: 'space-between', px: 3, pb: 2}}
+              >
+                <Button
+                  onClick={() => {
+                    setShowCloseConfirm(false);
+                    setMapOpen(false);
+                  }}
+                  color="error"
+                  variant="contained"
+                  disableElevation
+                >
+                  Discard
+                </Button>
+                <Button
+                  onClick={() => setShowCloseConfirm(false)}
+                  color="primary"
+                  variant="contained"
+                  disableElevation
+                >
+                  Keep editing
+                </Button>
+              </DialogActions>
+            </Dialog>
+          );
+        })()}
       </div>
       <style>
         {`

--- a/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
@@ -28,8 +28,10 @@ import {
   Box,
   Dialog,
   DialogActions,
+  DialogContent,
+  DialogTitle,
   Grid,
-  IconButton,
+  Stack,
   Toolbar,
   Tooltip,
   Typography,
@@ -130,6 +132,8 @@ function MapWrapper(props: MapProps) {
 
   const geoJson = new GeoJSON();
   const [showConfirmSave, setShowConfirmSave] = useState<boolean>(false);
+  /** Confirm dialog for closing with unsaved drawn features (BSS-1144). */
+  const [showCloseConfirm, setShowCloseConfirm] = useState<boolean>(false);
   const [featuresExtent, setFeaturesExtent] = useState<Extent>();
 
   // Has the user drawn features?
@@ -373,38 +377,33 @@ function MapWrapper(props: MapProps) {
                 paddingX: {xs: '8px', sm: '12px'},
               }}
             >
+              {/* Cancel — destructive. If the user has unsaved drawn
+                  features, prompt before discarding. */}
               <Box
                 sx={{display: 'flex', alignItems: 'center', marginLeft: '10px'}}
               >
-                <IconButton
-                  edge="start"
-                  color="inherit"
-                  onClick={() => setMapOpen(false)}
-                  aria-label="close"
+                <Button
+                  onClick={() => {
+                    if (hasDrawnFeatures) {
+                      setShowCloseConfirm(true);
+                    } else {
+                      setMapOpen(false);
+                    }
+                  }}
+                  aria-label="cancel"
+                  color="error"
+                  variant="contained"
+                  disableElevation
+                  startIcon={<CloseIcon sx={{fontSize: 16}} />}
                   sx={{
-                    backgroundColor: theme.palette.primary.dark,
-                    color: theme.palette.background.default,
-                    fontSize: '16px',
-                    gap: '4px',
-                    fontWeight: 'bold',
-                    borderRadius: '6px',
-                    padding: '6px 12px',
-                    transition:
-                      'background-color 0.3s ease-in-out, transform 0.2s ease-in-out',
-                    '&:hover': {
-                      backgroundColor: theme.palette.text.primary,
-                      transform: 'scale(1.05)',
+                    '& .MuiButton-startIcon': {
+                      marginLeft: 0,
+                      marginRight: '4px',
                     },
                   }}
                 >
-                  <CloseIcon
-                    sx={{
-                      stroke: theme.palette.background.default,
-                      strokeWidth: '1.5',
-                    }}
-                  />
-                  Close
-                </IconButton>
+                  Cancel
+                </Button>
               </Box>
 
               <Box
@@ -413,39 +412,24 @@ function MapWrapper(props: MapProps) {
                   gap: 1,
                 }}
               >
+                {/* Clear — secondary action, outlined so it stays
+                    visually quieter than Save. */}
                 <Button
-                  color="inherit"
                   onClick={() => handleClose('clear')}
-                  sx={{
-                    borderRadius: '6px',
-                    fontWeight: 'bold',
-                    transition:
-                      'background-color 0.3s ease-in-out, transform 0.2s ease-in-out',
-                    '&:hover': {
-                      backgroundColor: 'lightgray',
-
-                      transform: 'scale(1.05)',
-                    },
-                  }}
+                  color="primary"
+                  variant="outlined"
+                  // Disabled if there's nothing to clear
+                  disabled={!hasExistingFeatures && !hasDrawnFeatures}
                 >
                   Clear
                 </Button>
 
+                {/* Save — primary action, green via bssTheme success token. */}
                 <Button
-                  color="inherit"
                   onClick={() => handleClose('save')}
-                  sx={{
-                    // backgroundColor: theme.palette.alert.successBackground,
-                    // color: theme.palette.dialogButton.dialogText,
-                    borderRadius: '6px',
-                    fontWeight: 'bold',
-                    transition:
-                      'background-color 0.3s ease-in-out, transform 0.2s ease-in-out',
-                    '&:hover': {
-                      backgroundColor: 'lightgray',
-                      transform: 'scale(1.05)',
-                    },
-                  }}
+                  color="success"
+                  variant="contained"
+                  disableElevation
                   // Gray out when no features and hasn't drawn any
                   disabled={!hasExistingFeatures && !hasDrawnFeatures}
                 >
@@ -572,6 +556,54 @@ function MapWrapper(props: MapProps) {
               }}
             >
               Confirm
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        <Dialog
+          open={showCloseConfirm}
+          onClose={() => setShowCloseConfirm(false)}
+          aria-labelledby="map-close-confirm-title"
+          aria-describedby="map-close-confirm-description"
+          fullWidth
+          maxWidth="sm"
+        >
+          <DialogTitle
+            id="map-close-confirm-title"
+            sx={{textAlign: 'center', fontSize: '1.35rem', fontWeight: 600}}
+          >
+            Are you sure you want to discard the location?
+          </DialogTitle>
+          <DialogContent>
+            <Stack spacing={2} id="map-close-confirm-description">
+              <Typography variant="body2">
+                You have selected a location on the map but haven't saved it.
+                If you close now, your selection will be lost.
+              </Typography>
+            </Stack>
+          </DialogContent>
+          {/* Destructive action (Discard) on the left, continue action
+              (Keep editing) on the right — the right-hand button is the one
+              we want the user to head back to. */}
+          <DialogActions sx={{justifyContent: 'space-between', px: 3, pb: 2}}>
+            <Button
+              onClick={() => {
+                setShowCloseConfirm(false);
+                setMapOpen(false);
+              }}
+              color="error"
+              variant="contained"
+              disableElevation
+            >
+              Discard
+            </Button>
+            <Button
+              onClick={() => setShowCloseConfirm(false)}
+              color="primary"
+              variant="contained"
+              disableElevation
+            >
+              Keep editing
             </Button>
           </DialogActions>
         </Dialog>

--- a/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
@@ -582,9 +582,6 @@ function MapWrapper(props: MapProps) {
               </Typography>
             </Stack>
           </DialogContent>
-          {/* Destructive action (Discard) on the left, continue action
-              (Keep editing) on the right — the right-hand button is the one
-              we want the user to head back to. */}
           <DialogActions sx={{justifyContent: 'space-between', px: 3, pb: 2}}>
             <Button
               onClick={() => {


### PR DESCRIPTION


 
[BSS-1147](https://jira.csiro.au/browse/BSS-1147)
 
As discussed and reviewed by Elana, these are final set of updates: 

Restyles the map field's toolbar so Save (green) is the prominent action and the old Close button is renamed to Cancel (red) to make the destructive action look destructive. 
Adds a confirmation dialog when the user clicks Cancel after dropping a pin, so a selected location isn't silently lost. Also exposes the bssTheme success (green) palette token so the colour is reusable elsewhere.

Before adding a point
<img width="817" height="301" alt="image" src="https://github.com/user-attachments/assets/d373e79a-5dbe-4e15-b3ae-00d337cbc531" />


After adding a point
<img width="831" height="222" alt="image" src="https://github.com/user-attachments/assets/88b6cacf-a02a-49a9-ad65-dbc9b01fd55b" />

Cancel is renamed from CLOSE.

<img width="820" height="642" alt="image" src="https://github.com/user-attachments/assets/3e937db1-4092-4949-8113-8941280282a7" />

<img width="808" height="488" alt="image" src="https://github.com/user-attachments/assets/14ad46c2-f3d7-45b9-8441-333666fb8cdf" />

![Uploading image.png…]()

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
