### PR TITLE
fix: make advanced-helper popup responsive and fix close icon placement

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
@@ -172,7 +172,6 @@ const RelatedRecordListItem = ({
             primary: {
               variant: 'body2',
               sx: {
-                fontFamily: 'monospace',
                 fontWeight: isHumanReadableHrid ? 'bold' : 'normal',
                 // Monospace only as a fallback when no real HRID was configured
                 // (i.e. we're showing the opaque record id). Real HRIDs use the

--- a/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
@@ -15,9 +15,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Box,
-  Button,
   Dialog,
-  DialogActions,
   DialogContent,
   DialogTitle,
   IconButton,
@@ -290,12 +288,33 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
           fullWidth
           maxWidth="sm"
           slotProps={{
+            container: {
+              sx: {
+                // Portaled dialogs don't inherit body safe-area padding (App.css).
+                pt: {
+                  xs: 'max(12px, calc(12px + env(safe-area-inset-top, 0px)))',
+                  sm: 0,
+                },
+                pb: {
+                  xs: 'max(12px, calc(12px + env(safe-area-inset-bottom, 0px)))',
+                  sm: 0,
+                },
+                pl: {
+                  xs: 'max(12px, calc(12px + env(safe-area-inset-left, 0px)))',
+                  sm: 0,
+                },
+                pr: {
+                  xs: 'max(12px, calc(12px + env(safe-area-inset-right, 0px)))',
+                  sm: 0,
+                },
+              },
+            },
             paper: {
               sx: {
                 borderRadius: 2,
-                m: {xs: 1.5, sm: 4},
-                width: {xs: 'calc(100% - 24px)', sm: 'calc(100% - 64px)'},
-                maxHeight: {xs: 'calc(100% - 24px)', sm: 'calc(100% - 64px)'},
+                m: {xs: 0, sm: 4},
+                width: {xs: '100%', sm: 'calc(100% - 64px)'},
+                maxHeight: {xs: '100%', sm: 'calc(100% - 64px)'},
                 boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
               },
             },
@@ -320,9 +339,20 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
             </Box>
             <IconButton
               onClick={() => setOpenDialog(false)}
-              size="small"
+              size="medium"
               aria-label="Close"
-              sx={{flexShrink: 0, mt: -0.5, mr: -0.5}}
+              sx={{
+                flexShrink: 0,
+                mt: -0.5,
+                mr: -0.5,
+                bgcolor: alpha(theme.palette.common.black, 0.06),
+                boxShadow: '0 4px 20px rgba(0, 0, 0, 0.25)',
+                padding: 1,
+                '&:hover': {
+                  bgcolor: alpha(theme.palette.common.black, 0.1),
+                  boxShadow: '0 6px 24px rgba(0, 0, 0, 0.35)',
+                },
+              }}
             >
               <CloseIcon />
             </IconButton>
@@ -357,30 +387,6 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
               <RichTextContent content={String(advancedHelperText || '')} />
             </Box>
           </DialogContent>
-
-          <DialogActions
-            sx={{
-              px: {xs: 1.75, sm: 2.5},
-              py: {xs: 1, sm: 1.25},
-              justifyContent: 'flex-end',
-            }}
-          >
-            <Button
-              onClick={() => setOpenDialog(false)}
-              variant="contained"
-              sx={{
-                fontWeight: 'bold',
-                textTransform: 'none',
-                fontSize: isMobile ? '0.85rem' : '0.95rem',
-                px: 2.5,
-                '&:hover': {
-                  color: '#fff',
-                },
-              }}
-            >
-              Close
-            </Button>
-          </DialogActions>
         </Dialog>
       )}
 

--- a/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/wrappers/FieldWrapper.tsx
@@ -288,14 +288,15 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
           open={openDialog}
           onClose={() => setOpenDialog(false)}
           fullWidth
-          maxWidth="md"
+          maxWidth="sm"
           slotProps={{
             paper: {
               sx: {
                 borderRadius: 2,
-                p: 1,
+                m: {xs: 1.5, sm: 4},
+                width: {xs: 'calc(100% - 24px)', sm: 'calc(100% - 64px)'},
+                maxHeight: {xs: 'calc(100% - 24px)', sm: 'calc(100% - 64px)'},
                 boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
-                position: 'relative',
               },
             },
           }}
@@ -303,14 +304,25 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
           <DialogTitle
             sx={{
               fontWeight: 'bold',
-              fontSize: '1.2rem',
-              paddingRight: 4,
+              fontSize: {xs: '1.1rem', sm: '1.2rem'},
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 1,
+              py: {xs: 1.25, sm: 1.75},
+              px: {xs: 1.75, sm: 2.5},
             }}
           >
-            {heading}
+            <Box
+              component="span"
+              sx={{flex: 1, minWidth: 0, wordBreak: 'break-word'}}
+            >
+              {heading}
+            </Box>
             <IconButton
               onClick={() => setOpenDialog(false)}
-              sx={{position: 'absolute', right: 16, top: 16}}
+              size="small"
+              aria-label="Close"
+              sx={{flexShrink: 0, mt: -0.5, mr: -0.5}}
             >
               <CloseIcon />
             </IconButton>
@@ -320,7 +332,8 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
             dividers
             onClick={onHelperImageClick}
             sx={{
-              maxHeight: '60vh',
+              px: {xs: 1.75, sm: 2.5},
+              py: {xs: 1.25, sm: 1.75},
               overflowY: 'auto',
               '& img': {
                 maxWidth: '100%',
@@ -337,7 +350,7 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
           >
             <Box
               sx={{
-                fontSize: '1rem',
+                fontSize: {xs: '0.95rem', sm: '1rem'},
                 lineHeight: 1.6,
               }}
             >
@@ -345,7 +358,13 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
             </Box>
           </DialogContent>
 
-          <DialogActions sx={{pt: 2, justifyContent: 'flex-end'}}>
+          <DialogActions
+            sx={{
+              px: {xs: 1.75, sm: 2.5},
+              py: {xs: 1, sm: 1.25},
+              justifyContent: 'flex-end',
+            }}
+          >
             <Button
               onClick={() => setOpenDialog(false)}
               variant="contained"


### PR DESCRIPTION
# feat/fix/chore: pr title

## JIRA Ticket

https://jira.csiro.au/browse/BSS-1334

## Description

fixes the advanced helper text popup, content fit, padding, placement of close icon on top right as discussed.

<img width="348" height="847" alt="Screenshot 2026-06-15 153414" src="https://github.com/user-attachments/assets/e380c311-9d7b-4c9b-9788-97efcfe6ef0a" />

<img width="334" height="490" alt="Screenshot 2026-06-15 153444" src="https://github.com/user-attachments/assets/2dfa53bb-92c7-46b2-8302-0ef194074728" />


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
