### PR TITLE
fix(designer): scope condition field picker to current form

### DIFF
--- a/web/src/designer/components/condition.test.tsx
+++ b/web/src/designer/components/condition.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import {vi, describe, expect, test} from 'vitest';
-import {act, fireEvent, render, screen} from '@testing-library/react';
+import {act, fireEvent, render, screen, within} from '@testing-library/react';
 import {ConditionControl} from './condition/ConditionControl';
 import {ConditionType} from '../types/condition';
 import {sampleNotebook} from '../test-notebook';
@@ -152,6 +152,92 @@ describe('ConditionControl', () => {
     // });
     // // but another field is there
     // expect(document.querySelector(`[data-value="Field ID"]`)).not.toBeNull();
+  });
+
+  /**
+   * Builds a store from the sample notebook plus a second form ("Secondary")
+   * containing a single field, so cross-form scoping of the field picker can be
+   * exercised. Returns the hydrated store.
+   */
+  const storeWithSecondForm = () => {
+    const store = createDesignerStore();
+    const {migrated: notebook} = migrateNotebook(
+      JSON.parse(JSON.stringify(sampleNotebook))
+    );
+    const uiSpec = notebook.uiSpec as NotebookUISpec;
+
+    // A field that lives only in the second form.
+    uiSpec.fields['Cross-Form-Field'] = {
+      ...uiSpec.fields['New-Text-Field'],
+      'component-parameters': {
+        ...uiSpec.fields['New-Text-Field']['component-parameters'],
+        label: 'Cross Form Widget',
+        name: 'Cross-Form-Field',
+      },
+    };
+    uiSpec.views['Secondary-Section'] = {
+      label: 'Secondary Detail',
+      fields: ['Cross-Form-Field'],
+    };
+    uiSpec.viewsets['Secondary'] = {
+      label: 'Secondary Form',
+      views: ['Secondary-Section'],
+    };
+    uiSpec.visible_types.push('Secondary');
+
+    store.dispatch(loaded(uiSpec));
+    return store;
+  };
+
+  /** Opens the field-picker Autocomplete and returns the rendered option labels. */
+  const openFieldOptions = (): string[] => {
+    const input = within(screen.getByTestId('field-input')).getByRole(
+      'combobox'
+    ) as HTMLInputElement;
+    act(() => {
+      input.focus();
+      fireEvent.keyDown(input, {key: 'ArrowDown'});
+    });
+    return screen
+      .getAllByRole('option')
+      .map(o => o.textContent ?? '')
+      .filter(Boolean);
+  };
+
+  test('field condition picker excludes fields from other forms', () => {
+    const store = storeWithSecondForm();
+    const onChangeFn = vi.fn();
+    render(
+      <WithProviders store={store}>
+        {/* New-Text-Field belongs to the "Primary" form */}
+        <ConditionControl onChange={onChangeFn} field={'New-Text-Field'} />
+      </WithProviders>
+    );
+
+    const optionLabels = openFieldOptions();
+
+    // A same-form field (different section) is still offered.
+    expect(optionLabels).toContain('ID');
+    // The field that lives in another form must NOT be offered.
+    expect(optionLabels).not.toContain('Cross Form Widget');
+  });
+
+  test('section condition picker excludes fields from other forms', () => {
+    const store = storeWithSecondForm();
+    const onChangeFn = vi.fn();
+    render(
+      <WithProviders store={store}>
+        {/* Primary-New-Section belongs to the "Primary" form */}
+        <ConditionControl onChange={onChangeFn} view={'Primary-New-Section'} />
+      </WithProviders>
+    );
+
+    const optionLabels = openFieldOptions();
+
+    // A field from another section of the same form is still offered.
+    expect(optionLabels).toContain('ID');
+    // The field that lives in another form must NOT be offered.
+    expect(optionLabels).not.toContain('Cross Form Widget');
   });
 
   test('make a boolean condition from a field', () => {

--- a/web/src/designer/components/condition/ConditionControl.tsx
+++ b/web/src/designer/components/condition/ConditionControl.tsx
@@ -48,7 +48,7 @@ import {
 } from '../../types/condition';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import SplitscreenIcon from '@mui/icons-material/Splitscreen';
-import {getFieldLabel} from './utils';
+import {buildFieldLocationMaps, getFieldLabel} from './utils';
 
 /** Options from a Select/Radio/Multi field usable as condition RHS values. */
 const getSelectableOptions = (
@@ -238,16 +238,48 @@ export const FieldConditionControl = (props: ConditionProps) => {
     state => state.notebook.uiSpec.present.fields
   );
   const views = useAppSelector(state => state.notebook.uiSpec.present.views);
+  const viewsets = useAppSelector(
+    state => state.notebook.uiSpec.present.viewsets
+  );
 
-  // work out which fields to show in the select/combobox, remove either
-  // the current field or the fields in the current view
-  let selectFields = Object.keys(allFields);
-  if (props.field) {
-    selectFields = selectFields.filter(f => f !== props.field);
-  } else if (props.view) {
-    const view = views[props.view];
-    selectFields = selectFields.filter(f => view.fields.indexOf(f) < 0);
-  }
+  // Work out which fields to show in the select/combobox. Conditions can only
+  // reference fields within the same form, so scope the list to the current
+  // form (viewset): resolve the entry context (props.field or props.view) to
+  // its containing form, then gather every field across that form's sections
+  // (mirrors TemplatedStringFieldEditor's viewSetFields). Then remove either
+  // the current field or the fields in the current view.
+  const selectFields = useMemo(() => {
+    const {sectionToForm, fieldToSection} = buildFieldLocationMaps(
+      views,
+      viewsets
+    );
+
+    const currentSectionId = props.view
+      ? props.view
+      : props.field
+        ? fieldToSection.get(props.field)?.sectionId
+        : undefined;
+    const formId = currentSectionId
+      ? sectionToForm.get(currentSectionId)?.formId
+      : undefined;
+    const viewset = formId ? viewsets[formId] : undefined;
+
+    // Fall back to all fields only when the form can't be resolved (e.g. a
+    // nested boolean condition with no field/view context).
+    const formFields = viewset
+      ? Array.from(
+          new Set(viewset.views.flatMap(id => views[id]?.fields ?? []))
+        )
+      : Object.keys(allFields);
+
+    if (props.field) {
+      return formFields.filter(f => f !== props.field);
+    } else if (props.view) {
+      const view = views[props.view];
+      return formFields.filter(f => view.fields.indexOf(f) < 0);
+    }
+    return formFields;
+  }, [allFields, views, viewsets, props.field, props.view]);
 
   const targetFieldDef = condition.field ? allFields[condition.field] : null;
 

--- a/web/src/designer/components/condition/ConditionControl.tsx
+++ b/web/src/designer/components/condition/ConditionControl.tsx
@@ -274,7 +274,9 @@ export const FieldConditionControl = (props: ConditionProps) => {
       : [];
 
     // Exclude the current field, or the current section's own fields.
-    const ownSectionFields = props.view ? (views[props.view]?.fields ?? []) : [];
+    const ownSectionFields = props.view
+      ? (views[props.view]?.fields ?? [])
+      : [];
     return props.field
       ? formFields.filter(f => f !== props.field)
       : formFields.filter(f => !ownSectionFields.includes(f));
@@ -612,6 +614,26 @@ export const FieldConditionControl = (props: ConditionProps) => {
   const valueMismatch = !isValueValidForField();
   const allowedOperators = getAllowedOperatorsForField(targetFieldDef);
 
+  // If there are no fields to select, show a message instead of the editor.
+  if (selectFields.length === 0) {
+    return (
+      <div style={{color: 'red'}}>
+        {props.view ? (
+          <>
+            This form has only one section. Adding conditions for a section
+            requires more than one section so that fields from other sections
+            can be referenced.
+          </>
+        ) : (
+          <>
+            This form only has one field. Please add fields to this form to
+            enable adding conditions.
+          </>
+        )}
+      </div>
+    );
+  }
+
   return (
     <Grid container>
       <Stack
@@ -634,7 +656,6 @@ export const FieldConditionControl = (props: ConditionProps) => {
           )}
           style={{minWidth: 200}}
           clearOnEscape
-          noOptionsText={props.view ? 'No fields in this form outside this section' : props.field ? 'No other fields in this form' : 'No fields available'}
         />
 
         <FormControl

--- a/web/src/designer/components/condition/ConditionControl.tsx
+++ b/web/src/designer/components/condition/ConditionControl.tsx
@@ -48,7 +48,7 @@ import {
 } from '../../types/condition';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import SplitscreenIcon from '@mui/icons-material/Splitscreen';
-import {buildFieldLocationMaps, getFieldLabel} from './utils';
+import {getFieldLabel} from './utils';
 
 /** Options from a Select/Radio/Multi field usable as condition RHS values. */
 const getSelectableOptions = (
@@ -249,36 +249,35 @@ export const FieldConditionControl = (props: ConditionProps) => {
   // (mirrors TemplatedStringFieldEditor's viewSetFields). Then remove either
   // the current field or the fields in the current view.
   const selectFields = useMemo(() => {
-    const {sectionToForm, fieldToSection} = buildFieldLocationMaps(
-      views,
-      viewsets
-    );
-
-    const currentSectionId = props.view
-      ? props.view
-      : props.field
-        ? fieldToSection.get(props.field)?.sectionId
-        : undefined;
-    const formId = currentSectionId
-      ? sectionToForm.get(currentSectionId)?.formId
-      : undefined;
-    const viewset = formId ? viewsets[formId] : undefined;
-
-    // Fall back to all fields only when the form can't be resolved (e.g. a
-    // nested boolean condition with no field/view context).
-    const formFields = viewset
-      ? Array.from(
-          new Set(viewset.views.flatMap(id => views[id]?.fields ?? []))
-        )
-      : Object.keys(allFields);
-
-    if (props.field) {
-      return formFields.filter(f => f !== props.field);
-    } else if (props.view) {
-      const view = views[props.view];
-      return formFields.filter(f => view.fields.indexOf(f) < 0);
+    // Which section's condition are we editing?
+    let sectionId: string | undefined;
+    if (props.view) {
+      sectionId = props.view;
+    } else if (props.field) {
+      const field = props.field;
+      sectionId = Object.keys(views).find(id =>
+        views[id].fields.includes(field)
+      );
+    } else {
+      // Standalone use, no context: nothing to scope to, show all fields.
+      return Object.keys(allFields);
     }
-    return formFields;
+
+    // The form (viewset) that owns the section. Conditions can only reference
+    // fields in the same form, so if it can't be resolved, show nothing rather
+    // than leaking other forms' fields.
+    const viewset = Object.values(viewsets).find(
+      vs => sectionId !== undefined && vs.views.includes(sectionId)
+    );
+    const formFields = viewset
+      ? viewset.views.flatMap(id => views[id]?.fields ?? [])
+      : [];
+
+    // Exclude the current field, or the current section's own fields.
+    const ownSectionFields = props.view ? (views[props.view]?.fields ?? []) : [];
+    return props.field
+      ? formFields.filter(f => f !== props.field)
+      : formFields.filter(f => !ownSectionFields.includes(f));
   }, [allFields, views, viewsets, props.field, props.view]);
 
   const targetFieldDef = condition.field ? allFields[condition.field] : null;

--- a/web/src/designer/components/condition/ConditionControl.tsx
+++ b/web/src/designer/components/condition/ConditionControl.tsx
@@ -634,6 +634,7 @@ export const FieldConditionControl = (props: ConditionProps) => {
           )}
           style={{minWidth: 200}}
           clearOnEscape
+          noOptionsText={props.view ? 'No fields in this form outside this section' : props.field ? 'No other fields in this form' : 'No fields available'}
         />
 
         <FormControl

--- a/web/src/designer/components/condition/utils.ts
+++ b/web/src/designer/components/condition/utils.ts
@@ -52,7 +52,14 @@ export type FieldDependencyReference = {
   templateUsage?: string;
 };
 
-const buildFieldLocationMaps = (allViews: ViewMap, viewsets: ViewSetMap) => {
+/**
+ * Builds lookup maps from the UI spec: section (view) → its form (viewset), and
+ * field → its section. Used to resolve which form a field or section belongs to.
+ */
+export const buildFieldLocationMaps = (
+  allViews: ViewMap,
+  viewsets: ViewSetMap
+) => {
   const sectionToForm = new Map<string, {formId: string; formLabel: string}>();
   const fieldToSection = new Map<
     string,

--- a/web/src/designer/components/condition/utils.ts
+++ b/web/src/designer/components/condition/utils.ts
@@ -52,14 +52,7 @@ export type FieldDependencyReference = {
   templateUsage?: string;
 };
 
-/**
- * Builds lookup maps from the UI spec: section (view) → its form (viewset), and
- * field → its section. Used to resolve which form a field or section belongs to.
- */
-export const buildFieldLocationMaps = (
-  allViews: ViewMap,
-  viewsets: ViewSetMap
-) => {
+const buildFieldLocationMaps = (allViews: ViewMap, viewsets: ViewSetMap) => {
   const sectionToForm = new Map<string, {formId: string; formLabel: string}>();
   const fieldToSection = new Map<
     string,

--- a/web/src/designer/components/section-editor.tsx
+++ b/web/src/designer/components/section-editor.tsx
@@ -385,7 +385,7 @@ export const SectionEditor = ({
             <Typography sx={designerPipeSx}> | </Typography>
 
             <ConditionModal
-              label="Add conditions to section"
+              label="Add condition to section"
               initial={fView.condition}
               onChange={conditionChanged}
               view={viewId}


### PR DESCRIPTION
# fix: scope condition field picker to current form

## JIRA Ticket

N/A (open-source contribution). Tracked in GitHub: Closes #2087

## Description

In the Notebook Editor (Designer), the condition/visibility field-picker listed fields from every form in the notebook. Conditions are evaluated against a single record's values (one form), so fields from other forms are never in scope and would be non-functional options. This scopes the picker to the current form.

## Proposed Changes

- Scope the field-picker in `FieldConditionControl` to the current form, resolved from the editor context (`props.field` for field-level conditions, `props.view` for section-level).
- When the context cannot be resolved to a form, return no options instead of falling back to all notebook fields; guard against a missing section definition.
- Applies to both field-level and section-level conditions.
- Add regression tests covering both contexts.

## How to Test

1. Open the Designer for a notebook with two or more forms, each with distinct fields.
2. On a field in form A, choose **Add condition** and open the **Field** dropdown: it lists only form A's fields; form B's fields do not appear.
3. On a section, choose **Add conditions to section**: only the form's other-section fields appear.
4. Automated: `web/src/designer/components/condition.test.tsx` covers both contexts (run the `web` test suite).

## Additional Information

Section conditions on a single-section form now show an empty picker: they exclude their own section's fields, and there are no other sections to reference. This is pre-existing behaviour surfaced by the fix. See #2087 for a suggested follow-up (empty-state hint).

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes. (No new functions/classes; an existing component was updated.)
- [x] Relevant documentation such as READMEs, guides, and class comments are updated. (No relevant documentation affected.)



🤖 Generated with [Claude Code](https://claude.com/claude-code)
