### PR TITLE
feat: add directional record sync modes with large-notebook defaults and settings UX

### DIFF
--- a/app/src/buildconfig.ts
+++ b/app/src/buildconfig.ts
@@ -131,6 +131,31 @@ function pouch_batch_size(): number {
   }
 }
 
+// This number requires more tuning based on upcoming load testing results. 500
+// is probably okay for most devices to two-way sync, but this is a more
+// conservative estimate.
+const DEFAULT_SYNC_PUSH_ONLY_RECORD_THRESHOLD = 500;
+
+/*
+ * Record count above which activation defaults to push-only sync (when online).
+ * See VITE_SYNC_PUSH_ONLY_RECORD_THRESHOLD.
+ */
+function sync_push_only_record_threshold(): number {
+  const raw = import.meta.env.VITE_SYNC_PUSH_ONLY_RECORD_THRESHOLD;
+  if (raw === '' || raw === undefined) {
+    return DEFAULT_SYNC_PUSH_ONLY_RECORD_THRESHOLD;
+  }
+  try {
+    const parsed = parseInt(raw, 10);
+    return Number.isNaN(parsed)
+      ? DEFAULT_SYNC_PUSH_ONLY_RECORD_THRESHOLD
+      : parsed;
+  } catch (err) {
+    logError(err);
+    return DEFAULT_SYNC_PUSH_ONLY_RECORD_THRESHOLD;
+  }
+}
+
 /*
  * See batches_limit in https://pouchdb.com/api.html#replication
  */
@@ -754,6 +779,8 @@ export const DIRECTORY_AUTH = directory_auth();
 export const RUNNING_UNDER_TEST = is_testing();
 export const POUCH_BATCH_SIZE = pouch_batch_size();
 export const POUCH_BATCHES_LIMIT = pouch_batches_limit();
+export const SYNC_PUSH_ONLY_RECORD_THRESHOLD =
+  sync_push_only_record_threshold();
 export const CLUSTER_ADMIN_GROUP_NAME = cluster_admin_group_name();
 export const SHOW_POUCHDB_BROWSER = show_pouchdb_browser();
 export const SHOW_WIPE = show_wipe();

--- a/app/src/context/slices/alertSlice.ts
+++ b/app/src/context/slices/alertSlice.ts
@@ -9,8 +9,11 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 interface Alert {
   severity: AlertColor;
   key: string;
+  title?: string;
   message?: string;
   element?: JSX.Element[];
+  /** Snackbar visibility in ms; defaults by severity when omitted. */
+  autoHideDuration?: number;
 }
 
 interface AlertState {

--- a/app/src/context/slices/helpers/databaseHelpers.replication.test.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.replication.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it, vi} from 'vitest';
+import PouchDB from 'pouchdb-browser';
+import {createPouchDbReplication} from './databaseHelpers';
+import {PouchDBWrapper} from './pouchDBWrapper';
+
+vi.mock('pouchdb-browser', () => {
+  const sync = vi.fn(() => ({on: vi.fn().mockReturnThis()}));
+  const replicate = vi.fn(() => ({on: vi.fn().mockReturnThis()}));
+  return {
+    default: {sync, replicate},
+  };
+});
+
+describe('createPouchDbReplication', () => {
+  const localDb = {db: {name: 'local'}} as unknown as PouchDBWrapper<{}>;
+  const remoteDb = {name: 'remote'} as unknown as PouchDB.Database<{}>;
+
+  it('uses PouchDB.sync for both mode', () => {
+    createPouchDbReplication({
+      syncMode: 'both',
+      attachmentDownload: false,
+      localDb,
+      remoteDb,
+    });
+    expect(PouchDB.sync).toHaveBeenCalled();
+  });
+
+  it('uses PouchDB.replicate local→remote for push mode', () => {
+    createPouchDbReplication({
+      syncMode: 'push',
+      attachmentDownload: false,
+      localDb,
+      remoteDb,
+    });
+    expect(PouchDB.replicate).toHaveBeenCalledWith(
+      localDb.db,
+      remoteDb,
+      expect.objectContaining({live: true})
+    );
+  });
+
+  it('uses PouchDB.replicate remote→local for pull mode', () => {
+    createPouchDbReplication({
+      syncMode: 'pull',
+      attachmentDownload: false,
+      localDb,
+      remoteDb,
+    });
+    expect(PouchDB.replicate).toHaveBeenCalledWith(
+      remoteDb,
+      localDb.db,
+      expect.objectContaining({live: true})
+    );
+  });
+});

--- a/app/src/context/slices/helpers/databaseHelpers.replication.test.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.replication.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, it, vi} from 'vitest';
 import PouchDB from 'pouchdb-browser';
-import {createPouchDbReplication} from './databaseHelpers';
+import {
+  createPouchDbReplication,
+  normalizeChangeSyncInfo,
+} from './databaseHelpers';
 import {PouchDBWrapper} from './pouchDBWrapper';
 
 vi.mock('pouchdb-browser', () => {
@@ -9,6 +12,34 @@ vi.mock('pouchdb-browser', () => {
   return {
     default: {sync, replicate},
   };
+});
+
+describe('normalizeChangeSyncInfo', () => {
+  const replicateChange = {
+    ok: true,
+    start_time: '2025-01-01T00:00:00.000Z',
+    docs_read: 2,
+    docs_written: 1,
+    doc_write_failures: 0,
+    errors: [],
+    last_seq: 3,
+    pending: 4,
+  };
+
+  it('wraps one-way replicate() change events', () => {
+    expect(normalizeChangeSyncInfo(replicateChange, 'push')).toEqual({
+      direction: 'push',
+      change: replicateChange,
+    });
+  });
+
+  it('passes through two-way sync() change events', () => {
+    const syncChange = {
+      direction: 'pull' as const,
+      change: replicateChange,
+    };
+    expect(normalizeChangeSyncInfo(syncChange, 'push')).toEqual(syncChange);
+  });
 });
 
 describe('createPouchDbReplication', () => {

--- a/app/src/context/slices/helpers/databaseHelpers.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.ts
@@ -252,16 +252,34 @@ if (DEBUG_APP) {
   };
 }
 
+/**
+ * Live PouchDB replication handle returned by {@link createPouchDbReplication}.
+ *
+ * Either a two-way {@link PouchDB.Replication.Sync} (`syncMode: 'both'`) or a
+ * one-way {@link PouchDB.Replication.Replication} for push/pull-only modes.
+ */
 export type PouchReplicationHandle =
   | PouchDB.Replication.Sync<{}>
   | PouchDB.Replication.Replication<{}>;
 
+/**
+ * Attach replication event handlers to a sync/replicate handle.
+ *
+ * Shared by all sync modes so callers register handlers once regardless of
+ * direction. The types provided in `@types/pouchdb` are incomplete — e.g. see
+ * https://pouchdb.com/api.html#sync — these events are not even available in
+ * the types and the interfaces are incomplete/too-restrictive.
+ *
+ * @param replication The live sync or replicate object from PouchDB
+ * @param eventHandlers Optional handlers for replication lifecycle events
+ * @returns The same handle with handlers attached (for chaining)
+ */
 function attachReplicationEventHandlers(
   replication: PouchReplicationHandle,
   eventHandlers: SyncEventHandlers
 ): PouchReplicationHandle {
   let handle: PouchReplicationHandle = replication;
-  // PouchDB replication event types are incomplete in @types/pouchdb
+  // Attach all provided event handlers — see note above on @types/pouchdb gaps.
   if (eventHandlers.change) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -291,7 +309,30 @@ function attachReplicationEventHandlers(
 }
 
 /**
- * Creates live replication between local and remote DBs for the given sync mode.
+ * Creates live replication between the specified local and remote DBs.
+ *
+ * This is the preferred replication factory: it centralises PouchDB options so
+ * callers cannot misconfigure live/retry/batch sizing. Behaviour depends on
+ * {@link syncMode}:
+ *
+ * - **`both`**: two-way sync via `PouchDB.sync` (push + pull), with optional
+ *   attachment filtering on the pull side.
+ * - **`push`**: one-way replicate local → remote only.
+ * - **`pull`**: one-way replicate remote → local only, with optional attachment
+ *   filtering on the pull side.
+ *
+ * Live replication and retry-on-failure are always enabled. When
+ * `attachmentDownload` is false, pull replication uses
+ * {@link ATTACHMENT_FILTER_CONFIG} so attachments created on other devices are
+ * not downloaded (records still sync).
+ *
+ * @param syncMode Replication direction (`push`, `pull`, or `both`)
+ * @param attachmentDownload Download attachments from other devices when pull is active
+ * @param localDb The local DB to replicate
+ * @param remoteDb The remote DB to replicate
+ * @param eventHandlers Optional event handlers for replication events
+ *
+ * @returns The new live sync/replicate object (with handlers attached)
  */
 export function createPouchDbReplication<Content extends {}>({
   syncMode,
@@ -306,11 +347,16 @@ export function createPouchDbReplication<Content extends {}>({
   remoteDb: PouchDB.Database<Content>;
   eventHandlers?: SyncEventHandlers;
 }): PouchReplicationHandle {
+  // Configure attachment filtering if needed (applies to pull direction only)
   const pullFilter = attachmentDownload ? {} : ATTACHMENT_FILTER_CONFIG;
   const baseOpts: PouchDB.Replication.ReplicateOptions = {
+    // Live sync mode (i.e. poll)
     live: true,
+    // Retry on fail
     retry: true,
+    // Timeout after 15 seconds
     timeout: 15000,
+    // Sync batch sizing options
     batch_size: POUCH_BATCH_SIZE,
     batches_limit: POUCH_BATCHES_LIMIT,
   };
@@ -321,9 +367,16 @@ export function createPouchDbReplication<Content extends {}>({
     case 'both': {
       const options: DBReplicateOptions = {
         ...baseOpts,
-        push: {checkpoint: 'source'},
-        pull: {checkpoint: 'target', ...pullFilter},
+        // Push and pull specific options
+        push: {
+          checkpoint: 'source',
+        },
+        pull: {
+          checkpoint: 'target',
+          ...pullFilter,
+        },
       };
+      // Create the two-way sync object
       replication = PouchDB.sync(localDb.db, remoteDb, options);
       break;
     }
@@ -345,7 +398,22 @@ export function createPouchDbReplication<Content extends {}>({
   return attachReplicationEventHandlers(replication, eventHandlers);
 }
 
-/** @deprecated Use {@link createPouchDbReplication}. */
+/**
+ * Creates a new synchronisation (PouchDB.sync) between the specified local and
+ * remote DB. This uses the preferred sync options to avoid misconfiguration in
+ * caller functions. Two way sync is always enabled, with live and retry. If
+ * attachment filter is supplied, the pull sync options are overridden with a
+ * filter.
+ *
+ * @deprecated Use {@link createPouchDbReplication} with `syncMode: 'both'`.
+ *
+ * @param attachmentDownload Download attachments iff true
+ * @param localDb The local DB to sync
+ * @param remoteDb The remote DB to sync
+ * @param eventHandlers Optional event handlers for sync events
+ *
+ * @returns The new sync object
+ */
 export function createPouchDbSync<Content extends {}>(params: {
   attachmentDownload: boolean;
   localDb: PouchDBWrapper<Content>;

--- a/app/src/context/slices/helpers/databaseHelpers.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.ts
@@ -158,6 +158,9 @@ export function createRemotePouchDbFromConnectionInfo<Content extends {}>({
 /**
  * Information about replication progress/completion
  */
+/** Progress payload shared by PouchDB replicate() change events. */
+export type ReplicationChangeStats = ChangeSyncInfo['change'];
+
 export interface ChangeSyncInfo {
   /** Which sync direction is this? */
   direction: 'push' | 'pull';
@@ -263,6 +266,29 @@ export type PouchReplicationHandle =
   | PouchDB.Replication.Replication<{}>;
 
 /**
+ * Normalise PouchDB change events to the shape produced by two-way sync.
+ *
+ * `PouchDB.sync` emits `{direction, change}`, while one-way `PouchDB.replicate`
+ * emits the change stats object directly (no nested `change` property).
+ */
+export function normalizeChangeSyncInfo(
+  info: ChangeSyncInfo | ReplicationChangeStats,
+  defaultDirection: 'push' | 'pull'
+): ChangeSyncInfo {
+  if ('direction' in info && info.change) {
+    return {
+      direction: info.direction ?? defaultDirection,
+      change: info.change,
+    };
+  }
+
+  return {
+    direction: defaultDirection,
+    change: info as ReplicationChangeStats,
+  };
+}
+
+/**
  * Attach replication event handlers to a sync/replicate handle.
  *
  * Shared by all sync modes so callers register handlers once regardless of
@@ -276,14 +302,18 @@ export type PouchReplicationHandle =
  */
 function attachReplicationEventHandlers(
   replication: PouchReplicationHandle,
-  eventHandlers: SyncEventHandlers
+  eventHandlers: SyncEventHandlers,
+  defaultDirection: 'push' | 'pull'
 ): PouchReplicationHandle {
   let handle: PouchReplicationHandle = replication;
   // Attach all provided event handlers — see note above on @types/pouchdb gaps.
   if (eventHandlers.change) {
+    const onChange = eventHandlers.change;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    handle = handle.on('change', eventHandlers.change);
+    handle = handle.on('change', (info: ChangeSyncInfo | ReplicationChangeStats) => {
+      onChange(normalizeChangeSyncInfo(info, defaultDirection));
+    });
   }
   if (eventHandlers.paused) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -395,7 +425,14 @@ export function createPouchDbReplication<Content extends {}>({
       break;
   }
 
-  return attachReplicationEventHandlers(replication, eventHandlers);
+  const defaultDirection: 'push' | 'pull' =
+    syncMode === 'pull' ? 'pull' : 'push';
+
+  return attachReplicationEventHandlers(
+    replication,
+    eventHandlers,
+    defaultDirection
+  );
 }
 
 /**

--- a/app/src/context/slices/helpers/databaseHelpers.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.ts
@@ -311,9 +311,12 @@ function attachReplicationEventHandlers(
     const onChange = eventHandlers.change;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    handle = handle.on('change', (info: ChangeSyncInfo | ReplicationChangeStats) => {
-      onChange(normalizeChangeSyncInfo(info, defaultDirection));
-    });
+    handle = handle.on(
+      'change',
+      (info: ChangeSyncInfo | ReplicationChangeStats) => {
+        onChange(normalizeChangeSyncInfo(info, defaultDirection));
+      }
+    );
   }
   if (eventHandlers.paused) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/app/src/context/slices/helpers/databaseHelpers.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.ts
@@ -289,12 +289,30 @@ export function normalizeChangeSyncInfo(
 }
 
 /**
+ * PouchDB sync/replicate event surface at runtime.
+ *
+ * `@types/pouchdb` omits several replication events (e.g. `change`, `active`);
+ * see https://pouchdb.com/api.html#sync.
+ */
+type ReplicationEventEmitter = {
+  on(
+    event: 'change' | 'paused' | 'active' | 'denied' | 'error',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listener: (...args: any[]) => any
+  ): PouchReplicationHandle;
+};
+
+function asReplicationEventEmitter(
+  handle: PouchReplicationHandle
+): ReplicationEventEmitter {
+  return handle as unknown as ReplicationEventEmitter;
+}
+
+/**
  * Attach replication event handlers to a sync/replicate handle.
  *
  * Shared by all sync modes so callers register handlers once regardless of
- * direction. The types provided in `@types/pouchdb` are incomplete — e.g. see
- * https://pouchdb.com/api.html#sync — these events are not even available in
- * the types and the interfaces are incomplete/too-restrictive.
+ * direction.
  *
  * @param replication The live sync or replicate object from PouchDB
  * @param eventHandlers Optional handlers for replication lifecycle events
@@ -306,12 +324,10 @@ function attachReplicationEventHandlers(
   defaultDirection: 'push' | 'pull'
 ): PouchReplicationHandle {
   let handle: PouchReplicationHandle = replication;
-  // Attach all provided event handlers — see note above on @types/pouchdb gaps.
+
   if (eventHandlers.change) {
     const onChange = eventHandlers.change;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    handle = handle.on(
+    handle = asReplicationEventEmitter(handle).on(
       'change',
       (info: ChangeSyncInfo | ReplicationChangeStats) => {
         onChange(normalizeChangeSyncInfo(info, defaultDirection));
@@ -319,24 +335,25 @@ function attachReplicationEventHandlers(
     );
   }
   if (eventHandlers.paused) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    handle = handle.on('paused', eventHandlers.paused);
+    handle = asReplicationEventEmitter(handle).on(
+      'paused',
+      eventHandlers.paused
+    );
   }
   if (eventHandlers.active) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    handle = handle.on('active', eventHandlers.active);
+    handle = asReplicationEventEmitter(handle).on(
+      'active',
+      eventHandlers.active
+    );
   }
   if (eventHandlers.denied) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    handle = handle.on('denied', eventHandlers.denied);
+    handle = asReplicationEventEmitter(handle).on(
+      'denied',
+      eventHandlers.denied
+    );
   }
   if (eventHandlers.error) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    handle = handle.on('error', eventHandlers.error);
+    handle = asReplicationEventEmitter(handle).on('error', eventHandlers.error);
   }
   return handle;
 }

--- a/app/src/context/slices/helpers/databaseHelpers.ts
+++ b/app/src/context/slices/helpers/databaseHelpers.ts
@@ -7,6 +7,7 @@ import {
   POUCH_BATCHES_LIMIT,
   RUNNING_UNDER_TEST,
 } from '../../../buildconfig';
+import type {ReplicatingSyncMode} from '../../../sync/syncMode';
 import {DatabaseConnectionConfig, ProjectIdentity} from '../projectSlice';
 import {PouchDBWrapper} from './pouchDBWrapper';
 
@@ -251,87 +252,110 @@ if (DEBUG_APP) {
   };
 }
 
+export type PouchReplicationHandle =
+  | PouchDB.Replication.Sync<{}>
+  | PouchDB.Replication.Replication<{}>;
+
+function attachReplicationEventHandlers(
+  replication: PouchReplicationHandle,
+  eventHandlers: SyncEventHandlers
+): PouchReplicationHandle {
+  let handle: PouchReplicationHandle = replication;
+  // PouchDB replication event types are incomplete in @types/pouchdb
+  if (eventHandlers.change) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    handle = handle.on('change', eventHandlers.change);
+  }
+  if (eventHandlers.paused) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    handle = handle.on('paused', eventHandlers.paused);
+  }
+  if (eventHandlers.active) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    handle = handle.on('active', eventHandlers.active);
+  }
+  if (eventHandlers.denied) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    handle = handle.on('denied', eventHandlers.denied);
+  }
+  if (eventHandlers.error) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    handle = handle.on('error', eventHandlers.error);
+  }
+  return handle;
+}
+
 /**
- * Creates a new synchronisation (PouchDB.sync) between the specified local and
- * remote DB. This uses the preferred sync options to avoid misconfiguration in
- * caller functions. Two way sync is always enabled, with live and retry. If
- * attachment filter is supplied, the pull sync options are overridden with a
- * filter.
- *
- * @param attachmentDownload Download attachments iff true
- * @param localDb The local DB to sync
- * @param remoteDb The remote DB to sync
- * @param eventHandlers Optional event handlers for sync events
- *
- * @returns The new sync object
+ * Creates live replication between local and remote DBs for the given sync mode.
  */
-export function createPouchDbSync<Content extends {}>({
+export function createPouchDbReplication<Content extends {}>({
+  syncMode,
   attachmentDownload,
   localDb,
   remoteDb,
   eventHandlers = DEFAULT_SYNC_HANDLERS,
 }: {
+  syncMode: ReplicatingSyncMode;
   attachmentDownload: boolean;
   localDb: PouchDBWrapper<Content>;
   remoteDb: PouchDB.Database<Content>;
   eventHandlers?: SyncEventHandlers;
-}) {
-  // Configure attachment filtering if needed
+}): PouchReplicationHandle {
   const pullFilter = attachmentDownload ? {} : ATTACHMENT_FILTER_CONFIG;
-  const options: DBReplicateOptions = {
-    // Live sync mode (i.e. poll)
+  const baseOpts: PouchDB.Replication.ReplicateOptions = {
     live: true,
-    // Retry on fail
     retry: true,
-    // Timeout after 15 seconds
     timeout: 15000,
-    // Sync batch sizing options
     batch_size: POUCH_BATCH_SIZE,
     batches_limit: POUCH_BATCHES_LIMIT,
-    // Push and pull specific options
-    push: {
-      checkpoint: 'source',
-    },
-    pull: {
-      checkpoint: 'target',
-      ...pullFilter,
-    },
   };
 
-  // Create the sync object
-  let sync = PouchDB.sync(localDb.db, remoteDb, options);
+  let replication: PouchReplicationHandle;
 
-  // Attach all provided event handlers These types provided in the library are
-  // completely wrong - e.g. see the docs here https://pouchdb.com/api.html#sync
-  // - these events are not even available in the types and the interfaces are
-  //   incomplete/too-restrictive
-  if (eventHandlers.change) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    sync = sync.on('change', eventHandlers.change);
-  }
-  if (eventHandlers.paused) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    sync = sync.on('paused', eventHandlers.paused);
-  }
-  if (eventHandlers.active) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    sync = sync.on('active', eventHandlers.active);
-  }
-  if (eventHandlers.denied) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    sync = sync.on('denied', eventHandlers.denied);
-  }
-  if (eventHandlers.error) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    sync = sync.on('error', eventHandlers.error);
+  switch (syncMode) {
+    case 'both': {
+      const options: DBReplicateOptions = {
+        ...baseOpts,
+        push: {checkpoint: 'source'},
+        pull: {checkpoint: 'target', ...pullFilter},
+      };
+      replication = PouchDB.sync(localDb.db, remoteDb, options);
+      break;
+    }
+    case 'push':
+      replication = PouchDB.replicate(localDb.db, remoteDb, {
+        ...baseOpts,
+        checkpoint: 'source',
+      });
+      break;
+    case 'pull':
+      replication = PouchDB.replicate(remoteDb, localDb.db, {
+        ...baseOpts,
+        checkpoint: 'target',
+        ...pullFilter,
+      });
+      break;
   }
 
-  return sync;
+  return attachReplicationEventHandlers(replication, eventHandlers);
+}
+
+/** @deprecated Use {@link createPouchDbReplication}. */
+export function createPouchDbSync<Content extends {}>(params: {
+  attachmentDownload: boolean;
+  localDb: PouchDBWrapper<Content>;
+  remoteDb: PouchDB.Database<Content>;
+  eventHandlers?: SyncEventHandlers;
+}): PouchReplicationHandle {
+  return createPouchDbReplication({
+    syncMode: 'both',
+    ...params,
+  });
 }
 
 /**

--- a/app/src/context/slices/helpers/databaseService.ts
+++ b/app/src/context/slices/helpers/databaseService.ts
@@ -9,7 +9,10 @@
 import {logError, ProjectDataObject} from '@faims3/data-model';
 import PouchDB from 'pouchdb-browser';
 import PouchDBFind from 'pouchdb-find';
-import {createLocalPouchDatabase} from './databaseHelpers';
+import {
+  createLocalPouchDatabase,
+  PouchReplicationHandle,
+} from './databaseHelpers';
 import {PouchDBWrapper} from './pouchDBWrapper';
 PouchDB.plugin(PouchDBFind);
 
@@ -30,10 +33,7 @@ class DatabaseService {
   private cleanupInProgress: Set<string> = new Set();
   private localDatabases: Map<string, PouchDBWrapper<ProjectDataObject>> =
     new Map();
-  private databaseSyncs: Map<
-    string,
-    PouchDB.Replication.Sync<ProjectDataObject>
-  > = new Map();
+  private databaseSyncs: Map<string, PouchReplicationHandle> = new Map();
   // remote databases are not wrapped
   private remoteDatabases: Map<string, PouchDB.Database<ProjectDataObject>> =
     new Map();
@@ -166,7 +166,7 @@ class DatabaseService {
   }
   async registerSync(
     id: string,
-    sync: PouchDB.Replication.Sync<ProjectDataObject>,
+    sync: PouchReplicationHandle,
     {tolerant = true}: RegisterDbOptions = {}
   ) {
     if (this.databaseSyncs.has(id)) {

--- a/app/src/context/slices/helpers/notebookDefinition.ts
+++ b/app/src/context/slices/helpers/notebookDefinition.ts
@@ -45,5 +45,6 @@ export function projectInformationFromGetNotebook(
     status: notebook.status,
     updatedAt: notebook.updatedAt,
     uiDefinition,
+    recordCount: notebook.recordCount,
   };
 }

--- a/app/src/context/slices/helpers/replicationLifecycle.ts
+++ b/app/src/context/slices/helpers/replicationLifecycle.ts
@@ -1,0 +1,63 @@
+import {ProjectDataObject} from '@faims3/data-model';
+import type {ReplicatingSyncMode} from '../../../sync/syncMode';
+import {isReplicating} from '../../../sync/syncMode';
+import {
+  buildSyncId,
+  createPouchDbReplication,
+  SyncEventHandlers,
+} from './databaseHelpers';
+import {databaseService} from './databaseService';
+import {PouchDBWrapper} from './pouchDBWrapper';
+
+export interface RegisterReplicationParams {
+  syncMode: ReplicatingSyncMode;
+  attachmentDownload: boolean;
+  localDb: PouchDBWrapper<ProjectDataObject>;
+  remoteDb: PouchDB.Database<ProjectDataObject>;
+  localDbId: string;
+  remoteDbId: string;
+  eventHandlers: SyncEventHandlers;
+  oldSyncId?: string;
+}
+
+export interface RegisterReplicationResult {
+  syncId: string | undefined;
+}
+
+/**
+ * Tear down an existing replication handle (if any) and register a new one when
+ * syncMode is not `none`.
+ */
+export async function replaceProjectReplication({
+  syncMode,
+  attachmentDownload,
+  localDb,
+  remoteDb,
+  localDbId,
+  remoteDbId,
+  eventHandlers,
+  oldSyncId,
+}: RegisterReplicationParams): Promise<RegisterReplicationResult> {
+  if (oldSyncId) {
+    await databaseService.closeAndRemoveSync(oldSyncId);
+  }
+
+  if (!isReplicating(syncMode)) {
+    return {syncId: undefined};
+  }
+
+  const replication = createPouchDbReplication({
+    syncMode,
+    attachmentDownload,
+    localDb,
+    remoteDb,
+    eventHandlers,
+  });
+
+  const syncId = buildSyncId({
+    localId: localDbId,
+    remoteId: remoteDbId,
+  });
+  await databaseService.registerSync(syncId, replication);
+  return {syncId};
+}

--- a/app/src/context/slices/helpers/replicationLifecycle.ts
+++ b/app/src/context/slices/helpers/replicationLifecycle.ts
@@ -1,3 +1,22 @@
+/**
+ * @file replicationLifecycle.ts
+ *
+ * Shared lifecycle for PouchDB record replication on an activated notebook.
+ *
+ * Redux persists sync *settings* (`syncMode`, `syncId`, attachment preference) but
+ * cannot hold live PouchDB sync/replicate handles — those live in
+ * {@link databaseService}. Whenever replication must change direction or
+ * options, callers need the same sequence: close any existing handle, optionally
+ * create a new one via {@link createPouchDbReplication}, and register it under
+ * a stable sync id ({@link buildSyncId}).
+ *
+ * This module centralises that teardown/recreate flow so thunks such as
+ * `setSyncMode` in `projectSlice` stay readable and cannot drift in how they
+ * wire handlers, attachment filters, or cleanup. Use
+ * {@link replaceProjectReplication} whenever an activated project's replication
+ * should be replaced wholesale rather than patched in place.
+ */
+
 import {ProjectDataObject} from '@faims3/data-model';
 import type {ReplicatingSyncMode} from '../../../sync/syncMode';
 import {isReplicating} from '../../../sync/syncMode';

--- a/app/src/context/slices/projectSlice.ts
+++ b/app/src/context/slices/projectSlice.ts
@@ -2281,10 +2281,11 @@ export function createSyncStateHandlers(
       syncStateService.setActive(serverId, projectId);
     },
     change: info => {
+      const change = info.change;
       syncStateService.recordChange(serverId, projectId, {
-        pending: info.change.pending ?? 0,
-        docsRead: info.change.docs_read,
-        docsWritten: info.change.docs_written,
+        pending: change.pending ?? 0,
+        docsRead: change.docs_read ?? 0,
+        docsWritten: change.docs_written ?? 0,
         direction: info.direction,
       });
     },

--- a/app/src/context/slices/projectSlice.ts
+++ b/app/src/context/slices/projectSlice.ts
@@ -17,6 +17,7 @@ import {
   CONDUCTOR_URLS,
   DELETE_ON_DEACTIVATION,
   FORCE_REMOTE_DELETION,
+  NOTEBOOK_NAME,
 } from '../../buildconfig';
 import {AppDispatch, RootState} from '../store';
 import {AuthState, isTokenValid, selectActiveServerId} from './authSlice';
@@ -26,7 +27,7 @@ import {
   buildPouchIdentifier,
   buildSyncId,
   createLocalPouchDatabase,
-  createPouchDbSync,
+  createPouchDbReplication,
   createRemotePouchDbFromConnectionInfo,
   fetchNotebookDetails,
   getRemoteDatabaseNameFromId,
@@ -34,7 +35,15 @@ import {
 } from './helpers/databaseHelpers';
 import {databaseService} from './helpers/databaseService';
 import {PouchDBWrapper} from './helpers/pouchDBWrapper';
+import {replaceProjectReplication} from './helpers/replicationLifecycle';
 import {syncStateService} from './helpers/syncStateService';
+import {addAlert} from './alertSlice';
+import {resolveActivationSyncMode} from '../../sync/syncModeDefaults';
+import type {SyncMode} from '../../sync/syncMode';
+import {isReplicating, syncModeIncludesPull} from '../../sync/syncMode';
+import {clearPushOnlyBannerDismissal} from '../../utils/pushOnlyBannerDismissal';
+
+export type {SyncMode};
 
 /**
  * Per server+project: consecutive successful directory responses where the server
@@ -167,13 +176,13 @@ export interface DatabaseConnectionConfig extends DatabaseAuth {
 /**
  * This manages a remote couch connection - a remote connection is a combination
  * of the remote database ID (see databaseService to retrieve it), the sync
- * object (which is only instantiated/active if isSyncing = true)
+ * object (which is only instantiated/active if syncMode !== 'none')
  */
 export interface RemoteCouchConnection {
   // ID of the remote DB - use databaseService to fetch
   remoteDbId: string;
   // The sync object ID - use databaseService to fetch - can be undefined if
-  // isSyncing = false
+  // syncMode = 'none'
   syncId: string | undefined;
   // The configuration for the remote connection e.g. auth, endpoint etc
   connectionConfiguration: DatabaseConnectionConfig;
@@ -182,11 +191,11 @@ export interface DatabaseConnection {
   // A reference to the local data database - retrieve from databaseService
   localDbId: string;
 
-  // This defines whether the database synchronisation is active
-  isSyncing: boolean;
+  /** Record replication direction; `none` = local Pouch only. */
+  syncMode: SyncMode;
 
   // Is pouch configured to download attachments? Attachment download is managed
-  // through a filter on the sync object
+  // through a filter on the pull side of replication
   isSyncingAttachments: boolean;
 
   // Remote database connection (this is always defined since we will always
@@ -211,6 +220,8 @@ export interface ProjectInformation {
   status: ProjectStatus;
   /** Last update from the server, when known. */
   updatedAt?: string;
+  /** Server record count from GET /api/notebooks/:id when known. */
+  recordCount?: number;
 }
 
 // A project is a notebook (configurable label via NOTEBOOK_NAME) — it is relevant to a server, can be
@@ -466,6 +477,7 @@ const projectsSlice = createSlice({
         isActivated: false,
         database: undefined,
         status: payload.status,
+        recordCount: payload.recordCount,
       };
     },
 
@@ -639,6 +651,8 @@ const projectsSlice = createSlice({
         uiDefinition: payload.uiDefinition,
         uiSpecificationId: compiledSpecId,
         status: payload.status,
+        recordCount:
+          payload.recordCount ?? server.projects[payload.projectId].recordCount,
       };
     },
 
@@ -661,6 +675,8 @@ const projectsSlice = createSlice({
         connectionConfiguration,
         remoteDbId,
         syncId,
+        syncMode,
+        recordCount,
       } = action.payload;
 
       // updates the state with all of this new information
@@ -679,7 +695,7 @@ const projectsSlice = createSlice({
         // These are updated
         isActivated: true,
         database: {
-          isSyncing: true,
+          syncMode,
           isSyncingAttachments: false,
           localDbId: localDatabaseId,
           remote: {
@@ -688,6 +704,7 @@ const projectsSlice = createSlice({
             syncId: syncId,
           },
         },
+        recordCount: recordCount ?? project.recordCount,
       };
     },
 
@@ -763,6 +780,7 @@ const projectsSlice = createSlice({
 
       // Cleanup sync state
       syncStateService.removeSyncState(payload.serverId, payload.projectId);
+      clearPushOnlyBannerDismissal(payload);
 
       // updates the state with all of this new information
       state.servers[payload.serverId].projects[payload.projectId] = {
@@ -776,6 +794,7 @@ const projectsSlice = createSlice({
         serverId: project.serverId,
         status: project.status,
         name: project.name,
+        recordCount: project.recordCount,
 
         // These are updated (to indicate de-activation)
         isActivated: false,
@@ -796,7 +815,7 @@ const projectsSlice = createSlice({
         connectionConfiguration: DatabaseConnectionConfig;
         remoteDbId: string;
         syncId: string | undefined;
-        isSyncing: boolean;
+        syncMode: SyncMode;
         isSyncingAttachments: boolean;
         localDbId: string;
       }>
@@ -807,7 +826,7 @@ const projectsSlice = createSlice({
         connectionConfiguration,
         remoteDbId,
         syncId,
-        isSyncing,
+        syncMode,
         isSyncingAttachments,
         localDbId,
       } = action.payload;
@@ -830,11 +849,12 @@ const projectsSlice = createSlice({
         serverId: project.serverId,
         status: project.status,
         name: project.name,
+        recordCount: project.recordCount,
 
         // These are updated
         isActivated: true,
         database: {
-          isSyncing,
+          syncMode,
           isSyncingAttachments,
           localDbId,
           remote: {
@@ -846,7 +866,38 @@ const projectsSlice = createSlice({
       };
     },
 
-    // update the state after we have turned off sync for a project
+    setSyncModeSuccess: (state, action: PayloadAction<Project>) => {
+      const project = action.payload;
+      if (!project.database) {
+        throw new Error('Project database not properly initialised');
+      }
+      state.servers[project.serverId].projects[project.projectId] = {
+        projectId: project.projectId,
+        uiDefinition: project.uiDefinition,
+        uiSpecificationId: project.uiSpecificationId,
+        description: project.description,
+        templateId: project.templateId,
+        updatedAt: project.updatedAt,
+        serverId: project.serverId,
+        status: project.status,
+        name: project.name,
+        recordCount: project.recordCount,
+        isActivated: true,
+        database: {
+          syncMode: project.database.syncMode,
+          isSyncingAttachments: project.database.isSyncingAttachments,
+          localDbId: project.database.localDbId,
+          remote: {
+            connectionConfiguration:
+              project.database.remote.connectionConfiguration,
+            remoteDbId: project.database.remote.remoteDbId,
+            syncId: project.database.remote.syncId,
+          },
+        },
+      };
+    },
+
+    // @deprecated — use setSyncModeSuccess
     stopSyncingProjectSuccess: (state, action: PayloadAction<Project>) => {
       // check project/server exists
       const project = action.payload;
@@ -866,30 +917,25 @@ const projectsSlice = createSlice({
         serverId: project.serverId,
         status: project.status,
         name: project.name,
+        recordCount: project.recordCount,
 
         // Project remains activated, but syncing is stopped
         isActivated: true,
         database: {
-          // Update sync state to indicate no syncing
-          isSyncing: false,
-          // Retain attachment sync setting for when sync is resumed
+          syncMode: 'none',
           isSyncingAttachments: project.database.isSyncingAttachments,
-          // Retain local database reference
           localDbId: project.database.localDbId,
-          // Retain remote connection info for future re-sync
           remote: {
-            // Keep connection configuration for when sync is resumed
             connectionConfiguration:
               project.database.remote.connectionConfiguration,
             remoteDbId: project.database.remote.remoteDbId,
-            // No sync object when syncing is paused
             syncId: undefined,
           },
         },
       };
     },
 
-    // update the state after we have turned sync back on for a project
+    // @deprecated — use setSyncModeSuccess
     resumeSyncingProjectSuccess: (state, action: PayloadAction<Project>) => {
       // check project/server exists
       const project = action.payload;
@@ -909,22 +955,18 @@ const projectsSlice = createSlice({
         serverId: project.serverId,
         status: project.status,
         name: project.name,
+        recordCount: project.recordCount,
 
         // These are updated
         isActivated: true,
         database: {
-          // Set syncing to true
-          isSyncing: true,
-          // Retain attachment sync setting
+          syncMode: project.database.syncMode,
           isSyncingAttachments: project.database.isSyncingAttachments,
-          // Retain local database reference
           localDbId: project.database.localDbId,
           remote: {
-            // Keep existing connection configuration
             connectionConfiguration:
               project.database.remote.connectionConfiguration,
             remoteDbId: project.database.remote.remoteDbId,
-            // Set new sync ID
             syncId: project.database.remote.syncId,
           },
         },
@@ -997,8 +1039,8 @@ const projectsSlice = createSlice({
 
       // Remove if needed
       const oldSyncId = project.database.remote.syncId;
-      if (project.database.isSyncing && oldSyncId) {
-        databaseService.closeAndRemoveSync(oldSyncId);
+      if (isReplicating(project.database.syncMode) && oldSyncId) {
+        void databaseService.closeAndRemoveSync(oldSyncId);
 
         updatedSyncId = buildSyncId({
           localId: project.database.localDbId,
@@ -1009,19 +1051,14 @@ const projectsSlice = createSlice({
           payload.projectId,
           payload.serverId
         );
-        // creates the sync object (PouchDB.Replication.Sync)
-        const sync = createPouchDbSync({
-          // STOP syncing attachments
+        const replication = createPouchDbReplication({
+          syncMode: project.database.syncMode,
           attachmentDownload: false,
-          // local is fine to continue using!
           localDb,
-          // reuse existing remote db
           remoteDb,
           eventHandlers: handlers,
         });
-
-        // Register the sync
-        databaseService.registerSync(updatedSyncId, sync);
+        void databaseService.registerSync(updatedSyncId, replication);
       }
 
       // updates the state with all of this new information
@@ -1036,22 +1073,18 @@ const projectsSlice = createSlice({
         serverId: project.serverId,
         status: project.status,
         name: project.name,
+        recordCount: project.recordCount,
 
         // These are updated
         isActivated: true,
         database: {
-          // retain
-          isSyncing: project.database.isSyncing,
-          // This is UPDATED
+          syncMode: project.database.syncMode,
           isSyncingAttachments: false,
-          // This is retained
           localDbId: project.database.localDbId,
           remote: {
-            // reuse connection and remote
             connectionConfiguration:
               project.database.remote.connectionConfiguration,
             remoteDbId: project.database.remote.remoteDbId,
-            // new sync
             syncId: updatedSyncId,
           },
         },
@@ -1127,8 +1160,12 @@ const projectsSlice = createSlice({
 
       // Remove if needed
       const oldSyncId = project.database.remote.syncId;
-      if (project.database.isSyncing && oldSyncId) {
-        databaseService.closeAndRemoveSync(oldSyncId);
+      if (
+        isReplicating(project.database.syncMode) &&
+        syncModeIncludesPull(project.database.syncMode) &&
+        oldSyncId
+      ) {
+        void databaseService.closeAndRemoveSync(oldSyncId);
 
         updatedSyncId = buildSyncId({
           localId: project.database.localDbId,
@@ -1139,19 +1176,14 @@ const projectsSlice = createSlice({
           payload.projectId,
           payload.serverId
         );
-        // creates the sync object (PouchDB.Replication.Sync)
-        const sync = createPouchDbSync({
-          // START syncing attachments
+        const replication = createPouchDbReplication({
+          syncMode: project.database.syncMode,
           attachmentDownload: true,
-          // local is fine to continue using!
           localDb,
-          // reuse existing remote db
           remoteDb,
           eventHandlers: handlers,
         });
-
-        // Register the sync
-        databaseService.registerSync(updatedSyncId, sync);
+        void databaseService.registerSync(updatedSyncId, replication);
       }
 
       // updates the state with all of this new information
@@ -1166,22 +1198,18 @@ const projectsSlice = createSlice({
         serverId: project.serverId,
         status: project.status,
         name: project.name,
+        recordCount: project.recordCount,
 
         // These are updated
         isActivated: true,
         database: {
-          // retained
-          isSyncing: project.database.isSyncing,
-          // This is UPDATED
+          syncMode: project.database.syncMode,
           isSyncingAttachments: true,
-          // This is retained
           localDbId: project.database.localDbId,
           remote: {
-            // reuse connection and remote
             connectionConfiguration:
               project.database.remote.connectionConfiguration,
             remoteDbId: project.database.remote.remoteDbId,
-            // new sync
             syncId: updatedSyncId,
           },
         },
@@ -1471,25 +1499,23 @@ export const updateDatabaseCredentials = createAsyncThunk<
 
         // Step 5: Create new sync if needed
         let updatedSyncId: string | undefined = undefined;
-        if (project.database.isSyncing) {
+        if (isReplicating(project.database.syncMode)) {
           const handlers = createSyncStateHandlers(
             project.projectId,
             project.serverId
           );
-          const sync = createPouchDbSync({
-            // re-use existing attachment sync setting
+          const replication = createPouchDbReplication({
+            syncMode: project.database.syncMode,
             attachmentDownload: project.database.isSyncingAttachments,
-            // use the same local database
-            localDb: localDb,
+            localDb,
             remoteDb,
             eventHandlers: handlers,
           });
-          // register the sync
           updatedSyncId = buildSyncId({
             localId: project.database.localDbId,
             remoteId: remoteDbId,
           });
-          databaseService.registerSync(updatedSyncId, sync);
+          databaseService.registerSync(updatedSyncId, replication);
         }
 
         // Step 6: Update Redux state with new configuration
@@ -1500,7 +1526,7 @@ export const updateDatabaseCredentials = createAsyncThunk<
             connectionConfiguration,
             remoteDbId,
             syncId: updatedSyncId,
-            isSyncing: project.database.isSyncing,
+            syncMode: project.database.syncMode,
             isSyncingAttachments: project.database.isSyncingAttachments,
             localDbId: project.database.localDbId,
           })
@@ -1605,21 +1631,29 @@ export const activateProject = createAsyncThunk<
     );
   await databaseService.registerRemoteDatabase(remoteDbId, remoteDb);
 
-  // creates the sync object (PouchDB.Replication.Sync)
+  const activationSync = await resolveActivationSyncMode({
+    serverUrl: server.serverUrl,
+    projectId: payload.projectId,
+    token: payload.jwtToken,
+  });
+  const initialSyncMode = activationSync.syncMode;
   const handlers = createSyncStateHandlers(payload.projectId, payload.serverId);
-  const sync = createPouchDbSync({
-    attachmentDownload: false,
-    localDb,
-    remoteDb,
-    eventHandlers: handlers,
-  });
-  const syncId = buildSyncId({
-    localId: localDatabaseId,
-    remoteId: remoteDbId,
-  });
-  await databaseService.registerSync(syncId, sync);
+  let syncId: string | undefined;
+  if (isReplicating(initialSyncMode)) {
+    const replication = createPouchDbReplication({
+      syncMode: initialSyncMode,
+      attachmentDownload: false,
+      localDb,
+      remoteDb,
+      eventHandlers: handlers,
+    });
+    syncId = buildSyncId({
+      localId: localDatabaseId,
+      remoteId: remoteDbId,
+    });
+    await databaseService.registerSync(syncId, replication);
+  }
 
-  // now call the reducer to update the state
   dispatch(
     activateProjectSuccess({
       project,
@@ -1627,9 +1661,22 @@ export const activateProject = createAsyncThunk<
       localDatabaseId,
       connectionConfiguration,
       remoteDbId,
-      syncId,
+      syncId: syncId ?? undefined,
+      syncMode: initialSyncMode,
+      recordCount: activationSync.recordCount,
     })
   );
+
+  if (activationSync.usedPushOnlyDefault) {
+    dispatch(
+      addAlert({
+        severity: 'info',
+        title: 'Sync mode changed',
+        autoHideDuration: 12000,
+        message: `This ${NOTEBOOK_NAME} has a large number of records. Sync has been set to "upload only" to reduce device stress. Other users' records won't be available unless you change the sync mode in the ${NOTEBOOK_NAME}'s Settings.`,
+      })
+    );
+  }
 
   // Perform async initialisation outside of reducer
   await couchInitialiser({
@@ -1645,7 +1692,9 @@ interface ActivateProjectSuccessPayload {
   localDatabaseId: string;
   connectionConfiguration: DatabaseConnectionConfig;
   remoteDbId: string;
-  syncId: string;
+  syncId: string | undefined;
+  syncMode: SyncMode;
+  recordCount?: number;
 }
 
 /**
@@ -1905,6 +1954,7 @@ export const initialiseProjects = createAsyncThunk<void, {serverId: string}>(
               serverId,
               couchDbUrl: details.dataDb.base_url!,
               status: meta.status ?? existingProject.status,
+              recordCount: meta.recordCount ?? existingProject.recordCount,
             })
           );
         }
@@ -2079,186 +2129,118 @@ export const initialiseAllProjects = createAsyncThunk<void>(
 );
 
 /**
- * A syncing database is one where the sync object exists between the local
- * and remote pouch DBs. This stops this sync by destroying this sync
- * object. Updates databaseService registrations and store states.
+ * Change record replication mode for an activated notebook.
  */
-export const stopSyncingProject = createAsyncThunk<void, ProjectIdentity>(
-  'projects/stopSyncingProject',
-  async (payload, {dispatch, getState}) => {
-    const state = getState() as RootState;
-    const projectState = state.projects;
+export const setSyncMode = createAsyncThunk<
+  void,
+  ProjectIdentity & {syncMode: SyncMode}
+>('projects/setSyncMode', async (payload, {dispatch, getState}) => {
+  const state = getState() as RootState;
+  const projectState = state.projects;
+  const {syncMode, ...identity} = payload;
 
-    // Check the server exists
-    const server = serverById(projectState, payload.serverId);
-    if (!server) {
-      // abort
-      throw new Error(
-        `You cannot stop syncing a project for a server which does not exist. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
-    }
-
-    // check the project exists
-    const project = projectByIdentity(projectState, payload);
-    if (!project) {
-      // abort
-      throw new Error(
-        `You cannot stop syncing a project which does not exist. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
-    }
-
-    // check it's already active
-    if (!project.isActivated) {
-      throw new Error(
-        `You cannot stop syncing an inactive project. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
-    }
-
-    // check database and remote are defined
-    if (!project.database || !project.database.remote) {
-      throw new Error(
-        `You cannot stop syncing a project which has no database object and/or remote connection. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}.`
-      );
-    }
-
-    // If already not syncing, nothing to do
-    if (!project.database.isSyncing) {
-      return;
-    }
-
-    // cleanup existing sync
-    const syncId = project.database.remote.syncId;
-    if (!syncId) {
-      throw new Error(
-        `Failed to stop syncing project due to missing sync. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
-    }
-    // async...
-    await databaseService.closeAndRemoveSync(syncId);
-
-    // Create updated project with new sync state
-    const updatedProject: Project = {
-      ...project,
-      database: {
-        ...project.database,
-        isSyncing: false,
-        remote: {
-          ...project.database.remote,
-        },
-      },
-    };
-
-    // update store
-    dispatch(stopSyncingProjectSuccess(updatedProject));
+  const server = serverById(projectState, identity.serverId);
+  if (!server) {
+    throw new Error(
+      `You cannot change sync mode for a server which does not exist. Server ID: ${identity.serverId}. Project ID: ${identity.projectId}`
+    );
   }
-);
 
-/**
- * A syncing database is one where the sync object exists between the local
- * and remote pouch DBs. This stops resumes this sync by establishing this
- * sync object. Updates databaseService registrations and store states.
- */
-export const resumeSyncingProject = createAsyncThunk<void, ProjectIdentity>(
-  'projects/resumeSyncingProject',
-  async (payload, {dispatch, getState}) => {
-    const state = getState() as RootState;
-    const projectState = state.projects;
+  const project = projectByIdentity(projectState, identity);
+  if (!project) {
+    throw new Error(
+      `You cannot change sync mode for a project which does not exist. Server ID: ${identity.serverId}. Project ID: ${identity.projectId}`
+    );
+  }
 
-    console.log('resumeSyncingProject', payload);
+  if (!project.isActivated) {
+    throw new Error(
+      `You cannot change sync mode for an inactive project. Server ID: ${identity.serverId}. Project ID: ${identity.projectId}`
+    );
+  }
 
-    // Check the server exists
-    const server = serverById(projectState, payload.serverId);
-    if (!server) {
-      // abort
-      throw new Error(
-        `You cannot resume syncing a project for a server which does not exist. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
+  if (!project.database || !project.database.remote) {
+    throw new Error(
+      `You cannot change sync mode without a database connection. Server ID: ${identity.serverId}. Project ID: ${identity.projectId}.`
+    );
+  }
+
+  if (project.database.syncMode === syncMode) {
+    return;
+  }
+
+  const oldSyncId = project.database.remote.syncId;
+  let newSyncId: string | undefined;
+
+  if (!isReplicating(syncMode)) {
+    if (oldSyncId) {
+      await databaseService.closeAndRemoveSync(oldSyncId);
     }
-
-    // check the project exists
-    const project = projectByIdentity(projectState, payload);
-    if (!project) {
-      // abort
-      throw new Error(
-        `You cannot resume syncing a project which does not exist. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
-    }
-
-    // check it's already active
-    if (!project.isActivated) {
-      throw new Error(
-        `You cannot resume syncing an inactive project. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}`
-      );
-    }
-
-    // check database and remote are defined
-    if (!project.database || !project.database.remote) {
-      throw new Error(
-        `You cannot resume syncing a project which has no database object and/or remote connection. Server ID: ${payload.serverId}. Project ID: ${payload.projectId}.`
-      );
-    }
-
-    // If already syncing, nothing to do
-    if (project.database.isSyncing) {
-      return;
-    }
-
-    // fetch the existing local DB
+    syncStateService.removeSyncState(identity.serverId, identity.projectId);
+  } else {
     const localDb = databaseService.getLocalDatabase(
       project.database.localDbId
     );
     if (!localDb) {
       throw new Error(
-        `The local DB with ID ${project.database.localDbId} does not exist, so cannot resume syncing.`
+        `The local DB with ID ${project.database.localDbId} does not exist, so cannot change sync mode.`
       );
     }
 
-    // fetch the existing remote DB
     const remoteDb = databaseService.getRemoteDatabase(
       project.database.remote.remoteDbId
     );
     if (!remoteDb) {
       throw new Error(
-        `The remote DB with ID ${project.database.remote.remoteDbId} does not exist, so cannot resume syncing.`
+        `The remote DB with ID ${project.database.remote.remoteDbId} does not exist, so cannot change sync mode.`
       );
     }
 
     const handlers = createSyncStateHandlers(
-      payload.projectId,
-      payload.serverId
+      identity.projectId,
+      identity.serverId
     );
-    // creates the sync object (PouchDB.Replication.Sync)
-    const sync = createPouchDbSync({
-      // Use existing setting for attachments
+    const result = await replaceProjectReplication({
+      syncMode,
       attachmentDownload: project.database.isSyncingAttachments,
-      // Use existing local DB
       localDb,
-      // Use existing remote DB
       remoteDb,
+      localDbId: project.database.localDbId,
+      remoteDbId: project.database.remote.remoteDbId,
       eventHandlers: handlers,
+      oldSyncId,
     });
+    newSyncId = result.syncId;
+  }
 
-    // Register the sync
-    const syncId = buildSyncId({
-      localId: project.database.localDbId,
-      remoteId: project.database.remote.remoteDbId,
-    });
-    await databaseService.registerSync(syncId, sync);
-
-    // Create updated project with new sync state
-    const updatedProject: Project = {
-      ...project,
-      database: {
-        ...project.database,
-        isSyncing: true,
-        remote: {
-          ...project.database.remote,
-          syncId: syncId,
-        },
+  const updatedProject: Project = {
+    ...project,
+    database: {
+      ...project.database,
+      syncMode,
+      remote: {
+        ...project.database.remote,
+        syncId: newSyncId,
       },
-    };
+    },
+  };
 
-    dispatch(resumeSyncingProjectSuccess(updatedProject));
+  dispatch(setSyncModeSuccess(updatedProject));
+});
+
+/** @deprecated Use {@link setSyncMode} with syncMode `'none'`. */
+export const stopSyncingProject = createAsyncThunk<void, ProjectIdentity>(
+  'projects/stopSyncingProject',
+  async (payload, {dispatch}) => {
+    await dispatch(setSyncMode({...payload, syncMode: 'none'})).unwrap();
+  }
+);
+
+/** @deprecated Use {@link setSyncMode} with syncMode `'both'`. */
+export const resumeSyncingProject = createAsyncThunk<void, ProjectIdentity>(
+  'projects/resumeSyncingProject',
+  async (payload, {dispatch}) => {
+    await dispatch(setSyncMode({...payload, syncMode: 'both'})).unwrap();
   }
 );
 
@@ -2307,21 +2289,25 @@ export const rebuildDbs = async (
             });
 
             // and the sync (if needed)
-            if (dbInfo.isSyncing && dbInfo.remote.syncId) {
+            if (isReplicating(dbInfo.syncMode) && dbInfo.remote.syncId) {
               const handlers = createSyncStateHandlers(
                 project.projectId,
                 project.serverId
               );
-              // creates the sync object (PouchDB.Replication.Sync)
-              const sync = createPouchDbSync({
+              const replication = createPouchDbReplication({
+                syncMode: dbInfo.syncMode,
                 attachmentDownload: dbInfo.isSyncingAttachments,
                 localDb,
                 remoteDb,
                 eventHandlers: handlers,
               });
-              await databaseService.registerSync(dbInfo.remote.syncId, sync, {
-                tolerant: true,
-              });
+              await databaseService.registerSync(
+                dbInfo.remote.syncId,
+                replication,
+                {
+                  tolerant: true,
+                }
+              );
             }
           }
           // otherwise we are all good - just local db needed
@@ -2392,11 +2378,7 @@ export function createSyncStateHandlers(
 }
 
 // Private reducers
-const {
-  activateProjectSuccess,
-  stopSyncingProjectSuccess,
-  resumeSyncingProjectSuccess,
-} = projectsSlice.actions;
+const {activateProjectSuccess, setSyncModeSuccess} = projectsSlice.actions;
 
 // Public reducers
 export const {

--- a/app/src/context/slices/projectSlice.ts
+++ b/app/src/context/slices/projectSlice.ts
@@ -304,6 +304,16 @@ export const initialProjectState: ProjectsState = {
   isInitialised: false,
 };
 
+/**
+ * Merge an incoming `recordCount` with a stored value.
+ */
+function mergeRecordCount(
+  incoming: number | undefined,
+  existing: number | undefined
+): number | undefined {
+  return incoming !== undefined ? incoming : existing;
+}
+
 const projectsSlice = createSlice({
   name: 'projects',
   initialState: initialProjectState,
@@ -651,8 +661,10 @@ const projectsSlice = createSlice({
         uiDefinition: payload.uiDefinition,
         uiSpecificationId: compiledSpecId,
         status: payload.status,
-        recordCount:
-          payload.recordCount ?? server.projects[payload.projectId].recordCount,
+        recordCount: mergeRecordCount(
+          payload.recordCount,
+          server.projects[payload.projectId].recordCount
+        ),
       };
     },
 
@@ -704,7 +716,7 @@ const projectsSlice = createSlice({
             syncId: syncId,
           },
         },
-        recordCount: recordCount ?? project.recordCount,
+        recordCount: mergeRecordCount(recordCount, project.recordCount),
       };
     },
 
@@ -882,82 +894,6 @@ const projectsSlice = createSlice({
         status: project.status,
         name: project.name,
         recordCount: project.recordCount,
-        isActivated: true,
-        database: {
-          syncMode: project.database.syncMode,
-          isSyncingAttachments: project.database.isSyncingAttachments,
-          localDbId: project.database.localDbId,
-          remote: {
-            connectionConfiguration:
-              project.database.remote.connectionConfiguration,
-            remoteDbId: project.database.remote.remoteDbId,
-            syncId: project.database.remote.syncId,
-          },
-        },
-      };
-    },
-
-    // @deprecated — use setSyncModeSuccess
-    stopSyncingProjectSuccess: (state, action: PayloadAction<Project>) => {
-      // check project/server exists
-      const project = action.payload;
-
-      if (!project.database)
-        throw new Error('Project database not properly initialised');
-
-      // updates the state to indicate no syncing
-      state.servers[project.serverId].projects[project.projectId] = {
-        // These are retained
-        projectId: project.projectId,
-        uiDefinition: project.uiDefinition,
-        uiSpecificationId: project.uiSpecificationId,
-        description: project.description,
-        templateId: project.templateId,
-        updatedAt: project.updatedAt,
-        serverId: project.serverId,
-        status: project.status,
-        name: project.name,
-        recordCount: project.recordCount,
-
-        // Project remains activated, but syncing is stopped
-        isActivated: true,
-        database: {
-          syncMode: 'none',
-          isSyncingAttachments: project.database.isSyncingAttachments,
-          localDbId: project.database.localDbId,
-          remote: {
-            connectionConfiguration:
-              project.database.remote.connectionConfiguration,
-            remoteDbId: project.database.remote.remoteDbId,
-            syncId: undefined,
-          },
-        },
-      };
-    },
-
-    // @deprecated — use setSyncModeSuccess
-    resumeSyncingProjectSuccess: (state, action: PayloadAction<Project>) => {
-      // check project/server exists
-      const project = action.payload;
-
-      if (!project.database)
-        throw new Error('Project database not properly initialised');
-
-      // updates the state with all of this new information
-      state.servers[project.serverId].projects[project.projectId] = {
-        // These are retained
-        projectId: project.projectId,
-        uiDefinition: project.uiDefinition,
-        uiSpecificationId: project.uiSpecificationId,
-        description: project.description,
-        templateId: project.templateId,
-        updatedAt: project.updatedAt,
-        serverId: project.serverId,
-        status: project.status,
-        name: project.name,
-        recordCount: project.recordCount,
-
-        // These are updated
         isActivated: true,
         database: {
           syncMode: project.database.syncMode,
@@ -1954,7 +1890,10 @@ export const initialiseProjects = createAsyncThunk<void, {serverId: string}>(
               serverId,
               couchDbUrl: details.dataDb.base_url!,
               status: meta.status ?? existingProject.status,
-              recordCount: meta.recordCount ?? existingProject.recordCount,
+              recordCount: mergeRecordCount(
+                meta.recordCount,
+                existingProject.recordCount
+              ),
             })
           );
         }
@@ -2227,22 +2166,6 @@ export const setSyncMode = createAsyncThunk<
 
   dispatch(setSyncModeSuccess(updatedProject));
 });
-
-/** @deprecated Use {@link setSyncMode} with syncMode `'none'`. */
-export const stopSyncingProject = createAsyncThunk<void, ProjectIdentity>(
-  'projects/stopSyncingProject',
-  async (payload, {dispatch}) => {
-    await dispatch(setSyncMode({...payload, syncMode: 'none'})).unwrap();
-  }
-);
-
-/** @deprecated Use {@link setSyncMode} with syncMode `'both'`. */
-export const resumeSyncingProject = createAsyncThunk<void, ProjectIdentity>(
-  'projects/resumeSyncingProject',
-  async (payload, {dispatch}) => {
-    await dispatch(setSyncMode({...payload, syncMode: 'both'})).unwrap();
-  }
-);
 
 /**
  * As part of initialisation, rebuilds and registers all databases (local,

--- a/app/src/context/slices/projectsPersistMigration.test.ts
+++ b/app/src/context/slices/projectsPersistMigration.test.ts
@@ -14,6 +14,7 @@ import {
   ProjectStatus,
 } from '@faims3/data-model';
 import {migrateProjectsPersistedState} from './projectsPersistMigration';
+import {migrateProjectsSyncModeV2} from './projectsPersistMigration';
 
 const buildCompiledSpecId = ({
   projectId,
@@ -140,5 +141,99 @@ describe('migrateProjectsPersistedState', () => {
       again.servers[serverId]!.projects[projectId]!.uiDefinition.uiSpec
         .schemaVersion
     ).toBe(CURRENT_NOTEBOOK_UI_SCHEMA_VERSION);
+  });
+});
+
+describe('migrateProjectsSyncModeV2', () => {
+  it('maps legacy isSyncing boolean to syncMode', () => {
+    const migrated = migrateProjectsSyncModeV2({
+      isInitialised: true,
+      servers: {
+        'server-a': {
+          serverId: 'server-a',
+          serverUrl: 'https://example.test',
+          serverTitle: 'Test',
+          shortCodePrefix: 'T',
+          description: '',
+          projects: {
+            off: {
+              projectId: 'off',
+              serverId: 'server-a',
+              name: 'Off',
+              isActivated: true,
+              status: ProjectStatus.OPEN,
+              uiSpecificationId: 'x',
+              uiDefinition: {
+                uiSpec: {
+                  fields: {},
+                  views: {},
+                  viewsets: {},
+                  visible_types: [],
+                },
+                metadata: {
+                  information: {purposeMarkdown: ''},
+                  branding: {},
+                },
+              },
+              database: {
+                localDbId: 'local',
+                isSyncing: false,
+                isSyncingAttachments: false,
+                remote: {
+                  remoteDbId: 'remote',
+                  syncId: undefined,
+                  connectionConfiguration: {
+                    jwtToken: 't',
+                    couchUrl: 'https://couch',
+                    databaseName: 'data-x',
+                  },
+                },
+              },
+            },
+            on: {
+              projectId: 'on',
+              serverId: 'server-a',
+              name: 'On',
+              isActivated: true,
+              status: ProjectStatus.OPEN,
+              uiSpecificationId: 'y',
+              uiDefinition: {
+                uiSpec: {
+                  fields: {},
+                  views: {},
+                  viewsets: {},
+                  visible_types: [],
+                },
+                metadata: {
+                  information: {purposeMarkdown: ''},
+                  branding: {},
+                },
+              },
+              database: {
+                localDbId: 'local2',
+                isSyncing: true,
+                isSyncingAttachments: true,
+                remote: {
+                  remoteDbId: 'remote2',
+                  syncId: 'sync',
+                  connectionConfiguration: {
+                    jwtToken: 't',
+                    couchUrl: 'https://couch',
+                    databaseName: 'data-y',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(migrated.servers['server-a']!.projects.off!.database!.syncMode).toBe(
+      'none'
+    );
+    expect(migrated.servers['server-a']!.projects.on!.database!.syncMode).toBe(
+      'both'
+    );
   });
 });

--- a/app/src/context/slices/projectsPersistMigration.ts
+++ b/app/src/context/slices/projectsPersistMigration.ts
@@ -20,7 +20,9 @@ import type {
   Project,
   ProjectsState,
   ProjectIdToProjectMap,
+  DatabaseConnection,
 } from './projectSlice';
+import {syncModeFromLegacyIsSyncing} from '../../sync/syncMode';
 import {notebookDefinitionFromLegacyPersistedProject} from './helpers/notebookDefinition';
 
 const emptyProjectsState: ProjectsState = {
@@ -339,5 +341,71 @@ export function migrateProjectsPersistedState(state: unknown): ProjectsState {
     ...inbound,
     servers: migratedServers,
     isInitialised: false,
+  };
+}
+
+type LegacyDatabaseConnection = DatabaseConnection & {
+  isSyncing?: boolean;
+};
+
+function migrateDatabaseConnection(
+  database: LegacyDatabaseConnection | undefined
+): DatabaseConnection | undefined {
+  if (!database) {
+    return undefined;
+  }
+  if ('syncMode' in database && database.syncMode) {
+    return database as DatabaseConnection;
+  }
+  const legacyIsSyncing = database.isSyncing ?? true;
+  const {isSyncing: _removed, ...rest} = database;
+  return {
+    ...rest,
+    syncMode: syncModeFromLegacyIsSyncing(legacyIsSyncing),
+  };
+}
+
+function migrateProjectSyncMode(project: Project): Project {
+  if (!project.database) {
+    return project;
+  }
+  return {
+    ...project,
+    database: migrateDatabaseConnection(
+      project.database as LegacyDatabaseConnection
+    ),
+  };
+}
+
+/**
+ * redux-persist migration 2: legacy `database.isSyncing` boolean → `syncMode` enum.
+ */
+export function migrateProjectsSyncModeV2(state: unknown): ProjectsState {
+  logMigrationInfo('begin', {persistVersion: 2});
+
+  if (!isPlainObject(state)) {
+    return emptyProjectsState;
+  }
+
+  const inbound = state as unknown as ProjectsState;
+  const servers = inbound.servers ?? {};
+  const migratedServers: ProjectsState['servers'] = {};
+
+  for (const [serverId, server] of Object.entries(servers)) {
+    if (!server) {
+      continue;
+    }
+    const projects: ProjectIdToProjectMap = {};
+    for (const [projectId, project] of Object.entries(server.projects ?? {})) {
+      projects[projectId] = migrateProjectSyncMode(project);
+    }
+    migratedServers[serverId] = {...server, projects};
+  }
+
+  logMigrationInfo('complete', {persistVersion: 2});
+
+  return {
+    ...inbound,
+    servers: migratedServers,
   };
 }

--- a/app/src/context/slices/projectsPersistMigration.ts
+++ b/app/src/context/slices/projectsPersistMigration.ts
@@ -1,14 +1,33 @@
 /**
- * redux-persist migration for the projects slice (persist version 0 → 1).
+ * @file projectsPersistMigration.ts
  *
- * Older app builds stored each project with a loose `metadata` bag plus
- * `rawUiSpecification` (decoded {@link UiSpecModel}). Current builds expect
- * a typed {@link NotebookDefinition} on `uiDefinition`, with `description` and
- * `templateId` at the project root.
+ * redux-persist migrations for the **projects** slice.
  *
- * Called from `projectsPersistConfig` in `store.tsx` (`createMigrate` version 1).
- * After migration, `isInitialised` is reset to `false` so sync re-runs against
- * the server with the modern shape.
+ * Wired from `projectsPersistConfig` in `store.tsx` via `createMigrate`. When a
+ * user upgrades the app, redux-persist rehydrates IndexedDB state and runs each
+ * migration step from the stored `_persist.version` up to the configured
+ * version (currently **2**).
+ *
+ * These functions must be **pure transforms** of persisted JSON: no network I/O,
+ * no PouchDB handles, and no Redux dispatches. Structured logging
+ * (`[redux-persist-migration]`) is the only intentional side effect.
+ *
+ * **Version 1** — {@link migrateProjectsPersistedState}
+ * - Replaces legacy per-project `metadata` + `rawUiSpecification` with a typed
+ *   {@link NotebookDefinition} on `uiDefinition`, and lifts `description` /
+ *   `templateId` to the project root.
+ * - Resets `isInitialised` to `false` so the app re-fetches the directory and
+ *   recompiles specs against the modern shape (see `initialize()`).
+ * - Per-project failures are **dropped** (logged) rather than aborting the whole
+ *   migration.
+ *
+ * **Version 2** — {@link migrateProjectsSyncModeV2}
+ * - Maps legacy `database.isSyncing: boolean` to {@link SyncMode} on
+ *   `database.syncMode` (`true` → `'both'`, `false` → `'none'`).
+ * - Preserves all other project fields; does not reset `isInitialised`.
+ *
+ * @see store.tsx — `projectsPersistConfig.version` and migrate map
+ * @see projectsPersistMigration.test.ts — regression tests for v1 and v2
  */
 import {
   normalizeNotebookUiSpecification,
@@ -25,28 +44,38 @@ import type {
 import {syncModeFromLegacyIsSyncing} from '../../sync/syncMode';
 import {notebookDefinitionFromLegacyPersistedProject} from './helpers/notebookDefinition';
 
+/** Fallback projects state when persisted data is missing or unusable. */
 const emptyProjectsState: ProjectsState = {
   servers: {},
   isInitialised: false,
 };
 
+/** Log prefix shared with `store.tsx` migrate wrappers for grep-friendly traces. */
 const PERSIST_MIGRATION_LOG = '[redux-persist-migration]';
 
+/** Info-level migration progress (counts, server ids, version transitions). */
 const logMigrationInfo = (
   event: string,
   fields?: Record<string, unknown>
 ): void => logInfo(`${PERSIST_MIGRATION_LOG} ${event}`, fields ?? {});
 
+/** Warn-level migration events (skipped projects, partial data loss). */
 const logMigrationWarn = (
   event: string,
   fields?: Record<string, unknown>
 ): void => logWarn(`${PERSIST_MIGRATION_LOG} ${event}`, fields ?? {});
 
+/** Counters aggregated across a single migration run for the completion log. */
 type PersistMigrationStats = {
+  /** Projects rebuilt from legacy metadata / rawUiSpecification. */
   legacyMigrated: number;
+  /** Projects that only needed uiDefinition re-normalisation. */
   normalized: number;
+  /** normalize-only path failed; fell back to full legacy migration. */
   lightNormalizeFallback: number;
+  /** No uiDefinition, metadata, or rawUiSpecification to migrate. */
   skippedNoPayload: number;
+  /** Normalisation or legacy extraction threw. */
   skippedError: number;
 };
 
@@ -82,10 +111,12 @@ type LegacyPersistedProject = {
   updatedAt?: string;
 };
 
+/** Type guard for corrupt or non-object persisted blobs. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/** Total project count across all servers (for before/after migration logs). */
 function countProjects(servers: ProjectsState['servers'] | undefined): number {
   if (!servers) {
     return 0;
@@ -96,6 +127,7 @@ function countProjects(servers: ProjectsState['servers'] | undefined): number {
   );
 }
 
+/** Log and count a single project that could not be migrated (v1). */
 function logProjectMigrationError(
   projectId: string,
   serverId: string,
@@ -253,11 +285,20 @@ function migrateServerProjects(
 }
 
 /**
- * redux-persist migration 1: legacy `metadata` + `rawUiSpecification` →
- * `uiDefinition`, with root-level `description` / `templateId`.
+ * redux-persist **migration 1**: legacy notebook shape → current {@link Project}.
  *
- * Safe on corrupt or non-object persisted blobs (returns {@link emptyProjectsState}).
- * Per-project failures are dropped rather than failing the whole migration.
+ * Transforms the entire persisted `projects` slice:
+ * - `metadata` + `rawUiSpecification` → `uiDefinition` ({@link NotebookDefinition})
+ * - Root-level `description` and `templateId` backfilled from metadata or spec
+ * - `database` left unchanged (sync mode migration is v2)
+ *
+ * Safe on corrupt or non-object persisted blobs (returns
+ * {@link emptyProjectsState}). Per-project failures are dropped rather than
+ * failing the whole migration. Always sets `isInitialised: false` on success so
+ * startup re-runs directory initialisation.
+ *
+ * @param state Raw rehydrated state from redux-persist (unknown at runtime)
+ * @returns Migrated {@link ProjectsState}
  */
 export function migrateProjectsPersistedState(state: unknown): ProjectsState {
   const stats = emptyPersistMigrationStats();
@@ -344,10 +385,22 @@ export function migrateProjectsPersistedState(state: unknown): ProjectsState {
   };
 }
 
+/**
+ * Persisted {@link DatabaseConnection} before sync-mode work (v2).
+ *
+ * Older builds stored a boolean `isSyncing` instead of {@link SyncMode}.
+ */
 type LegacyDatabaseConnection = DatabaseConnection & {
   isSyncing?: boolean;
 };
 
+/**
+ * Map one persisted database connection to the current shape.
+ *
+ * If `syncMode` is already present, the record is returned unchanged. Otherwise
+ * `isSyncing` is converted via {@link syncModeFromLegacyIsSyncing} (default
+ * `true` when the legacy field is absent, matching historical “sync on” default).
+ */
 function migrateDatabaseConnection(
   database: LegacyDatabaseConnection | undefined
 ): DatabaseConnection | undefined {
@@ -365,6 +418,7 @@ function migrateDatabaseConnection(
   };
 }
 
+/** Apply {@link migrateDatabaseConnection} when a project has an active database. */
 function migrateProjectSyncMode(project: Project): Project {
   if (!project.database) {
     return project;
@@ -378,7 +432,18 @@ function migrateProjectSyncMode(project: Project): Project {
 }
 
 /**
- * redux-persist migration 2: legacy `database.isSyncing` boolean → `syncMode` enum.
+ * redux-persist **migration 2**: `database.isSyncing` boolean → `syncMode` enum.
+ *
+ * Expands record replication from on/off to directional modes in app code;
+ * persisted upgrades map the legacy boolean to:
+ * - `isSyncing: true` (or missing) → `'both'`
+ * - `isSyncing: false` → `'none'`
+ *
+ * Does not alter UI definitions, activation flags, or `isInitialised`. Safe on
+ * corrupt inbound state (returns {@link emptyProjectsState}).
+ *
+ * @param state Output of migration 1 (or v0 state that already used `syncMode`)
+ * @returns Projects state with `database.syncMode` on every activated project
  */
 export function migrateProjectsSyncModeV2(state: unknown): ProjectsState {
   logMigrationInfo('begin', {persistVersion: 2});

--- a/app/src/context/store.tsx
+++ b/app/src/context/store.tsx
@@ -30,7 +30,10 @@ import authReducer, {
   selectIsAuthenticated,
 } from './slices/authSlice';
 import {databaseService} from './slices/helpers/databaseService';
-import {migrateProjectsPersistedState} from './slices/projectsPersistMigration';
+import {
+  migrateProjectsPersistedState,
+  migrateProjectsSyncModeV2,
+} from './slices/projectsPersistMigration';
 import projectsReducer from './slices/projectSlice';
 
 // The below configures indexed DB storage which has a greater limit than
@@ -49,7 +52,7 @@ const PERSIST_MIGRATION_LOG = '[redux-persist-migration]';
 // Configure persistence for the projects slice
 const projectsPersistConfig = {
   key: 'projects',
-  version: 1,
+  version: 2,
   storage: storage('faims-projects-db'),
   blacklist: ['isInitialised'],
   migrate: createMigrate(
@@ -89,6 +92,29 @@ const projectsPersistConfig = {
               cause: err instanceof Error ? err.message : String(err),
             }
           );
+          throw err;
+        }
+      },
+      2: state => {
+        const fromVersion = state?._persist?.version ?? 'unknown';
+        logInfo(`${PERSIST_MIGRATION_LOG} version_migrate`, {
+          fromVersion,
+          toVersion: 2,
+          slice: 'projects',
+        });
+        if (!state) {
+          return state;
+        }
+        try {
+          const migrated = migrateProjectsSyncModeV2(state);
+          return {...migrated, _persist: state._persist};
+        } catch (err) {
+          logWarn(`${PERSIST_MIGRATION_LOG} version_migrate_failed`, {
+            fromVersion,
+            toVersion: 2,
+            slice: 'projects',
+            message: err instanceof Error ? err.message : String(err),
+          });
           throw err;
         }
       },

--- a/app/src/gui/components/alert.tsx
+++ b/app/src/gui/components/alert.tsx
@@ -19,6 +19,7 @@
  */
 
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Snackbar from '@mui/material/Snackbar';
 import {ThemeProvider} from '@mui/material/styles';
 import {createUseStyles} from 'react-jss';
@@ -70,13 +71,17 @@ export default function SystemAlert() {
     return null;
   }
 
+  const autoHideDuration =
+    currentAlert.autoHideDuration ??
+    (currentAlert.severity === 'error' ? 10000 : 6000);
+
   return (
     <ThemeProvider theme={theme}>
       <div className={classes.root}>
         <Snackbar
           key={currentAlert.key || 'default-snackbar-key'}
           open={!!currentAlert}
-          autoHideDuration={currentAlert.severity === 'error' ? 10000 : 6000}
+          autoHideDuration={autoHideDuration}
           onClose={() => handleClose(currentAlert.key)}
           anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
         >
@@ -91,7 +96,10 @@ export default function SystemAlert() {
               transform: 'scale(1)',
             }}
           >
-            {'message' in currentAlert
+            {currentAlert.title ? (
+              <AlertTitle>{currentAlert.title}</AlertTitle>
+            ) : null}
+            {'message' in currentAlert && currentAlert.message
               ? currentAlert.message
               : currentAlert.element}
           </Alert>

--- a/app/src/gui/components/notebook/PushOnlySyncBanner.tsx
+++ b/app/src/gui/components/notebook/PushOnlySyncBanner.tsx
@@ -1,0 +1,68 @@
+import {Alert, AlertTitle, Box, Button, Typography} from '@mui/material';
+import {useState} from 'react';
+import {
+  NOTEBOOK_NAME,
+  SYNC_PUSH_ONLY_RECORD_THRESHOLD,
+} from '../../../buildconfig';
+import {
+  dismissPushOnlyBanner,
+  isPushOnlyBannerDismissed,
+} from '../../../utils/pushOnlyBannerDismissal';
+import type {Project} from '../../../context/slices/projectSlice';
+
+type PushOnlySyncBannerProps = {
+  project: Project;
+  onGoToSyncSettings: () => void;
+};
+
+export default function PushOnlySyncBanner({
+  project,
+  onGoToSyncSettings,
+}: PushOnlySyncBannerProps) {
+  const [dismissed, setDismissed] = useState(() =>
+    isPushOnlyBannerDismissed({
+      serverId: project.serverId,
+      projectId: project.projectId,
+    })
+  );
+
+  const syncMode = project.database?.syncMode;
+  const recordCount = project.recordCount;
+
+  if (
+    dismissed ||
+    syncMode !== 'both' ||
+    recordCount === undefined ||
+    recordCount <= SYNC_PUSH_ONLY_RECORD_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    dismissPushOnlyBanner({
+      serverId: project.serverId,
+      projectId: project.projectId,
+    });
+    setDismissed(true);
+  };
+
+  return (
+    <Alert severity="warning" sx={{mb: 1}}>
+      <AlertTitle>Large {NOTEBOOK_NAME}</AlertTitle>
+      <Typography variant="body2">
+        This {NOTEBOOK_NAME} has a large number of records. Switch to "upload
+        only" to reduce device stress. Your records will be uploaded to the
+        server, but other users&apos; records will not be available on this
+        device.
+      </Typography>
+      <Box sx={{display: 'flex', gap: 1, mt: 1.5}}>
+        <Button variant="outlined" size="small" onClick={onGoToSyncSettings}>
+          Go to sync settings
+        </Button>
+        <Button variant="outlined" size="small" onClick={handleDismiss}>
+          Dismiss
+        </Button>
+      </Box>
+    </Alert>
+  );
+}

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -1,5 +1,5 @@
 import {Action, getVisibleTypes, ProjectStatus} from '@faims3/data-model';
-import {Alert, AlertTitle, AppBar, Box, Paper, Tab, Tabs} from '@mui/material';
+import {Alert, AlertTitle, Box, Paper, Tab, Tabs} from '@mui/material';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {useQueryClient} from '@tanstack/react-query';
@@ -27,6 +27,7 @@ import {DE_ACTIVATE_VERB} from '../workspace/notebooks';
 import AddRecordButtons from './add_record_by_type';
 import {MetadataDisplayComponent} from './MetadataDisplay';
 import {OverviewMap} from './OverviewMap';
+import PushOnlySyncBanner from './PushOnlySyncBanner';
 import {RecordsTable} from './record_table';
 import NotebookSettings from './settings';
 
@@ -41,9 +42,9 @@ type TabIndex = 0 | 1 | 2 | 3 | 4;
 const TAB_TO_INDEX = new Map<TabIndexLabel, TabIndex>([
   ['my_records', 0],
   ['other_records', 1],
-  ['details', 2],
-  ['settings', 3],
-  ['map', 4],
+  ['map', 2],
+  ['details', 3],
+  ['settings', 4],
 ]);
 const INDEX_TO_TAB = new Map<TabIndex, TabIndexLabel>(
   Array.from(TAB_TO_INDEX.entries()).map(([k, v]) => [v, k])
@@ -196,6 +197,11 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
     setTabValue(newValue);
   };
 
+  const goToSyncSettings = () => {
+    setTabIndex(4);
+    setTabValue(4);
+  };
+
   // recordLabel based on viewsets
   const recordLabel =
     uiSpecification.visible_types?.length === 1
@@ -221,6 +227,10 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
           tab. No additional data can be collected for this {NOTEBOOK_NAME}.
         </Alert>
       )}
+      <PushOnlySyncBanner
+        project={project}
+        onGoToSyncSettings={goToSyncSettings}
+      />
       <Box>
         {isAllowedToAddRecords && (
           <Box sx={{mb: 1.5}}>

--- a/app/src/gui/components/notebook/settings/index.tsx
+++ b/app/src/gui/components/notebook/settings/index.tsx
@@ -54,8 +54,13 @@ import {
   DE_ACTIVATE_ACTIVE_VERB,
   DE_ACTIVATE_VERB,
 } from '../../workspace/notebooks';
+import {
+  syncModeIncludesPull,
+  syncModeIncludesPush,
+} from '../../../../sync/syncMode';
 import AutoIncrementerSettingsList from './auto_incrementers';
 import NotebookSyncSwitch from './sync_switch';
+import SyncModeHelpDialog from './syncModeHelpDialog';
 
 export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
   const nav = useNavigate();
@@ -66,6 +71,9 @@ export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
   if (!project) return <></>;
 
   const isSyncingAttachments = project.database?.isSyncingAttachments ?? false;
+  const syncMode = project.database?.syncMode ?? 'none';
+  const pullSyncEnabled = syncModeIncludesPull(syncMode);
+  const pushSyncEnabled = syncModeIncludesPush(syncMode);
   const [openDeactivateDialog, setOpenDeactivateDialog] = React.useState(false);
   const [deactivateSyncAcknowledged, setDeactivateSyncAcknowledged] =
     React.useState(false);
@@ -107,9 +115,17 @@ export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
             elevation={0}
             sx={{p: 2, mb: {xs: 1, sm: 2, md: 3}}}
           >
-            <Typography variant={'h6'} sx={{mb: 2}}>
-              Sync {NOTEBOOK_NAME_CAPITALIZED}
-            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                mb: 2,
+              }}
+            >
+              <Typography variant={'h6'}>Sync Mode</Typography>
+              <SyncModeHelpDialog recordCount={project.recordCount} />
+            </Box>
             <NotebookSyncSwitch project={project} showHelperText={true} />
           </Box>
 
@@ -128,6 +144,7 @@ export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
                 control={
                   <Switch
                     checked={isSyncingAttachments}
+                    disabled={!pullSyncEnabled}
                     sx={{
                       '& .MuiSwitch-switchBase.Mui-checked': {
                         color: theme.palette.icon.main,
@@ -169,14 +186,9 @@ export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
                 }
               />
               <Typography variant={'body2'}>
-                This control is app and device specific. If this option is
-                enabled, Fieldmark™ will automatically download and show images
-                and attachments created by other devices. Be aware that this may
-                be resource intensive and use your mobile data plan. Disable
-                this setting to minimise network usage. This setting will not
-                affect uploading of your data from this device to the central
-                server. Attachments are always uploaded to the server regardless
-                of this setting.
+                {pullSyncEnabled
+                  ? 'This control is app and device specific. If this option is enabled, Fieldmark™ will automatically download and show images and attachments created by other devices. Be aware that this may be resource intensive and use your mobile data plan. Disable this setting to minimise network usage. This setting will not affect uploading of your data from this device to the central server. Attachments are always uploaded to the server regardless of this setting.'
+                  : 'Attachment download requires two-way sync. Change sync mode above to enable this option.'}
               </Typography>
             </Box>
           </Box>
@@ -188,9 +200,10 @@ export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
             <Box>
               <Typography variant={'body2'} sx={{mb: 2}}>
                 {DE_ACTIVATE_ACTIVE_VERB} this {NOTEBOOK_NAME} will remove it
-                from your device and delete all records on your device. Ensure
-                all your records have a green sync status before{' '}
-                {DE_ACTIVATE_ACTIVE_VERB.toLowerCase()}.
+                from your device and delete all records on your device.{' '}
+                {syncMode === 'none'
+                  ? 'Ensure any records you need on the server have been synced before deactivating.'
+                  : 'Ensure all your records have a green sync status (uploaded) before deactivating.'}
               </Typography>
               <Button
                 variant={'outlined'}
@@ -231,7 +244,11 @@ export default function NotebookSettings(props: {uiSpec: UiSpecModel}) {
                   color="primary"
                 />
               }
-              label="I have checked that all records have a green sync status."
+              label={
+                pushSyncEnabled
+                  ? 'I have checked that all records have a green sync status.'
+                  : 'I understand local records will be removed from this device.'
+              }
             />
           </Stack>
         </DialogContent>

--- a/app/src/gui/components/notebook/settings/syncModeHelpDialog.tsx
+++ b/app/src/gui/components/notebook/settings/syncModeHelpDialog.tsx
@@ -80,7 +80,7 @@ export default function SyncModeHelpDialog({
             sx: {
               borderRadius: 2,
               p: 1,
-              boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+              boxShadow: theme.shadows[8],
               position: 'relative',
             },
           },
@@ -115,11 +115,17 @@ export default function SyncModeHelpDialog({
           <Button
             onClick={() => setOpen(false)}
             variant="contained"
+            disableElevation
             sx={{
+              backgroundColor: theme.palette.dialogButton.confirm,
+              color: theme.palette.dialogButton.dialogText,
               fontWeight: 'bold',
               textTransform: 'none',
               fontSize: isMobile ? '0.85rem' : '0.95rem',
               px: 2.5,
+              '&:hover': {
+                backgroundColor: theme.palette.dialogButton.hoverBackground,
+              },
             }}
           >
             Close

--- a/app/src/gui/components/notebook/settings/syncModeHelpDialog.tsx
+++ b/app/src/gui/components/notebook/settings/syncModeHelpDialog.tsx
@@ -1,0 +1,131 @@
+import CloseIcon from '@mui/icons-material/Close';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import {useState, type ReactNode} from 'react';
+import {
+  SYNC_MODE_HELP_MODES,
+  SyncModeHelpContent,
+} from '../../../../sync/syncModeHelpContent';
+import {SYNC_MODE_LABELS} from '../../../../sync/syncMode';
+
+function SyncModeExplanation({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <Box sx={{mb: 2}}>
+      <Typography variant="subtitle1" sx={{fontWeight: 'bold', mb: 0.5}}>
+        {title}
+      </Typography>
+      <Typography variant="body2" component="div">
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+type SyncModeHelpDialogProps = {
+  recordCount?: number;
+};
+
+export default function SyncModeHelpDialog({
+  recordCount,
+}: SyncModeHelpDialogProps) {
+  const [open, setOpen] = useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <>
+      <IconButton
+        aria-label="Sync mode help"
+        size="small"
+        onClick={() => setOpen(true)}
+        sx={{
+          padding: 0,
+          '&:hover': {
+            backgroundColor: 'transparent',
+          },
+        }}
+      >
+        <InfoOutlinedIcon
+          sx={{
+            fontSize: '1.6rem',
+            color: theme.palette.secondary.main,
+          }}
+        />
+      </IconButton>
+
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        fullWidth
+        maxWidth="sm"
+        slotProps={{
+          paper: {
+            sx: {
+              borderRadius: 2,
+              p: 1,
+              boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+              position: 'relative',
+            },
+          },
+        }}
+      >
+        <DialogTitle
+          sx={{
+            fontWeight: 'bold',
+            fontSize: '1.2rem',
+            paddingRight: 4,
+          }}
+        >
+          Sync Mode
+          <IconButton
+            aria-label="Close"
+            onClick={() => setOpen(false)}
+            sx={{position: 'absolute', right: 16, top: 16}}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent dividers sx={{maxHeight: '60vh', overflowY: 'auto'}}>
+          {SYNC_MODE_HELP_MODES.map(mode => (
+            <SyncModeExplanation key={mode} title={SYNC_MODE_LABELS[mode]}>
+              <SyncModeHelpContent mode={mode} recordCount={recordCount} />
+            </SyncModeExplanation>
+          ))}
+        </DialogContent>
+
+        <DialogActions sx={{pt: 2, justifyContent: 'flex-end'}}>
+          <Button
+            onClick={() => setOpen(false)}
+            variant="contained"
+            sx={{
+              fontWeight: 'bold',
+              textTransform: 'none',
+              fontSize: isMobile ? '0.85rem' : '0.95rem',
+              px: 2.5,
+            }}
+          >
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/app/src/gui/components/notebook/settings/sync_switch.tsx
+++ b/app/src/gui/components/notebook/settings/sync_switch.tsx
@@ -142,7 +142,11 @@ export default function NotebookSyncSwitch({
             aria-labelledby="sync-mode-dialog-title"
             maxWidth="sm"
             fullWidth
-            PaperProps={{sx: {p: 1}}}
+            slotProps={{
+              paper: {
+                sx: {p: 1},
+              },
+            }}
           >
             <DialogTitle id="sync-mode-dialog-title">
               Change sync mode?

--- a/app/src/gui/components/notebook/settings/sync_switch.tsx
+++ b/app/src/gui/components/notebook/settings/sync_switch.tsx
@@ -13,31 +13,37 @@
  * See, the License, for the specific language governing permissions and
  * limitations under the License.
  *
- * Filename: sync.tsx
+ * Filename: sync_switch.tsx
  * Description:
- * This provides a react component to manage the syncing state of a specific
- * project via a toggle.
+ * Sync mode selector for an activated notebook.
  */
 
 import {
-  Alert,
-  AlertTitle,
   Box,
   Button,
   Dialog,
   DialogActions,
-  FormControlLabel,
+  DialogContent,
+  DialogTitle,
+  FormControl,
   FormHelperText,
-  Switch,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
   Typography,
 } from '@mui/material';
 import {useState} from 'react';
 import {NOTEBOOK_NAME} from '../../../../buildconfig';
 import {
   Project,
-  resumeSyncingProject,
-  stopSyncingProject,
+  setSyncMode,
+  SyncMode,
 } from '../../../../context/slices/projectSlice';
+import {
+  SYNC_MODE_LABELS,
+  syncModeIncludesPull,
+} from '../../../../sync/syncMode';
+import {SyncModeHelpContent} from '../../../../sync/syncModeHelpContent';
 import {theme} from '../../../themes';
 import NotebookActivationSwitch from './activation-switch';
 import {useAppDispatch} from '../../../../context/store';
@@ -48,16 +54,55 @@ type NotebookSyncSwitchProps = {
   setTabID?: Function;
 };
 
+const SYNC_MODE_OPTIONS: SyncMode[] = ['none', 'push', 'both'];
+
 export default function NotebookSyncSwitch({
   project,
   showHelperText,
   setTabID = () => {},
 }: NotebookSyncSwitchProps) {
   const [open, setOpen] = useState(false);
+  const [pendingMode, setPendingMode] = useState<SyncMode | null>(null);
   const dispatch = useAppDispatch();
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
-  const isSyncing = project.database?.isSyncing ?? false;
+
+  const currentMode = project.database?.syncMode ?? 'none';
+
+  const handleModeSelect = (event: SelectChangeEvent<SyncMode>) => {
+    const next = event.target.value as SyncMode;
+    if (next === currentMode) {
+      return;
+    }
+    setPendingMode(next);
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setPendingMode(null);
+  };
+
+  const handleConfirm = () => {
+    if (!pendingMode) {
+      handleClose();
+      return;
+    }
+    dispatch(
+      setSyncMode({
+        projectId: project.projectId,
+        serverId: project.serverId,
+        syncMode: pendingMode,
+      })
+    );
+    handleClose();
+  };
+
+  const warning =
+    pendingMode !== null ? (
+      <SyncModeHelpContent
+        mode={pendingMode}
+        recordCount={project.recordCount}
+      />
+    ) : null;
 
   return (
     <Box sx={{display: 'flex', alignItems: 'center', height: '100%'}}>
@@ -69,51 +114,51 @@ export default function NotebookSyncSwitch({
         />
       ) : (
         <Box>
-          <FormControlLabel
-            sx={{mr: 0, md: 2}}
-            control={
-              <Switch
-                checked={isSyncing ?? false}
-                disabled={false}
-                onClick={handleOpen}
-                sx={{
-                  '& .MuiSwitch-switchBase.Mui-checked': {
-                    color: theme.palette.icon.main,
-                  },
-                  '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                    backgroundColor: theme.palette.icon.main,
-                  },
-                }}
-              />
-            }
-            label={
-              <Typography variant={'button'}>
-                {isSyncing ? 'On' : 'Off'}
-              </Typography>
-            }
-          />
+          <FormControl fullWidth size="small" sx={{minWidth: 220}}>
+            <Select
+              value={currentMode}
+              onChange={handleModeSelect}
+              renderValue={value => SYNC_MODE_LABELS[value as SyncMode]}
+              aria-label="Sync mode"
+            >
+              {SYNC_MODE_OPTIONS.map(mode => (
+                <MenuItem key={mode} value={mode}>
+                  {SYNC_MODE_LABELS[mode]}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
           {showHelperText ? (
             <FormHelperText>
-              Toggle syncing this {NOTEBOOK_NAME} to the server.
+              Choose how this {NOTEBOOK_NAME} syncs record data with the server.
+              {!syncModeIncludesPull(currentMode)
+                ? ' Attachment download requires two-way sync.'
+                : ''}
             </FormHelperText>
-          ) : (
-            ''
-          )}
+          ) : null}
           <Dialog
             open={open}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-            slotProps={{
-              paper: {
-                sx: {padding: 2},
-              },
-            }}
+            onClose={handleClose}
+            aria-labelledby="sync-mode-dialog-title"
+            maxWidth="sm"
+            fullWidth
+            PaperProps={{sx: {p: 1}}}
           >
-            <Alert severity={isSyncing ? 'warning' : 'info'}>
-              <AlertTitle>Are you sure?</AlertTitle>
-              Do you want to {isSyncing ? 'stop' : 'start'} syncing the{' '}
-              {project.name} {NOTEBOOK_NAME} to your device?
-            </Alert>
+            <DialogTitle id="sync-mode-dialog-title">
+              Change sync mode?
+            </DialogTitle>
+            <DialogContent>
+              {pendingMode !== null ? (
+                <Typography variant="body2" sx={{mb: 1}}>
+                  Switch to &ldquo;{SYNC_MODE_LABELS[pendingMode]}&rdquo;?
+                </Typography>
+              ) : null}
+              {warning ? (
+                <Typography variant="body2" component="div">
+                  {warning}
+                </Typography>
+              ) : null}
+            </DialogContent>
             <DialogActions className="dialog-actions-spread">
               <Button
                 variant="contained"
@@ -127,35 +172,15 @@ export default function NotebookSyncSwitch({
                 Cancel
               </Button>
               <Button
-                size={'small'}
                 variant="contained"
                 sx={{
                   backgroundColor: theme.palette.dialogButton?.confirm,
                   color: theme.palette.dialogButton.dialogText,
                 }}
                 disableElevation
-                onClick={async () => {
-                  if (isSyncing) {
-                    // stop syncing
-                    dispatch(
-                      stopSyncingProject({
-                        projectId: project.projectId,
-                        serverId: project.serverId,
-                      })
-                    );
-                  } else {
-                    // start syncing
-                    dispatch(
-                      resumeSyncingProject({
-                        projectId: project.projectId,
-                        serverId: project.serverId,
-                      })
-                    );
-                  }
-                  handleClose();
-                }}
+                onClick={handleConfirm}
               >
-                {isSyncing ? 'Stop ' : 'Start'} sync
+                Confirm
               </Button>
             </DialogActions>
           </Dialog>

--- a/app/src/gui/components/notebook/settings/sync_switch.tsx
+++ b/app/src/gui/components/notebook/settings/sync_switch.tsx
@@ -166,9 +166,13 @@ export default function NotebookSyncSwitch({
             <DialogActions className="dialog-actions-spread">
               <Button
                 variant="contained"
+                disableElevation
                 sx={{
                   backgroundColor: theme.palette.dialogButton.cancel,
                   color: theme.palette.dialogButton.dialogText,
+                  '&:hover': {
+                    backgroundColor: theme.palette.text.primary,
+                  },
                 }}
                 onClick={handleClose}
                 autoFocus
@@ -177,11 +181,14 @@ export default function NotebookSyncSwitch({
               </Button>
               <Button
                 variant="contained"
-                sx={{
-                  backgroundColor: theme.palette.dialogButton?.confirm,
-                  color: theme.palette.dialogButton.dialogText,
-                }}
                 disableElevation
+                sx={{
+                  backgroundColor: theme.palette.dialogButton.confirm,
+                  color: theme.palette.dialogButton.dialogText,
+                  '&:hover': {
+                    backgroundColor: theme.palette.dialogButton.hoverBackground,
+                  },
+                }}
                 onClick={handleConfirm}
               >
                 Confirm

--- a/app/src/sync/sync-state.tsx
+++ b/app/src/sync/sync-state.tsx
@@ -276,11 +276,17 @@ export default function SyncStatus() {
         aggregatedStatus.pendingRecords > 0
           ? ` (${aggregatedStatus.pendingRecords} pending)`
           : '';
-      return `Sync is underway${pendingText}`;
+      const direction =
+        isSyncingUp && !isSyncingDown
+          ? 'Upload'
+          : isSyncingDown && !isSyncingUp
+            ? 'Download'
+            : 'Sync';
+      return `${direction} is underway${pendingText}`;
     }
 
     if (status === 'paused') {
-      return 'Sync is paused';
+      return 'Sync is idle';
     }
 
     return 'Waiting for changes';
@@ -291,7 +297,9 @@ export default function SyncStatus() {
    */
   const getStatusLabel = (): string => {
     if (isSyncError) return 'Error';
-    if (isSyncingUp || isSyncingDown) return 'In Progress';
+    if (isSyncingUp && isSyncingDown) return 'In Progress';
+    if (isSyncingUp) return 'Uploading';
+    if (isSyncingDown) return 'Downloading';
     if (status === 'paused') return 'Complete';
     return 'Complete';
   };

--- a/app/src/sync/syncMode.ts
+++ b/app/src/sync/syncMode.ts
@@ -1,0 +1,32 @@
+/** Record replication direction for an activated notebook. */
+export type SyncMode = 'none' | 'push' | 'pull' | 'both';
+
+export type ReplicatingSyncMode = Exclude<SyncMode, 'none'>;
+
+export const SYNC_MODES_WITH_REPLICATION: SyncMode[] = ['push', 'pull', 'both'];
+
+export function isReplicating(
+  syncMode: SyncMode
+): syncMode is ReplicatingSyncMode {
+  return syncMode !== 'none';
+}
+
+export function syncModeIncludesPull(syncMode: SyncMode): boolean {
+  return syncMode === 'pull' || syncMode === 'both';
+}
+
+export function syncModeIncludesPush(syncMode: SyncMode): boolean {
+  return syncMode === 'push' || syncMode === 'both';
+}
+
+/** Migrate legacy persisted `isSyncing` boolean to {@link SyncMode}. */
+export function syncModeFromLegacyIsSyncing(isSyncing: boolean): SyncMode {
+  return isSyncing ? 'both' : 'none';
+}
+
+export const SYNC_MODE_LABELS: Record<SyncMode, string> = {
+  none: 'Sync off (local device only)',
+  push: 'Upload only',
+  pull: 'Download only',
+  both: 'Upload and download',
+};

--- a/app/src/sync/syncModeDefaults.test.ts
+++ b/app/src/sync/syncModeDefaults.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest';
+
+vi.mock('../context/slices/helpers/databaseHelpers', () => ({
+  fetchNotebookDetails: vi.fn(),
+}));
+
+import {fetchNotebookDetails} from '../context/slices/helpers/databaseHelpers';
+import {resolveActivationSyncMode} from './syncModeDefaults';
+
+const mockFetchNotebookDetails = vi.mocked(fetchNotebookDetails);
+
+describe('resolveActivationSyncMode', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', {onLine: true});
+    mockFetchNotebookDetails.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to both when offline without calling the API', async () => {
+    vi.stubGlobal('navigator', {onLine: false});
+
+    const result = await resolveActivationSyncMode({
+      serverUrl: 'https://example.com',
+      projectId: 'p1',
+      token: 'token',
+    });
+
+    expect(result.syncMode).toBe('both');
+    expect(mockFetchNotebookDetails).not.toHaveBeenCalled();
+  });
+
+  it('defaults to both when the API throws', async () => {
+    mockFetchNotebookDetails.mockRejectedValue(new Error('network error'));
+
+    const result = await resolveActivationSyncMode({
+      serverUrl: 'https://example.com',
+      projectId: 'p1',
+      token: 'token',
+    });
+
+    expect(result.syncMode).toBe('both');
+    expect(result.usedPushOnlyDefault).toBe(false);
+  });
+
+  it('uses push when record count exceeds threshold', async () => {
+    mockFetchNotebookDetails.mockResolvedValue({
+      recordCount: 999999,
+    } as Awaited<ReturnType<typeof fetchNotebookDetails>>);
+
+    const result = await resolveActivationSyncMode({
+      serverUrl: 'https://example.com',
+      projectId: 'p1',
+      token: 'token',
+    });
+
+    expect(result.syncMode).toBe('push');
+    expect(result.usedPushOnlyDefault).toBe(true);
+    expect(result.recordCount).toBe(999999);
+  });
+
+  it('uses both when record count is below threshold', async () => {
+    mockFetchNotebookDetails.mockResolvedValue({
+      recordCount: 10,
+    } as Awaited<ReturnType<typeof fetchNotebookDetails>>);
+
+    const result = await resolveActivationSyncMode({
+      serverUrl: 'https://example.com',
+      projectId: 'p1',
+      token: 'token',
+    });
+
+    expect(result.syncMode).toBe('both');
+    expect(result.usedPushOnlyDefault).toBe(false);
+  });
+});

--- a/app/src/sync/syncModeDefaults.ts
+++ b/app/src/sync/syncModeDefaults.ts
@@ -1,16 +1,59 @@
+/**
+ * @file syncModeDefaults.ts
+ *
+ * **Activation-time** defaults for record replication mode.
+ *
+ * When a user activates a notebook, the app must choose an initial
+ * {@link SyncMode} before live PouchDB replication starts. This module applies a
+ * single heuristic: compare the server's record count (from
+ * `GET /api/notebooks/:id`) against {@link SYNC_PUSH_ONLY_RECORD_THRESHOLD}.
+ *
+ * ## Threshold
+ *
+ * Configured in `buildconfig.ts` as `SYNC_PUSH_ONLY_RECORD_THRESHOLD`
+ * (override via `VITE_SYNC_PUSH_ONLY_RECORD_THRESHOLD`; default **500**). The
+ * default is intentionally conservative — two-way sync of a few hundred
+ * records is usually fine on mobile, but downloading thousands of existing
+ * records can stress storage, bandwidth, and battery. Above the threshold,
+ * activation defaults to **upload only** (`push`) so the device uploads new work
+ * without pulling the full server dataset.
+ *
+ * Users can change mode later in Settings. If activation lands on `both` despite
+ * a large notebook (offline/error path), the record-list
+ * {@link ../gui/components/notebook/PushOnlySyncBanner} nudges them toward upload
+ * only once `recordCount` is known.
+ *
+ * This runs **once per activation** only; ongoing sync mode changes go through
+ * `setSyncMode` in `projectSlice`.
+ */
+
 import {SYNC_PUSH_ONLY_RECORD_THRESHOLD} from '../buildconfig';
 import {fetchNotebookDetails} from '../context/slices/helpers/databaseHelpers';
 import type {SyncMode} from './syncMode';
 
+/** Result of {@link resolveActivationSyncMode} for `activateProject`. */
 export interface ActivationSyncModeResult {
+  /** Initial replication mode to register with PouchDB. */
   syncMode: SyncMode;
+  /** Server record count when the activation API call succeeded. */
   recordCount?: number;
+  /**
+   * True when sync was set to `push` because count exceeded the threshold.
+   * Used to show the post-activation "Sync mode changed" snackbar.
+   */
   usedPushOnlyDefault: boolean;
 }
 
 /**
- * Resolve initial sync mode at notebook activation from server record count.
- * Offline or API failure → two-way sync (`both`).
+ * Resolve initial sync mode when a notebook is activated.
+ *
+ * Fetches notebook details when online and compares `recordCount` to
+ * {@link SYNC_PUSH_ONLY_RECORD_THRESHOLD}. Never throws — any failure or
+ * ambiguous count falls back to two-way sync (`both`).
+ *
+ * @param serverUrl Base URL for the listing server
+ * @param projectId Notebook id to activate
+ * @param token JWT for `GET /api/notebooks/:id`
  */
 export async function resolveActivationSyncMode({
   serverUrl,

--- a/app/src/sync/syncModeDefaults.ts
+++ b/app/src/sync/syncModeDefaults.ts
@@ -1,0 +1,49 @@
+import {SYNC_PUSH_ONLY_RECORD_THRESHOLD} from '../buildconfig';
+import {fetchNotebookDetails} from '../context/slices/helpers/databaseHelpers';
+import type {SyncMode} from './syncMode';
+
+export interface ActivationSyncModeResult {
+  syncMode: SyncMode;
+  recordCount?: number;
+  usedPushOnlyDefault: boolean;
+}
+
+/**
+ * Resolve initial sync mode at notebook activation from server record count.
+ * Offline or API failure → two-way sync (`both`).
+ */
+export async function resolveActivationSyncMode({
+  serverUrl,
+  projectId,
+  token,
+}: {
+  serverUrl: string;
+  projectId: string;
+  token: string;
+}): Promise<ActivationSyncModeResult> {
+  if (!navigator.onLine) {
+    return {syncMode: 'both', usedPushOnlyDefault: false};
+  }
+
+  try {
+    const details = await fetchNotebookDetails({
+      serverUrl,
+      projectId,
+      token,
+    });
+    const recordCount = details.recordCount;
+    if (recordCount === undefined || Number.isNaN(recordCount)) {
+      return {syncMode: 'both', usedPushOnlyDefault: false};
+    }
+    if (recordCount > SYNC_PUSH_ONLY_RECORD_THRESHOLD) {
+      return {
+        syncMode: 'push',
+        recordCount,
+        usedPushOnlyDefault: true,
+      };
+    }
+    return {syncMode: 'both', recordCount, usedPushOnlyDefault: false};
+  } catch {
+    return {syncMode: 'both', usedPushOnlyDefault: false};
+  }
+}

--- a/app/src/sync/syncModeHelpContent.tsx
+++ b/app/src/sync/syncModeHelpContent.tsx
@@ -1,8 +1,5 @@
 import {Box} from '@mui/material';
-import {
-  NOTEBOOK_NAME,
-  SYNC_PUSH_ONLY_RECORD_THRESHOLD,
-} from '../buildconfig';
+import {NOTEBOOK_NAME, SYNC_PUSH_ONLY_RECORD_THRESHOLD} from '../buildconfig';
 import type {SyncMode} from './syncMode';
 
 /** Modes shown in sync mode help and change confirmations. */

--- a/app/src/sync/syncModeHelpContent.tsx
+++ b/app/src/sync/syncModeHelpContent.tsx
@@ -1,0 +1,67 @@
+import {Box} from '@mui/material';
+import {
+  NOTEBOOK_NAME,
+  SYNC_PUSH_ONLY_RECORD_THRESHOLD,
+} from '../buildconfig';
+import type {SyncMode} from './syncMode';
+
+/** Modes shown in sync mode help and change confirmations. */
+export const SYNC_MODE_HELP_MODES: SyncMode[] = ['none', 'push', 'both'];
+
+export function showsLargeRecordNote(recordCount?: number): boolean {
+  return (
+    recordCount !== undefined && recordCount > SYNC_PUSH_ONLY_RECORD_THRESHOLD
+  );
+}
+
+type SyncModeHelpContentProps = {
+  mode: SyncMode;
+  recordCount?: number;
+};
+
+export function SyncModeHelpContent({
+  mode,
+  recordCount,
+}: SyncModeHelpContentProps) {
+  switch (mode) {
+    case 'none':
+      return (
+        <>
+          Records will only be saved to this device and are not uploaded to the
+          server. To upload your records, switch to &ldquo;Upload only&rdquo; or
+          &ldquo;Upload and download&rdquo;.
+        </>
+      );
+    case 'push':
+      return (
+        <>
+          Your records will be uploaded to the server, but other users&apos;
+          records will not be available on this device.
+        </>
+      );
+    case 'both':
+      return (
+        <>
+          Your records will be uploaded to the server, and other users&apos;
+          records will be available on this device.
+          {showsLargeRecordNote(recordCount) ? (
+            <Box component="span" sx={{display: 'block', mt: 1}}>
+              <strong>Note:</strong> this {NOTEBOOK_NAME} has{' '}
+              {recordCount!.toLocaleString()} records. Downloading a large
+              number of records may consume a large amount of bandwidth, storage
+              and battery.
+            </Box>
+          ) : null}
+        </>
+      );
+    case 'pull':
+      return (
+        <>
+          Records from the server will download to this device, but local edits
+          will not upload until you change sync mode.
+        </>
+      );
+    default:
+      return null;
+  }
+}

--- a/app/src/utils/pushOnlyBannerDismissal.ts
+++ b/app/src/utils/pushOnlyBannerDismissal.ts
@@ -1,0 +1,31 @@
+import type {ProjectIdentity} from '../context/slices/projectSlice';
+
+const STORAGE_PREFIX = 'faims.pushOnlyBannerDismissed';
+
+function storageKey({serverId, projectId}: ProjectIdentity): string {
+  return `${STORAGE_PREFIX}:${serverId}:${projectId}`;
+}
+
+export function isPushOnlyBannerDismissed(id: ProjectIdentity): boolean {
+  try {
+    return localStorage.getItem(storageKey(id)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function dismissPushOnlyBanner(id: ProjectIdentity): void {
+  try {
+    localStorage.setItem(storageKey(id), '1');
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export function clearPushOnlyBannerDismissal(id: ProjectIdentity): void {
+  try {
+    localStorage.removeItem(storageKey(id));
+  } catch {
+    // ignore quota / private mode
+  }
+}

--- a/docs/developer/docs/source/markdown/AppInitialisation.md
+++ b/docs/developer/docs/source/markdown/AppInitialisation.md
@@ -55,9 +55,11 @@ the active list but does not delete any databases.
 Note that when a local PouchDB instance is created, it will connect to an existing
 database if present or create a new one if not.
 
-The sync status of a project can be updated with the `stopSyncingProject` and
-`resumeSyncingProject` actions. These actions leave the database connections
-alone but operate on the sync object (created with `createPouchDBSync`).
+Record replication for an activated project is controlled with the
+`setSyncMode` async thunk (sync off, upload only, or upload and download).
+It tears down and recreates the live PouchDB replication handle via
+`replaceProjectReplication` while leaving local and remote database connections
+registered in {@link databaseService}.
 
 Lower level database connection management happens in [databaseService.ts](../../../../../app/src/context/slices/databaseService.ts)
 via the singleton `DatabaseService` class. This class maintains a register of

--- a/docs/developer/docs/source/markdown/Knip.md
+++ b/docs/developer/docs/source/markdown/Knip.md
@@ -77,15 +77,15 @@ mode and declares **every** pnpm workspace explicitly. Each entry under
 
 The workspaces and their entry points:
 
-| Workspace                | Entry                                                | Notes                                             |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------------------- |
-| `api`                    | `src/index.ts`, `src/scripts/*.ts`                   | Express server + ts-node CLIs; Mocha tests via plugin |
-| `app`                    | `src/index.tsx`                                       | Vite/Vitest + Capacitor                           |
-| `web`                    | `src/main.tsx`                                        | Vite/Vitest + TanStack Router (`routeTree.gen.ts`)|
-| `library/forms`          | `lib/index.ts`, `src/main.tsx`                        | Published lib (`lib/`) + dev harness (`src/`)     |
-| `library/data-model`     | `src/index.ts`                                        | Jest tests via plugin                             |
-| `infrastructure/aws-cdk` | `bin/aws-cdk-faims-infra.ts`, `validateConfig.ts`    | Code lives in `lib/`/`bin/`, not `src/`           |
-| `e2e`                    | `wdio*.conf.ts`, `test/specs/**/*.e2e.ts`, `chrome-headless-capabilities.ts` | WebdriverIO + Appium      |
+| Workspace                | Entry                                                                        | Notes                                                 |
+| ------------------------ | ---------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `api`                    | `src/index.ts`, `src/scripts/*.ts`                                           | Express server + ts-node CLIs; Mocha tests via plugin |
+| `app`                    | `src/index.tsx`                                                              | Vite/Vitest + Capacitor                               |
+| `web`                    | `src/main.tsx`                                                               | Vite/Vitest + TanStack Router (`routeTree.gen.ts`)    |
+| `library/forms`          | `lib/index.ts`, `src/main.tsx`                                               | Published lib (`lib/`) + dev harness (`src/`)         |
+| `library/data-model`     | `src/index.ts`                                                               | Jest tests via plugin                                 |
+| `infrastructure/aws-cdk` | `bin/aws-cdk-faims-infra.ts`, `validateConfig.ts`                            | Code lives in `lib/`/`bin/`, not `src/`               |
+| `e2e`                    | `wdio*.conf.ts`, `test/specs/**/*.e2e.ts`, `chrome-headless-capabilities.ts` | WebdriverIO + Appium                                  |
 
 Knip auto-detects and runs **tool plugins** based on each workspace's
 dependencies and config files (Vite, Vitest, Jest, Mocha, WebdriverIO,
@@ -107,7 +107,7 @@ The config also sets:
   ```
 
 - `ignoreBinaries: ["run-script"]` — suppresses a false positive: `pnpm
-  run-script ...` is a built-in pnpm subcommand, not an external binary.
+run-script ...` is a built-in pnpm subcommand, not an external binary.
 - Per-workspace `ignoreDependencies` for packages that are **resolved at
   runtime by a toolchain** and can never be seen by static analysis:
   - `app`: `@capacitor/android`, `@capacitor/ios` — native platform packages,
@@ -121,7 +121,7 @@ The config also sets:
 Knip honours `.gitignore` files when building its `project` file list. A
 malformed pattern in `api/.gitignore` (`*data_dummy_listing||*`) was previously
 parsed by Knip's glob engine as an empty alternation (`||`) that matched
-**everything**, so the entire `api/src` tree was excluded and *every* api
+**everything**, so the entire `api/src` tree was excluded and _every_ api
 dependency was falsely reported as unused. Git itself treats the `|` characters
 literally, so the bug was invisible outside of Knip. The pattern has been
 corrected to `*data_dummy_listing*` (its evident intent), which both fixes Knip
@@ -134,18 +134,18 @@ With the corrected configuration, the remaining findings are **genuine** and
 worth reviewing — they are no longer configuration artefacts. As of writing, a
 `pnpm knip` run reports roughly:
 
-| Category                     | Count | What to do                                                  |
-| ---------------------------- | ----- | ---------------------------------------------------------- |
-| Unused files                 | ~18   | Verify, then delete (e.g. orphaned themes, `._test` files) |
-| Unused dependencies          | ~51   | Verify each, then remove from the relevant `package.json`  |
-| Unused devDependencies       | ~28   | As above                                                   |
-| Unlisted dependencies        | ~10   | Add the package to the correct `package.json`              |
-| Unlisted binaries            | ~3    | Declare the providing package, or ignore if external (CI)  |
-| Unresolved imports           | ~2    | Fix the import / install or remove the referenced types    |
-| Unused exports               | ~236  | Verify, then remove the `export` keyword or the symbol     |
-| Unused exported types/enums  | ~11   | As above                                                   |
-| Duplicate exports            | ~42   | Mostly intentional back-compat aliases — see below         |
-| Configuration hints          | ~1    | Root `package.json` `main: index.js` points at a missing file |
+| Category                    | Count | What to do                                                    |
+| --------------------------- | ----- | ------------------------------------------------------------- |
+| Unused files                | ~18   | Verify, then delete (e.g. orphaned themes, `._test` files)    |
+| Unused dependencies         | ~51   | Verify each, then remove from the relevant `package.json`     |
+| Unused devDependencies      | ~28   | As above                                                      |
+| Unlisted dependencies       | ~10   | Add the package to the correct `package.json`                 |
+| Unlisted binaries           | ~3    | Declare the providing package, or ignore if external (CI)     |
+| Unresolved imports          | ~2    | Fix the import / install or remove the referenced types       |
+| Unused exports              | ~236  | Verify, then remove the `export` keyword or the symbol        |
+| Unused exported types/enums | ~11   | As above                                                      |
+| Duplicate exports           | ~42   | Mostly intentional back-compat aliases — see below            |
+| Configuration hints         | ~1    | Root `package.json` `main: index.js` points at a missing file |
 
 Counts will drift as the codebase changes.
 
@@ -162,7 +162,7 @@ Counts will drift as the codebase changes.
   by Vitest and therefore show up as unused files. They are orphaned test files,
   not dead production code — decide whether to re-enable or delete them.
 
-### Common reasons for a finding that is *not* dead code
+### Common reasons for a finding that is _not_ dead code
 
 Before deleting anything, check for these (they are the usual false-positive
 sources, and the ones that remain are why every finding needs a quick manual

--- a/docs/user/core/synchronisation.md
+++ b/docs/user/core/synchronisation.md
@@ -10,11 +10,11 @@ While working online, or within range of an offline server, records will be cont
 
 When you activate a {{notebook}}, record sync starts automatically. In **{{Notebook}} Settings**, use **Sync mode** to choose how record data moves between your device and the server:
 
-| Mode | Behaviour |
-|------|-----------|
-| **Sync off (local device only)** | Records stay on this device; nothing is sent to or received from the server. |
-| **Upload only** | Your new and updated records upload to the server. Existing records from other devices are not downloaded. |
-| **Upload and download** | Full two-way sync (default for smaller {{notebooks}} when online). |
+| Mode                             | Behaviour                                                                                                  |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Sync off (local device only)** | Records stay on this device; nothing is sent to or received from the server.                               |
+| **Upload only**                  | Your new and updated records upload to the server. Existing records from other devices are not downloaded. |
+| **Upload and download**          | Full two-way sync (default for smaller {{notebooks}} when online).                                         |
 
 When you activate a {{notebook}} while online, the app may set **Upload only** automatically for {{notebooks}} with very large numbers of records, to save storage and mobile data. If the record count cannot be fetched (offline or error), **Upload and download** is used instead.
 

--- a/docs/user/core/synchronisation.md
+++ b/docs/user/core/synchronisation.md
@@ -8,15 +8,25 @@ While working online, or within range of an offline server, records will be cont
 
 ## Configuring Synchronisation
 
-Synchronisation is on by default. It does not need to be activated and if you are online, records will synchronise. If you wish to turn off synchronisation, go to the Notebook Settings and slide the 'Sync Notebook' toggle to 'Off'.
+When you activate a {{notebook}}, record sync starts automatically. In **{{Notebook}} Settings**, use **Sync mode** to choose how record data moves between your device and the server:
+
+| Mode | Behaviour |
+|------|-----------|
+| **Sync off (local device only)** | Records stay on this device; nothing is sent to or received from the server. |
+| **Upload only** | Your new and updated records upload to the server. Existing records from other devices are not downloaded. |
+| **Upload and download** | Full two-way sync (default for smaller {{notebooks}} when online). |
+
+When you activate a {{notebook}} while online, the app may set **Upload only** automatically for {{notebooks}} with very large numbers of records, to save storage and mobile data. If the record count cannot be fetched (offline or error), **Upload and download** is used instead.
+
+On the record list, a banner may suggest switching to **Upload only** when a large {{notebook}} is still using two-way sync.
 
 ### Attachments from Other Users
 
 Users can choose whether or not to synchronise files and attachments created by other users.
 
-If enabled, the {{FAIMS}} will automatically download and show images and attachments created on other devices. As this may be resource intensive and affect your mobile data plan, this setting can be disabled to minimise network usage. Attachments are always uploaded to the server regardless of this setting.
+If enabled, the {{FAIMS}} will automatically download and show images and attachments created on other devices. As this may be resource intensive and affect your mobile data plan, this setting can be disabled to minimise network usage. Attachments are always uploaded to the server regardless of this setting. This option requires **Upload and download** sync mode.
 
-By default, notebooks are set to not download files and attachments created by other users. To activate, go to the Notebook Settings and slide the 'Get attachments from other devices' toggle to 'On'.
+By default, {{notebooks}} are set to not download files and attachments created by other users. To activate, go to the {{Notebook}} Settings and turn **Get attachments from other devices** to **On**.
 
 ## Verifying synchronisation
 


### PR DESCRIPTION
Replaces the binary sync on/off model with explicit record replication modes for activated notebooks, while keeping local-first PouchDB writes unchanged.

- **Sync modes:** `none` (local only), `push` (upload only), `pull` (download only, wired but not offered in UI), and `both` (two-way). Persisted `isSyncing` is migrated to `syncMode` via redux-persist **v2**.
- **Replication:** `createPouchDbReplication()` supports one- and two-way live replication; lifecycle is centralised through `setSyncMode` and `replaceProjectReplication`.
- **Activation defaults:** When online, fetches server `recordCount` and defaults to **upload only** above `VITE_SYNC_PUSH_ONLY_RECORD_THRESHOLD` (default 500); offline or API failure falls back to **upload and download**. Shows a titled snackbar (“Sync mode changed”)
- **Settings UX:** Sync mode dropdown (download-only hidden), help dialog, plain confirmation dialog with shared copy, attachment download gated on pull-capable modes. Uses configurable `{NOTEBOOK_NAME}` labels.
- **Record list banner:** Dismissible warning when two-way sync is active and record count exceeds threshold; links to Settings; dismissal stored in localStorage and cleared on deactivation.
- **Fixes:** fix notebook tab index mapping for Settings navigation.
- **Docs/tests:** User sync docs updated; tests for replication factory, persist migration v2, and activation sync defaults.

## Test plan

- [ ] Activate a small notebook online → defaults to upload and download; no push-only snackbar
- [ ] Activate a large notebook online (or set threshold very low e.g. 1 record) → upload only + “Sync mode changed” alert
- [ ] Activate offline → upload and download; record-list banner appears once `recordCount` is known
- [ ] Change sync modes in Settings; confirm dialog copy and help dialog match
- [ ] Change sync modes and validate behaviour with other connected client
- [ ] Dismiss record-list banner; de/re-activate → banner shows again
- [ ] Toggle “Get attachments from other devices” — enabled only under two-way sync
- [ ] Upgrade from persisted state with `isSyncing` → correct `syncMode` after rehydrate