### PR TITLE
fix(forms): make location edit icon smaller

### DIFF
--- a/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
@@ -335,7 +335,7 @@ function MapWrapper(props: MapProps) {
             {props.label}
           </Button>
         ) : (
-          <Box>
+          <Box sx={{flexShrink: 0}}>
             {!props.disabled && (
               <Tooltip title="Edit location">
                 <Box

--- a/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/MapWrapper.tsx
@@ -344,15 +344,16 @@ function MapWrapper(props: MapProps) {
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    width: 80,
-                    height: 80,
+                    flexShrink: 0,
+                    width: 44,
+                    height: 44,
                     backgroundColor: '#dfdfdf',
                     borderRadius: '6px',
                     cursor: 'pointer',
                     transition: 'all 0.3s ease-in-out',
                     '&:hover': {
                       backgroundColor: '#e0e0e0',
-                      transform: 'scale(1.1)',
+                      transform: 'scale(1.05)',
                       boxShadow: '0px 3px 8px rgba(0, 0, 0, 0.2)',
                     },
                   }}
@@ -360,7 +361,7 @@ function MapWrapper(props: MapProps) {
                 >
                   <EditIcon
                     sx={{
-                      fontSize: 26,
+                      fontSize: 22,
                       color: theme.palette.primary.main,
                     }}
                   />

--- a/library/forms/lib/fieldRegistry/fields/MapField/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/index.tsx
@@ -184,6 +184,57 @@ export function MapFormField(props: FieldProps): JSX.Element {
       });
   };
 
+  const mapWrapperEl = (
+    <MapWrapper
+      config={mapConfig}
+      label={buttonLabel}
+      featureType={featureType}
+      features={drawnFeatures}
+      zoom={zoom}
+      center={props.center}
+      setFeatures={setFeaturesCallback}
+      geoTiff={props.geoTiff}
+      projection={props.projection}
+      setNoPermission={setNoPermission}
+      isLocationSelected={isLocationSelected}
+      disabled={props.disabled}
+      allowSetToCurrentPoint={props.allowSetToCurrentPoint}
+    />
+  );
+
+  const locationChip = isLocationSelected ? (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 1.5,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        backgroundColor: theme.palette.success.light + '20',
+        borderColor: theme.palette.success.main,
+      }}
+    >
+      <CheckCircleOutlined color="success" fontSize="small" />
+      <Typography variant="body2" color="text.secondary">
+        {featureType === 'Point' && drawnFeatures?.features?.[0]?.geometry
+          ? `Location selected: ${(
+              drawnFeatures.features[0].geometry as {
+                coordinates: number[];
+              }
+            ).coordinates[1].toFixed(5)}, ${(
+              drawnFeatures.features[0].geometry as {
+                coordinates: number[];
+              }
+            ).coordinates[0].toFixed(5)}`
+          : `${featureType} captured (${
+              drawnFeatures?.features?.length ?? 0
+            } feature${
+              (drawnFeatures?.features?.length ?? 0) !== 1 ? 's' : ''
+            })`}
+      </Typography>
+    </Paper>
+  ) : null;
+
   return (
     <FieldWrapper
       heading={props.label}
@@ -228,66 +279,24 @@ export function MapFormField(props: FieldProps): JSX.Element {
                 </Alert>
               </>
             )}
+            {locationChip && <Box sx={{marginTop: 0.8}}>{locationChip}</Box>}
           </>
+        ) : isLocationSelected ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: {xs: 'column', md: 'row'},
+              alignItems: {xs: 'flex-start', md: 'center'},
+              gap: theme.spacing(1.5),
+              width: '100%',
+            }}
+          >
+            {locationChip}
+            {mapWrapperEl}
+          </Box>
         ) : (
-          <MapWrapper
-            config={mapConfig}
-            label={buttonLabel}
-            featureType={featureType}
-            features={drawnFeatures}
-            zoom={zoom}
-            center={props.center}
-            setFeatures={setFeaturesCallback}
-            geoTiff={props.geoTiff}
-            projection={props.projection}
-            setNoPermission={setNoPermission}
-            isLocationSelected={isLocationSelected}
-            disabled={props.disabled}
-            allowSetToCurrentPoint={props.allowSetToCurrentPoint}
-          />
+          mapWrapperEl
         )}
-        <Box
-          sx={{
-            alignItems: 'center',
-            marginTop: 0.8,
-            display: 'inline-flex',
-            gap: theme.spacing(1),
-          }}
-        >
-          {isLocationSelected && (
-            <Paper
-              variant="outlined"
-              sx={{
-                p: 1.5,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1,
-                backgroundColor: theme.palette.success.light + '20',
-                borderColor: theme.palette.success.main,
-              }}
-            >
-              <CheckCircleOutlined color="success" fontSize="small" />
-              <Typography variant="body2" color="text.secondary">
-                {featureType === 'Point' &&
-                drawnFeatures?.features?.[0]?.geometry
-                  ? `Location selected: ${(
-                      drawnFeatures.features[0].geometry as {
-                        coordinates: number[];
-                      }
-                    ).coordinates[1].toFixed(5)}, ${(
-                      drawnFeatures.features[0].geometry as {
-                        coordinates: number[];
-                      }
-                    ).coordinates[0].toFixed(5)}`
-                  : `${featureType} captured (${
-                      drawnFeatures?.features?.length ?? 0
-                    } feature${
-                      (drawnFeatures?.features?.length ?? 0) !== 1 ? 's' : ''
-                    })`}
-              </Typography>
-            </Paper>
-          )}
-        </Box>
       </Box>
 
       {/*  Show error if no permission */}

--- a/library/forms/lib/fieldRegistry/fields/MapField/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/MapField/index.tsx
@@ -210,14 +210,28 @@ export function MapFormField(props: FieldProps): JSX.Element {
         display: 'flex',
         alignItems: 'center',
         gap: 1,
+        flex: {xs: 1, md: '0 1 auto'},
+        minWidth: {xs: 0, md: 'auto'},
         backgroundColor: theme.palette.success.light + '20',
         borderColor: theme.palette.success.main,
       }}
     >
-      <CheckCircleOutlined color="success" fontSize="small" />
-      <Typography variant="body2" color="text.secondary">
+      <CheckCircleOutlined
+        color="success"
+        fontSize="small"
+        sx={{flexShrink: 0}}
+      />
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{
+          minWidth: {xs: 0, md: 'auto'},
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
         {featureType === 'Point' && drawnFeatures?.features?.[0]?.geometry
-          ? `Location selected: ${(
+          ? `Location: ${(
               drawnFeatures.features[0].geometry as {
                 coordinates: number[];
               }
@@ -285,10 +299,11 @@ export function MapFormField(props: FieldProps): JSX.Element {
           <Box
             sx={{
               display: 'flex',
-              flexDirection: {xs: 'column', md: 'row'},
-              alignItems: {xs: 'flex-start', md: 'center'},
+              flexDirection: 'row',
+              alignItems: 'center',
               gap: theme.spacing(1.5),
-              width: '100%',
+              width: {xs: '100%', md: 'fit-content'},
+              maxWidth: '100%',
             }}
           >
             {locationChip}


### PR DESCRIPTION



## JIRA Ticket

https://jira.csiro.au/browse/BSS-1117

## Description

Updated the placement of edit location button which was placed on top of location before and little bigger in size, now its sitting next to location and below the location in smaller screens


<img width="2546" height="1276" alt="Screenshot 2026-06-18 164554" src="https://github.com/user-attachments/assets/9bc89b08-b494-49e8-bdda-90c0ae6e6387" />

<img width="830" height="1102" alt="Screenshot 2026-06-18 164612" src="https://github.com/user-attachments/assets/9c205e77-5426-47ae-ab27-004a6c8b63c7" />


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
