### PR TITLE
fix: install @faims3/forms deps in Docker build so localdev.sh --all works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY api/package.json ./api/
 COPY app/package.json ./app/
 COPY web/package.json ./web/
 COPY library/data-model/package.json ./library/data-model/
+COPY library/forms/package.json ./library/forms/
 
 # Turbo config
 COPY turbo.json ./

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ This spins up four services:
 - Web app (`/web`) live reloading on http://localhost:3001
 - CouchDB on http://localhost:5984/\_utils
 
+On the **first run** this also installs all monorepo dependencies
+(`pnpm install`) and builds the shared libraries (`turbo build`) before the
+Docker images are built, so expect it to take several minutes. The `.env` files
+for `api`, `app` and `web` are created automatically from the `.env.dist`
+templates, and local signing keys are generated for you.
+
 ### Additional options
 
 - **Rebuild containers**: Use `--build` flag to rebuild Docker images
@@ -59,6 +65,22 @@ This spins up four services:
   ```bash
   ./localdev.sh --all --clear-db
   ```
+
+### Loading sample notebooks and templates
+
+The services start with an empty database. To populate it with the sample
+notebooks and templates:
+
+1. Open the Conductor at http://localhost:8080/ and log in as the local `admin`
+   user (the password is `COUCHDB_PASSWORD` in `api/.env`).
+2. On the Conductor home page, scroll to **"Copy Bearer Token to Clipboard"** and
+   paste the value into the root `.env` file as `USER_TOKEN`.
+3. Load the samples:
+
+   ```bash
+   pnpm run load-notebooks
+   pnpm run load-templates
+   ```
 
 ## CouchDB-only local development (recommended for live-reloading)
 


### PR DESCRIPTION
# fix: install @faims3/forms deps in Docker build so localdev.sh --all works

## JIRA Ticket

N/A (open-source contribution). No linked issue; found while setting up local dev for #2087.

## Description

On a clean checkout of `main`, `./localdev.sh --all` fails to build the `api` image. The builder stage's `pnpm turbo build` dies with ~40 "cannot find module" errors while compiling `@faims3/forms` (`@tanstack/react-form`, `react-dropzone`, `proj4`, `dompurify`, `vitest`, `lodash` types, `react-zoom-pan-pinch`, ...). This makes the documented full-stack local dev command unusable out of the box.

## Proposed Changes

- `Dockerfile`: add the missing `COPY library/forms/package.json ./library/forms/` to the base stage so `pnpm install --frozen-lockfile` installs the forms workspace's dependencies before the build.
- `README.md`: document the local-dev quick start more fully:
  - a first-run note (initial `pnpm install` + `turbo build` run before the Docker images build; `.env` files auto-created and local keys generated);
  - a "Loading sample notebooks and templates" subsection covering the manual step the script prints but the README omitted (copy the admin bearer token into the root `.env` as `USER_TOKEN`, then run `pnpm run load-notebooks` / `load-templates`).

## How to Test

1. From a clean checkout of this branch, run `./localdev.sh --all`.
2. The `api` image builds successfully and all four services come up: API `:8080`, app `:3000`, web `:3001`, CouchDB `:5984`.
3. Verified locally on Node 22 / pnpm 10.7 / Docker.

## Additional Information

Root cause: the base stage copies workspace manifests for `api`, `app`, `web` and `library/data-model`, but not `library/forms` — a workspace that both `app` and `web` depend on. Without its manifest, its dependencies are never installed, and the builder stage's `COPY . .` then builds `@faims3/forms` against a missing `node_modules`. This looks like a leftover from extracting the forms renderer into its own workspace.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes. (No new functions/classes; Dockerfile + README only.)
- [x] Relevant documentation such as READMEs, guides, and class comments are updated. (README updated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
