### PR TITLE
update designer dialog for fixing progress upon navigation

### DIFF
--- a/web/src/components/dialogs/designer-dialog.tsx
+++ b/web/src/components/dialogs/designer-dialog.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {DesignerWidget} from '../../designer/DesignerWidget';
 import type {NotebookWithHistory} from '../../designer/state/initial';
 
@@ -27,13 +27,23 @@ export function DesignerDialog({
     NotebookWithHistory | undefined
   >(undefined);
 
-  // Mount / unmount logic with animation
+  // Snapshot notebook only on open edge, ignore upstream refetches mid-session.
+  const wasOpenRef = useRef(false);
+
   useEffect(() => {
-    if (open) {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = open;
+
+    // capture notebook, mount, animate in.
+    if (open && !wasOpen) {
+      setSessionNotebook(notebook);
       setMounted(true);
       const tid = window.setTimeout(() => setAnimateIn(true), 50);
       return () => window.clearTimeout(tid);
-    } else if (mounted) {
+    }
+
+    // animate out, then unmount.
+    if (!open && wasOpen && mounted) {
       setAnimateOut(true);
       setAnimateIn(false);
       const tid = window.setTimeout(() => {
@@ -43,15 +53,7 @@ export function DesignerDialog({
       }, animationDuration);
       return () => window.clearTimeout(tid);
     }
-  }, [open, animationDuration, mounted]);
-
-
-  useEffect(() => {
-    if (open) {
-      setSessionNotebook(notebook);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, notebook, animationDuration, mounted]);
 
   // Lock body scroll while the designer dialog is open so the background page doesn't scroll through
   useEffect(() => {

--- a/web/src/components/dialogs/designer-dialog.tsx
+++ b/web/src/components/dialogs/designer-dialog.tsx
@@ -30,7 +30,6 @@ export function DesignerDialog({
   // Mount / unmount logic with animation
   useEffect(() => {
     if (open) {
-      setSessionNotebook(notebook);
       setMounted(true);
       const tid = window.setTimeout(() => setAnimateIn(true), 50);
       return () => window.clearTimeout(tid);
@@ -44,7 +43,15 @@ export function DesignerDialog({
       }, animationDuration);
       return () => window.clearTimeout(tid);
     }
-  }, [open, animationDuration, mounted, notebook]);
+  }, [open, animationDuration, mounted]);
+
+
+  useEffect(() => {
+    if (open) {
+      setSessionNotebook(notebook);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   // Lock body scroll while the designer dialog is open so the background page doesn't scroll through
   useEffect(() => {

--- a/web/src/components/dialogs/designer-dialog.tsx
+++ b/web/src/components/dialogs/designer-dialog.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {DesignerWidget} from '../../designer/DesignerWidget';
 import type {NotebookWithHistory} from '../../designer/state/initial';
 
@@ -27,33 +27,32 @@ export function DesignerDialog({
     NotebookWithHistory | undefined
   >(undefined);
 
-  // Snapshot notebook only on open edge, ignore upstream refetches mid-session.
-  const wasOpenRef = useRef(false);
-
+  // Open: capture notebook once, mount, animate in. The functional updater
+  // makes the snapshot idempotent — once `sessionNotebook` is set, later
+  // upstream refetches (React Query refetchOnWindowFocus, polling) cannot
+  // overwrite it. The session is only cleared on close.
   useEffect(() => {
-    const wasOpen = wasOpenRef.current;
-    wasOpenRef.current = open;
+    if (!open) return;
+    setSessionNotebook(prev => prev ?? notebook);
+    setMounted(true);
+    if (animateIn) return;
+    const tid = window.setTimeout(() => setAnimateIn(true), 50);
+    return () => window.clearTimeout(tid);
+  }, [open, notebook, animateIn]);
 
-    // capture notebook, mount, animate in.
-    if (open && !wasOpen) {
-      setSessionNotebook(notebook);
-      setMounted(true);
-      const tid = window.setTimeout(() => setAnimateIn(true), 50);
-      return () => window.clearTimeout(tid);
-    }
-
-    // animate out, then unmount.
-    if (!open && wasOpen && mounted) {
-      setAnimateOut(true);
-      setAnimateIn(false);
-      const tid = window.setTimeout(() => {
-        setMounted(false);
-        setAnimateOut(false);
-        setSessionNotebook(undefined);
-      }, animationDuration);
-      return () => window.clearTimeout(tid);
-    }
-  }, [open, notebook, animationDuration, mounted]);
+  // Close: animate out, then unmount and clear the snapshot so the next
+  // open starts fresh.
+  useEffect(() => {
+    if (open || !mounted) return;
+    setAnimateOut(true);
+    setAnimateIn(false);
+    const tid = window.setTimeout(() => {
+      setMounted(false);
+      setAnimateOut(false);
+      setSessionNotebook(undefined);
+    }, animationDuration);
+    return () => window.clearTimeout(tid);
+  }, [open, mounted, animationDuration]);
 
   // Lock body scroll while the designer dialog is open so the background page doesn't scroll through
   useEffect(() => {


### PR DESCRIPTION

## JIRA Ticket

](https://jira.csiro.au/browse/BSS-1302)

## Description

Fixes the issue where progress was being lost in the Designer when 
switching browser tabs.

If you opened the Designer, added a field, started typing into its 
name, then switched to another tab and came back — the field you 
were typing into would reset to empty.

The Designer dialog was watching the notebook prop too eagerly. 
When you switched tabs and came back, the parent re-fetched the 
notebook from the backend. 

The dialog now snapshots the notebook only once at the moment 
you open it. Refetches that happen while the dialog is open are 
ignored, so your work stays put.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
