### PR TITLE
improve child record display and make font consistent

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
@@ -131,6 +131,10 @@ const RelatedRecordListItem = ({
     return null;
   }
 
+  // True when we have a real HRID (templated string), false when we're
+  // falling back to the raw record id because no HRID was configured.
+  const isHumanReadableHrid = data.hrid !== link.record_id;
+
   // 3. Success State: Hydrated Data
   return (
     <ListItem
@@ -163,8 +167,11 @@ const RelatedRecordListItem = ({
           primary={data.hrid}
           primaryTypographyProps={{
             variant: 'body2',
-            fontFamily: 'monospace',
-            fontWeight: data.hrid !== link.record_id ? 'bold' : 'normal',
+            fontWeight: isHumanReadableHrid ? 'bold' : 'normal',
+            // Monospace only as a fallback when no real HRID was configured
+            // (i.e. we're showing the opaque record id). Real HRIDs use the
+            // theme's default font.
+            ...(isHumanReadableHrid ? {} : {fontFamily: 'monospace'}),
           }}
         />
       </ListItemButton>
@@ -367,40 +374,44 @@ const LinkExistingDialog = ({
             <List dense disablePadding sx={{maxHeight: 300, overflow: 'auto'}}>
               {filteredRecords
                 .filter(r => r.success)
-                .map(recordResult => (
-                  <ListItem
-                    key={recordResult.record.record._id}
-                    disablePadding
-                    divider
-                  >
-                    <ListItemButton
-                      onClick={async () => {
-                        await handleSelect(recordResult.record);
-                      }}
+                .map(recordResult => {
+                  const isHumanReadableHrid =
+                    recordResult.record.hrid !== recordResult.record.record._id;
+                  return (
+                    <ListItem
+                      key={recordResult.record.record._id}
+                      disablePadding
+                      divider
                     >
-                      <ListItemIcon sx={{minWidth: 40}}>
-                        <LinkIcon fontSize="small" />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={recordResult.record.hrid}
-                        secondary={recordResult.record.record._id}
-                        primaryTypographyProps={{
-                          variant: 'body2',
-                          fontFamily: 'monospace',
-                          fontWeight:
-                            recordResult.record.hrid !==
-                            recordResult.record.record._id
-                              ? 'bold'
-                              : 'normal',
+                      <ListItemButton
+                        onClick={async () => {
+                          await handleSelect(recordResult.record);
                         }}
-                        secondaryTypographyProps={{
-                          variant: 'caption',
-                          fontFamily: 'monospace',
-                        }}
-                      />
-                    </ListItemButton>
-                  </ListItem>
-                ))}
+                      >
+                        <ListItemIcon sx={{minWidth: 40}}>
+                          <LinkIcon fontSize="small" />
+                        </ListItemIcon>
+                        <ListItemText
+                          primary={recordResult.record.hrid}
+                          secondary={recordResult.record.record._id}
+                          primaryTypographyProps={{
+                            variant: 'body2',
+                            fontWeight: isHumanReadableHrid ? 'bold' : 'normal',
+                            ...(isHumanReadableHrid
+                              ? {}
+                              : {fontFamily: 'monospace'}),
+                          }}
+                          secondaryTypographyProps={{
+                            variant: 'caption',
+                            // Secondary is always the raw record id, kept
+                            // monospace so it reads as an opaque identifier.
+                            fontFamily: 'monospace',
+                          }}
+                        />
+                      </ListItemButton>
+                    </ListItem>
+                  );
+                })}
 
               {/* Load More Button */}
               {hasNextPage && (


### PR DESCRIPTION
# feat/fix/chore: pr title

## JIRA Ticket

https://jira.csiro.au/browse/BSS-1061


## Description

Previously, the HRID line in the linked-records list and the "Link existing record" 
dialog rendered in **monospace** regardless of whether it was a real human-readable 
HRID (e.g. "Residential Dwelling Apartment building 28-05-26 11:35pm admin") or 
a fallback raw record id. That made HRIDs look like opaque identifiers and broke 
visual consistency with everything else in the form.

<img width="594" height="1257" alt="Screenshot 2026-05-29 001118" src="https://github.com/user-attachments/assets/6aa41f9a-0183-4889-9a42-0bf7bc45c6bc" />

<img width="607" height="1246" alt="Screenshot 2026-05-29 001044" src="https://github.com/user-attachments/assets/efa55e6c-6b47-4036-9caf-a0a552cf9243" />


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
