### PR TITLE
fix: use normal font for child-record HRIDs instead of monospace

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
@@ -172,7 +172,6 @@ const RelatedRecordListItem = ({
             primary: {
               variant: 'body2',
               sx: {
-                fontFamily: 'monospace',
                 fontWeight: isHumanReadableHrid ? 'bold' : 'normal',
                 // Monospace only as a fallback when no real HRID was configured
                 // (i.e. we're showing the opaque record id). Real HRIDs use the


### PR DESCRIPTION

## JIRA Ticket

https://jira.csiro.au/browse/BSS-1061

## Description

Briefly describe the purpose of this pull request.

Fixes the child record font
BEFORE :
<img width="327" height="785" alt="Screenshot 2026-06-15 141417" src="https://github.com/user-attachments/assets/5ccdc38d-147e-40ed-9009-0eb2ef1ae268" />



AFTER FIX:
<img width="381" height="888" alt="image" src="https://github.com/user-attachments/assets/9b0a5660-f493-45b7-a8e2-a13658a6b93e" />


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
