### PR TITLE
Feat: enable notebook and team storage stats

### DIFF
--- a/api/public/swagger.json
+++ b/api/public/swagger.json
@@ -2086,6 +2086,11 @@
             "is_admin": {
               "type": "boolean",
               "description": "True when the caller has project admin on this notebook"
+            },
+            "byteCount": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional size of the notebook’s data in bytes (projects DB v4+)"
             }
           },
           "required": ["is_admin"]

--- a/api/public/swagger.json
+++ b/api/public/swagger.json
@@ -2136,13 +2136,17 @@
       ]
     },
     "GetNotebookResponse": {
-      "description": "GET /notebooks/{id} — project document plus optional record count.",
+      "description": "GET /notebooks/{id} — project document plus optional record count and byte count.",
       "allOf": [
         {"$ref": "#/definitions/ProjectDocument"},
         {
           "type": "object",
           "properties": {
             "recordCount": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "byteCount": {
               "type": "integer",
               "minimum": 0
             }

--- a/api/public/swagger.json
+++ b/api/public/swagger.json
@@ -2090,7 +2090,7 @@
             "byteCount": {
               "type": "integer",
               "minimum": 0,
-              "description": "Optional size of the notebook’s data in bytes (projects DB v4+)"
+              "description": "Size of the notebook’s data in bytes (projects DB v4+)"
             }
           },
           "required": ["is_admin"]

--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -88,6 +88,7 @@ import {
   countRecordsInNotebook,
   createNotebook,
   deleteNotebook,
+  getByteCount,
   getCompiledUiSpecModel,
   getProjectById,
   getRolesForNotebook,
@@ -551,6 +552,7 @@ api.get(
     res.json({
       ...project,
       recordCount: await countRecordsInNotebook(projectId),
+      byteCount: await getByteCount(projectId),
     } satisfies GetNotebookResponse);
   }
 );

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -687,6 +687,23 @@ export async function countRecordsInNotebook(
   }
 }
 
+export async function getByteCount(
+    project_id: ProjectID
+): Promise<number> {
+  const dataDB = await getDataDB(project_id);
+  // I can see what I want in sizes.active in CouchDB Fauxton, but it's not clear how to get it via the PouchDB API. This view is an approximation that sums the sizes of all attachments, which is likely to be the dominant contributor to database size for most projects.
+  try {
+    const res = await dataDB.query('index/attachmentSizeSum');
+    if (res.rows.length === 0) {
+      return 0;
+    }
+    return res.rows[0].value;
+  } catch (error) {
+    console.log(error);
+    return 0;
+  }
+}
+
 /*
  * For saving and loading attachment with type faims-attachment::Files
  */

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -61,7 +61,12 @@ import {
   CompiledNotebookUiSpec,
   compileUiSpecConditionals,
 } from '@faims3/data-model';
-import {initialiseDataDb, localGetProjectsDb, verifyCouchDBConnection} from '.';
+import {
+  getNanoDataDb,
+  initialiseDataDb,
+  localGetProjectsDb,
+  verifyCouchDBConnection,
+} from '.';
 import {COUCHDB_PUBLIC_URL, MIGRATE_NOTEBOOKS_ON_STARTUP} from '../buildconfig';
 import * as Exceptions from '../exceptions';
 import {userCanDo} from '../middleware';
@@ -687,17 +692,21 @@ export async function countRecordsInNotebook(
   }
 }
 
+/**
+ * Returns the storage size in bytes of a notebook's data database.
+ *
+ * PouchDB does not surface database sizes, so this uses CouchDB's GET /{db}
+ * info endpoint via nano. `sizes.active` is the size of the live data, matching
+ * the value shown in CouchDB Fauxton. (Use `sizes.file` instead if you want the
+ * on-disk size including view indexes and not-yet-compacted revisions.)
+ */
 export async function getByteCount(
-    project_id: ProjectID
+  project_id: ProjectID
 ): Promise<number> {
-  const dataDB = await getDataDB(project_id);
-  // I can see what I want in sizes.active in CouchDB Fauxton, but it's not clear how to get it via the PouchDB API. This view is an approximation that sums the sizes of all attachments, which is likely to be the dominant contributor to database size for most projects.
   try {
-    const res = await dataDB.query('index/attachmentSizeSum');
-    if (res.rows.length === 0) {
-      return 0;
-    }
-    return res.rows[0].value;
+    const dataDb = await getNanoDataDb(project_id);
+    const info = await dataDb.info();
+    return info.sizes.active;
   } catch (error) {
     console.log(error);
     return 0;

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -709,8 +709,8 @@ export async function getByteCount(
     const info = await dataDb.info();
     return info.sizes.active;
   } catch (error) {
-    console.log(error);
-    return 0;
+    console.error(error);
+    return -1;
   }
 }
 

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -246,7 +246,7 @@ export const getUserProjectsDirectory = async (
  * each row (including `uiSpecification`), which would defeat the lean list.
  *
  * @param user - only return notebooks that this user can see
- * @returns notebook list rows (from each row's `value`) plus `is_admin`
+ * @returns notebook list rows (from each row's `value`) plus `is_admin` and `byteCount`
  */
 export const getUserProjectsDetailed = async (
   user: Express.User,
@@ -288,7 +288,7 @@ export const getUserProjectsDetailed = async (
       });
     });
 
-  return userProjects.map(project => {
+  return await Promise.all(userProjects.map(async project => {
     const projectId = project._id;
     return {
       ...project,
@@ -297,8 +297,9 @@ export const getUserProjectsDetailed = async (
         projectId,
         role: Role.PROJECT_ADMIN,
       }),
+      byteCount: await getByteCount(projectId),
     } satisfies GetNotebookListResponse[number];
-  });
+  }));
 };
 
 /**

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -71,6 +71,7 @@ import {COUCHDB_PUBLIC_URL, MIGRATE_NOTEBOOKS_ON_STARTUP} from '../buildconfig';
 import * as Exceptions from '../exceptions';
 import {userCanDo} from '../middleware';
 import {nowIso} from '../time';
+import { use } from "chai";
 
 /**
  * Migrate legacy notebook JSON when needed, validate as {@link NotebookDefinition},
@@ -240,6 +241,15 @@ export const getUserProjectsDirectory = async (
 };
 
 /**
+ * How many projects {@link getUserProjectsDetailed} resolves per batch when
+ * computing each project's `byteCount`. Each `byteCount` costs one CouchDB
+ * `info()` call, so this caps the concurrent `info()` round-trips and stops a
+ * user/team with many notebooks from opening one connection per project at once
+ * and exhausting CouchDB's connection limits.
+ */
+const BYTE_COUNT_BATCH_SIZE = 10;
+
+/**
  * Lists notebooks using CouchDB views whose map `value` is the project doc
  * without `uiSpecification`. Uses `include_docs: false` on purpose: with
  * `include_docs: true`, CouchDB would also attach the full stored document for
@@ -251,7 +261,7 @@ export const getUserProjectsDirectory = async (
 export const getUserProjectsDetailed = async (
   user: Express.User,
   teamId: string | undefined = undefined,
-  includeArchived = false
+  includeArchived = false,
 ): Promise<APINotebookList[]> => {
   const projectsDb = localGetProjectsDb();
 
@@ -266,18 +276,18 @@ export const getUserProjectsDetailed = async (
           PROJECTS_LISTING_BY_PROJECT_ID,
           {
             include_docs: false,
-          }
+          },
         );
   } catch (error) {
     throw new Exceptions.InternalSystemError(
-      'An error occurred while reading projects from the Project DB.'
+      "An error occurred while reading projects from the Project DB.",
     );
   }
 
   const userProjects = resultList.rows
-    .filter(row => row.value != null && row.id && !row.id.startsWith('_'))
-    .map(row => row.value!)
-    .filter(project => {
+    .filter((row) => row.value != null && row.id && !row.id.startsWith("_"))
+    .map((row) => row.value!)
+    .filter((project) => {
       if (!includeArchived && project.status === ProjectStatus.ARCHIVED) {
         return false;
       }
@@ -288,18 +298,27 @@ export const getUserProjectsDetailed = async (
       });
     });
 
-  return await Promise.all(userProjects.map(async project => {
-    const projectId = project._id;
-    return {
-      ...project,
-      is_admin: userHasProjectRole({
-        user,
-        projectId,
-        role: Role.PROJECT_ADMIN,
-      }),
-      byteCount: await getByteCount(projectId),
-    } satisfies GetNotebookListResponse[number];
-  }));
+  const detailed: APINotebookList[] = [];
+  for (let p = 0; p < userProjects.length; p += BYTE_COUNT_BATCH_SIZE) {
+    const batch = userProjects.slice(p, p + BYTE_COUNT_BATCH_SIZE);
+    detailed.push(
+      ...(await Promise.all(
+        batch.map(async (project) => {
+          const projectId = project._id;
+          return {
+            ...project,
+            is_admin: userHasProjectRole({
+              user,
+              projectId,
+              role: Role.PROJECT_ADMIN,
+            }),
+            byteCount: await getByteCount(projectId),
+          };
+        }),
+      )),
+    );
+  }
+  return detailed;
 };
 
 /**

--- a/api/test/notebookStorageStats.test.ts
+++ b/api/test/notebookStorageStats.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: notebookStorageStats.test.ts
+ * Description:
+ *   Tests for getUserProjectsDetailed's per-project byteCount, the team storage
+ *   total it feeds, the N+1 info() fan-out over a team's notebooks, and the
+ *   byteCount required-vs-optional schema contract.
+ */
+import PouchDB from 'pouchdb';
+import PouchDBFind from 'pouchdb-find';
+PouchDB.plugin(require('pouchdb-adapter-memory')); // enable memory adapter for testing
+PouchDB.plugin(PouchDBFind);
+
+import {APINotebookListSchema} from '@faims3/data-model';
+import {expect} from 'chai';
+import sinon from 'sinon';
+// Imported as a namespace so getNanoDataDb (the cross-module call getByteCount
+// makes) can be stubbed without hitting a real CouchDB during tests.
+import * as couchdb from '../src/couchdb';
+import {
+  createNotebook,
+  getUserProjectsDetailed,
+} from '../src/couchdb/notebooks';
+import {getExpressUserFromEmailOrUserId} from '../src/couchdb/users';
+import {resetDatabases} from './mocks';
+import {EMPTY_UI_SPECIFICATION} from './sampleNotebook';
+
+describe('notebook storage stats', () => {
+  /** Fake `sizes.active` (bytes) returned by the stubbed db info(), keyed by project id. */
+  const byteCountByProject = new Map<string, number>();
+  /** Project ids whose stubbed info() should reject, simulating a CouchDB lookup failure. */
+  const erroringProjects = new Set<string>();
+  /** Number of stubbed info() calls since the last reset; one per project the fan-out touches. */
+  let infoCallCount = 0;
+
+  beforeEach(async () => {
+    await resetDatabases();
+    byteCountByProject.clear();
+    erroringProjects.clear();
+    infoCallCount = 0;
+
+    // Replace the real nano data DB (which would hit CouchDB) with a fake whose
+    // info() returns the per-project size we seeded, so byteCount is deterministic.
+    sinon.stub(couchdb, 'getNanoDataDb').callsFake((async (projectId: string) => {
+      return {
+        info: async () => {
+          infoCallCount++;
+          if (erroringProjects.has(projectId)) {
+            throw new Error(`simulated CouchDB info() failure for ${projectId}`);
+          }
+          return {sizes: {active: byteCountByProject.get(projectId) ?? 0}};
+        },
+      };
+    }) as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  /** Create a notebook owned by `teamId` and register its fake stored byte size. */
+  async function createTeamNotebook(
+    name: string,
+    teamId: string,
+    bytes: number
+  ): Promise<string> {
+    const projectId = await createNotebook({
+      projectName: name,
+      uiSpecification: EMPTY_UI_SPECIFICATION,
+      description: '',
+      createdBy: 'admin',
+      teamId,
+    });
+    if (!projectId) {
+      throw new Error(`could not create test notebook ${name}`);
+    }
+    byteCountByProject.set(projectId, bytes);
+    return projectId;
+  }
+
+  it('populates each project byteCount and the team total equals the sum of per-project counts', async () => {
+    const admin = await getExpressUserFromEmailOrUserId('admin');
+    if (!admin) {
+      throw new Error('admin user missing');
+    }
+
+    const teamId = 'team-storage-sum';
+    const sizes = {alpha: 100, beta: 250, gamma: 4096};
+    const alphaId = await createTeamNotebook('Alpha', teamId, sizes.alpha);
+    const betaId = await createTeamNotebook('Beta', teamId, sizes.beta);
+    const gammaId = await createTeamNotebook('Gamma', teamId, sizes.gamma);
+
+    const notebooks = await getUserProjectsDetailed(admin, teamId);
+    expect(notebooks).to.have.lengthOf(3);
+
+    // Each project carries its own byteCount, matched to the right project.
+    const byteCountById = new Map(notebooks.map(n => [n._id, n.byteCount]));
+    expect(byteCountById.get(alphaId)).to.equal(sizes.alpha);
+    expect(byteCountById.get(betaId)).to.equal(sizes.beta);
+    expect(byteCountById.get(gammaId)).to.equal(sizes.gamma);
+    for (const notebook of notebooks) {
+      expect(notebook.byteCount, `byteCount for ${notebook._id}`).to.be.a(
+        'number'
+      );
+    }
+
+    // The team total (what the UI sums for the team) equals the per-project sum.
+    const teamTotal = notebooks.reduce((sum, n) => sum + n.byteCount, 0);
+    expect(teamTotal).to.equal(sizes.alpha + sizes.beta + sizes.gamma);
+  });
+
+  it('fans out one info() call per project for a team with many notebooks', async () => {
+    const admin = await getExpressUserFromEmailOrUserId('admin');
+    if (!admin) {
+      throw new Error('admin user missing');
+    }
+
+    const teamId = 'team-many-projects';
+    // More than BYTE_COUNT_BATCH_SIZE (10) so the byteCount fan-out spans
+    // multiple batches; this is the N+1 info() concern under test.
+    const projectCount = 25;
+    let expectedTotal = 0;
+    for (let i = 0; i < projectCount; i++) {
+      const bytes = (i + 1) * 1000;
+      expectedTotal += bytes;
+      await createTeamNotebook(`Project ${i}`, teamId, bytes);
+    }
+
+    // Count only the info() calls made by the listing itself, not creation.
+    infoCallCount = 0;
+    const notebooks = await getUserProjectsDetailed(admin, teamId);
+
+    expect(notebooks).to.have.lengthOf(projectCount);
+    // One CouchDB info() round-trip per project: the N+1 fan-out.
+    expect(infoCallCount).to.equal(projectCount);
+    // Every project's byteCount is populated; no batch is dropped.
+    expect(notebooks.every(n => typeof n.byteCount === 'number')).to.be.true;
+    const teamTotal = notebooks.reduce((sum, n) => sum + n.byteCount, 0);
+    expect(teamTotal).to.equal(expectedTotal);
+  });
+
+  it('always populates byteCount as APINotebookListSchema requires, even when the size lookup fails', async () => {
+    const admin = await getExpressUserFromEmailOrUserId('admin');
+    if (!admin) {
+      throw new Error('admin user missing');
+    }
+
+    const teamId = 'team-required-contract';
+    const healthyId = await createTeamNotebook('Healthy', teamId, 512);
+    const brokenId = await createTeamNotebook('Broken', teamId, 999);
+    // Simulate getByteCount catching a CouchDB info() failure for this project.
+    erroringProjects.add(brokenId);
+
+    const notebooks = await getUserProjectsDetailed(admin, teamId);
+    expect(notebooks).to.have.lengthOf(2);
+
+    for (const notebook of notebooks) {
+      // byteCount is declared z.number() (required, not optional) on
+      // APINotebookListSchema, so it must be present on every row...
+      expect(notebook).to.have.property('byteCount');
+      expect(notebook.byteCount).to.be.a('number');
+      // ...and the full row validates against the wire schema.
+      expect(() => APINotebookListSchema.parse(notebook)).to.not.throw();
+    }
+
+    const byteCountById = new Map(notebooks.map(n => [n._id, n.byteCount]));
+    expect(byteCountById.get(healthyId)).to.equal(512);
+    // A failed lookup maps to -1 (still a number), never an absent field.
+    expect(byteCountById.get(brokenId)).to.equal(-1);
+  });
+});

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -251,6 +251,7 @@ export type APINotebookList = z.infer<typeof APINotebookListSchema>;
 /** GET /api/notebooks/:id — full project document plus optional record count. */
 export const GetNotebookResponseSchema = ExistingProjectDocumentSchema.extend({
   recordCount: z.number().optional(),
+  byteCount: z.number(),
 });
 export type GetNotebookResponse = z.infer<typeof GetNotebookResponseSchema>;
 

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -245,6 +245,7 @@ export type PostExchangeTokenResponse = z.infer<
 /** GET /api/notebooks list row (project summary + access flags; no uiSpecification). */
 export const APINotebookListSchema = ProjectListItemSchema.extend({
   is_admin: z.boolean(),
+  byteCount: z.number(),
 });
 export type APINotebookList = z.infer<typeof APINotebookListSchema>;
 

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -29,6 +29,17 @@ export const slugify = (str: string) => {
 };
 
 /**
+ * Formats file size in human-readable format
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
+}
+
+/**
  * Finds the difference between sets A and B, i.e. the elements which are in A,
  * but not in B.
  */

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -34,7 +34,7 @@ export const slugify = (str: string) => {
 export function formatFileSize(bytes: number): string {
   if (bytes === 0) return "0 Bytes";
   if (bytes < 0) return "Invalid size";
-  if (isNaN(bytes)) return "Invalid size";
+  if (!isFinite(bytes)) return "Invalid size";
   const k = 1024;
   const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
   const i = Math.min(

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -32,7 +32,8 @@ export const slugify = (str: string) => {
  * Formats file size in human-readable format
  */
 export function formatFileSize(bytes: number): string {
-  if (bytes <= 0) return "0 Bytes";
+  if (bytes === 0) return "0 Bytes";
+  if (bytes < 0) return "Invalid size";
   if (isNaN(bytes)) return "Invalid size";
   const k = 1024;
   const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -32,10 +32,14 @@ export const slugify = (str: string) => {
  * Formats file size in human-readable format
  */
 export function formatFileSize(bytes: number): string {
-  if (bytes === 0) return '0 Bytes';
+  if (bytes <= 0) return "0 Bytes";
+  if (isNaN(bytes)) return "Invalid size";
   const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const i = Math.min(
+    sizes.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(k)),
+  );
   return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
 }
 

--- a/library/data-model/tests/utils.test.ts
+++ b/library/data-model/tests/utils.test.ts
@@ -1,0 +1,74 @@
+import {formatFileSize} from '../src/utils';
+
+describe('formatFileSize', () => {
+  const KB = 1024;
+  const MB = KB * 1024;
+  const GB = MB * 1024;
+  const TB = GB * 1024;
+
+  describe('zero', () => {
+    it('formats 0 bytes', () => {
+      expect(formatFileSize(0)).toBe('0 Bytes');
+    });
+  });
+
+  describe('sub-1KB values stay in Bytes', () => {
+    it('formats a small byte count', () => {
+      expect(formatFileSize(500)).toBe('500 Bytes');
+    });
+
+    it('formats the largest sub-1KB value', () => {
+      expect(formatFileSize(KB - 1)).toBe('1023 Bytes');
+    });
+  });
+
+  describe('unit boundaries', () => {
+    it('formats exactly 1 KB', () => {
+      expect(formatFileSize(KB)).toBe('1 KB');
+    });
+
+    it('formats exactly 1 MB', () => {
+      expect(formatFileSize(MB)).toBe('1 MB');
+    });
+
+    it('formats exactly 1 GB', () => {
+      expect(formatFileSize(GB)).toBe('1 GB');
+    });
+
+    it('rounds within a unit to two decimal places', () => {
+      expect(formatFileSize(1.5 * MB)).toBe('1.5 MB');
+    });
+  });
+
+  describe('terabyte-scale values', () => {
+    it('formats exactly 1 TB without an undefined unit', () => {
+      const result = formatFileSize(TB);
+      expect(result).toBe('1 TB');
+      expect(result).not.toMatch(/undefined/);
+    });
+
+    it('formats a value above 1 TB without an undefined unit', () => {
+      const result = formatFileSize(2.5 * TB);
+      expect(result).toBe('2.5 TB');
+      expect(result).not.toMatch(/undefined/);
+    });
+  });
+
+  describe('non-finite and negative input is guarded', () => {
+    it('rejects negative sizes', () => {
+      expect(formatFileSize(-1)).toBe('Invalid size');
+    });
+
+    it('rejects NaN', () => {
+      expect(formatFileSize(NaN)).toBe('Invalid size');
+    });
+
+    it('rejects positive Infinity', () => {
+      expect(formatFileSize(Infinity)).toBe('Invalid size');
+    });
+
+    it('rejects negative Infinity', () => {
+      expect(formatFileSize(-Infinity)).toBe('Invalid size');
+    });
+  });
+});

--- a/library/forms/lib/fieldRegistry/fields/FileUploader/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/FileUploader/index.tsx
@@ -1,4 +1,4 @@
-import {logError} from '@faims3/data-model';
+import {formatFileSize, logError} from '@faims3/data-model';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CloseIcon from '@mui/icons-material/Close';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -65,17 +65,6 @@ interface FullFileUploaderFieldProps extends FileUploaderFieldProps {
  */
 function isImageFile(contentType: string): boolean {
   return contentType.startsWith('image/');
-}
-
-/**
- * Formats file size in human-readable format
- */
-function formatFileSize(bytes: number): string {
-  if (bytes === 0) return '0 Bytes';
-  const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
 }
 
 /**

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -86,9 +86,9 @@ const ProjectDetails = ({projectId}: {projectId: string}) => {
         getValue: p => (p.recordCount != null ? String(p.recordCount) : '—'),
       },
       {
-          key: 'byteCount',
-          label: 'Current byte count',
-          getValue: p => formatFileSize(p.byteCount),
+        key: 'byteCount',
+        label: 'Current byte count',
+        getValue: p => formatFileSize(p.byteCount),
       },
 
     ],

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -118,6 +118,12 @@ const ProjectDetails = ({projectId}: {projectId: string}) => {
         label: 'Current record count',
         getValue: p => (p.recordCount != null ? String(p.recordCount) : '—'),
       },
+      {
+          key: 'byteCount',
+          label: 'Current byte count',
+          getValue: p => (p.byteCount != null ? String(p.byteCount) : '—'),
+      },
+
     ],
     []
   );

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -7,7 +7,7 @@ import {List} from '@/components/ui/list';
 import {Card} from '@/components/ui/card';
 import {useGetProject} from '@/hooks/queries';
 import {TeamCellComponent} from '@/components/tables/cells/team-cell';
-import type {GetNotebookResponse} from '@faims3/data-model';
+import {formatFileSize, GetNotebookResponse} from '@faims3/data-model';
 import {ProjectStatus} from '@faims3/data-model';
 import {displayIsoTimestamp} from '@/lib/time';
 
@@ -121,7 +121,7 @@ const ProjectDetails = ({projectId}: {projectId: string}) => {
       {
           key: 'byteCount',
           label: 'Current byte count',
-          getValue: p => (p.byteCount != null ? String(p.byteCount) : '—'),
+          getValue: p => (p.byteCount != null ? `${p.byteCount} bytes (${formatFileSize(p.byteCount)})` : '—'),
       },
 
     ],

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -88,7 +88,7 @@ const ProjectDetails = ({projectId}: {projectId: string}) => {
       {
           key: 'byteCount',
           label: 'Current byte count',
-          getValue: p => (`${p.byteCount} bytes (${formatFileSize(p.byteCount)})`),
+          getValue: p => formatFileSize(p.byteCount),
       },
 
     ],

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -88,7 +88,7 @@ const ProjectDetails = ({projectId}: {projectId: string}) => {
       {
           key: 'byteCount',
           label: 'Current byte count',
-          getValue: p => (p.byteCount != null ? `${p.byteCount} bytes (${formatFileSize(p.byteCount)})` : '—'),
+          getValue: p => (`${p.byteCount} bytes (${formatFileSize(p.byteCount)})`),
       },
 
     ],

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -8,46 +8,13 @@ import {Card} from '@/components/ui/card';
 import {useGetProject} from '@/hooks/queries';
 import {TeamCellComponent} from '@/components/tables/cells/team-cell';
 import {formatFileSize, GetNotebookResponse} from '@faims3/data-model';
-import {ProjectStatus} from '@faims3/data-model';
 import {displayIsoTimestamp} from '@/lib/time';
+import {statusDisplay} from '@/lib/status-display';
 
 type DetailRow = {
   key: string;
   label: string;
   getValue: (project: GetNotebookResponse) => ReactNode;
-};
-
-const statusDisplay = (status: ProjectStatus | undefined): ReactNode => {
-  if (status === ProjectStatus.OPEN) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <div className="h-2 w-2 rounded-full bg-emerald-500" />
-        <span className="text-sm text-card-foreground">Open</span>
-      </div>
-    );
-  }
-  if (status === ProjectStatus.CLOSED) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <div className="h-2 w-2 rounded-full bg-muted-foreground" />
-        <span className="text-sm text-muted-foreground">Closed</span>
-      </div>
-    );
-  }
-  if (status === ProjectStatus.ARCHIVED) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <div className="h-2 w-2 rounded-full bg-amber-600/80" />
-        <span className="text-sm text-muted-foreground">Archived</span>
-      </div>
-    );
-  }
-  return (
-    <div className="flex items-center gap-1.5">
-      <div className="h-2 w-2 rounded-full bg-gray-300" />
-      <span className="text-sm text-muted-foreground">Unknown</span>
-    </div>
-  );
 };
 
 /**

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -67,12 +67,12 @@ const TeamDetails = ({teamId}: {teamId: string}) => {
             <ListDescription>
               <details>
                 <summary>
-              {projects ? `${projects.length} - ${formatFileSize(projects.reduce((acc, p) => acc + (p.byteCount ?? 0), 0))}` : 'Unknown...'}
+              {projects ? `${projects.length} - ${formatFileSize(projects.reduce((acc, p) => acc + (p.byteCount), 0))}` : 'Unknown...'}
                 </summary>
               <List className="pt-2 pl-4">
                 {[ProjectStatus.OPEN, ProjectStatus.ARCHIVED, ProjectStatus.CLOSED].map(status => {
                   const projectsWithStatus = projects ? projects.filter(p => p.status === status) : [];
-                  const byteCount = projectsWithStatus.reduce((acc, p) => acc + (p.byteCount ?? 0), 0);
+                  const byteCount = projectsWithStatus.reduce((acc, p) => acc + (p.byteCount), 0);
                   return (
                     <ListItem key={status}>
                       <ListLabel>{statusDisplay(status)}</ListLabel>

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -3,7 +3,7 @@ import {ListItem, ListLabel, ListDescription} from '@/components/ui/list';
 import {Skeleton} from '@/components/ui/skeleton';
 import {List} from '@/components/ui/list';
 import {Card} from '@/components/ui/card';
-import {useGetProjects, useGetProjectsForTeam, useGetTeam} from '@/hooks/queries';
+import {useGetProjectsForTeam, useGetTeam} from '@/hooks/queries';
 import {useMemo} from 'react';
 import {displayUnixTimestampMs} from '@/lib/time';
 import {NOTEBOOK_NAME_PLURAL_CAPITALIZED} from "@/constants";

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -74,6 +74,16 @@ const TeamDetails = ({teamId}: {teamId: string}) => {
             </ListItem>
           );
         })}
+        <ListItem>
+          <ListLabel>{NOTEBOOK_NAME_PLURAL_CAPITALIZED}</ListLabel>
+          {isProjectsPending ? (
+            <Skeleton/>
+          ) : (
+            <ListDescription>
+              {projects ? `${projects.length} - ${formatFileSize(projects.reduce((acc, p) => acc + (p.byteCount ?? 0), 0))}` : 'Unknown...'}
+            </ListDescription>
+          )}
+        </ListItem>
       </List>
     </Card>
   );

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -76,13 +76,9 @@ const TeamDetails = ({teamId}: {teamId: string}) => {
                   return (
                     <ListItem key={status}>
                       <ListLabel>{statusDisplay(status)}</ListLabel>
-                      {isProjectsPending ? (
-                        <Skeleton/>
-                      ) : (
-                        <ListDescription>
-                          {projects ? projects.filter(p => p.status === status).length : 'Unknown...'} - {formatFileSize(byteCount)}
-                        </ListDescription>
-                      )}
+                      <ListDescription>
+                        {projects ? projects.filter(p => p.status === status).length : 'Unknown...'} - {formatFileSize(byteCount)}
+                      </ListDescription>
                     </ListItem>
                   );
                 })}

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -3,9 +3,11 @@ import {ListItem, ListLabel, ListDescription} from '@/components/ui/list';
 import {Skeleton} from '@/components/ui/skeleton';
 import {List} from '@/components/ui/list';
 import {Card} from '@/components/ui/card';
-import {useGetTeam} from '@/hooks/queries';
+import {useGetProjects, useGetProjectsForTeam, useGetTeam} from '@/hooks/queries';
 import {useMemo} from 'react';
 import {displayUnixTimestampMs} from '@/lib/time';
+import {NOTEBOOK_NAME_PLURAL_CAPITALIZED} from "@/constants";
+import {formatFileSize, ProjectStatus} from "@faims3/data-model";
 
 const detailsFields = [
   {field: 'name', label: 'Name'},
@@ -24,8 +26,8 @@ const detailsFields = [
  */
 const TeamDetails = ({teamId}: {teamId: string}) => {
   const {user} = useAuth();
-
   const {data: rawData, isPending} = useGetTeam({user, teamId});
+  const {isPending: isProjectsPending, data: projects} = useGetProjectsForTeam({user, teamId, includeArchived: true});
 
   const data = useMemo(() => {
     return rawData
@@ -56,6 +58,22 @@ const TeamDetails = ({teamId}: {teamId: string}) => {
             )}
           </ListItem>
         ))}
+        {[ProjectStatus.OPEN, ProjectStatus.ARCHIVED, ProjectStatus.CLOSED].map(status => {
+          const projectsWithStatus = projects ? projects.filter(p => p.status === status) : [];
+          const byteCount = projectsWithStatus.reduce((acc, p) => acc + (p.byteCount ?? 0), 0);
+          return (
+            <ListItem key={status}>
+              <ListLabel>{NOTEBOOK_NAME_PLURAL_CAPITALIZED} with status {status}</ListLabel>
+              {isProjectsPending ? (
+                <Skeleton/>
+              ) : (
+                <ListDescription>
+                  {projects ? projects.filter(p => p.status === status).length : 'Unknown...'} - {formatFileSize(byteCount)}
+                </ListDescription>
+              )}
+            </ListItem>
+          );
+        })}
       </List>
     </Card>
   );

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -8,6 +8,7 @@ import {useMemo} from 'react';
 import {displayUnixTimestampMs} from '@/lib/time';
 import {NOTEBOOK_NAME_PLURAL_CAPITALIZED} from "@/constants";
 import {formatFileSize, ProjectStatus} from "@faims3/data-model";
+import {statusDisplay} from "@/lib/status-display";
 
 const detailsFields = [
   {field: 'name', label: 'Name'},
@@ -58,29 +59,35 @@ const TeamDetails = ({teamId}: {teamId: string}) => {
             )}
           </ListItem>
         ))}
-        {[ProjectStatus.OPEN, ProjectStatus.ARCHIVED, ProjectStatus.CLOSED].map(status => {
-          const projectsWithStatus = projects ? projects.filter(p => p.status === status) : [];
-          const byteCount = projectsWithStatus.reduce((acc, p) => acc + (p.byteCount ?? 0), 0);
-          return (
-            <ListItem key={status}>
-              <ListLabel>{NOTEBOOK_NAME_PLURAL_CAPITALIZED} with status {status}</ListLabel>
-              {isProjectsPending ? (
-                <Skeleton/>
-              ) : (
-                <ListDescription>
-                  {projects ? projects.filter(p => p.status === status).length : 'Unknown...'} - {formatFileSize(byteCount)}
-                </ListDescription>
-              )}
-            </ListItem>
-          );
-        })}
         <ListItem>
           <ListLabel>{NOTEBOOK_NAME_PLURAL_CAPITALIZED}</ListLabel>
           {isProjectsPending ? (
             <Skeleton/>
           ) : (
             <ListDescription>
+              <details>
+                <summary>
               {projects ? `${projects.length} - ${formatFileSize(projects.reduce((acc, p) => acc + (p.byteCount ?? 0), 0))}` : 'Unknown...'}
+                </summary>
+              <List className="pt-2 pl-4">
+                {[ProjectStatus.OPEN, ProjectStatus.ARCHIVED, ProjectStatus.CLOSED].map(status => {
+                  const projectsWithStatus = projects ? projects.filter(p => p.status === status) : [];
+                  const byteCount = projectsWithStatus.reduce((acc, p) => acc + (p.byteCount ?? 0), 0);
+                  return (
+                    <ListItem key={status}>
+                      <ListLabel>{statusDisplay(status)}</ListLabel>
+                      {isProjectsPending ? (
+                        <Skeleton/>
+                      ) : (
+                        <ListDescription>
+                          {projects ? projects.filter(p => p.status === status).length : 'Unknown...'} - {formatFileSize(byteCount)}
+                        </ListDescription>
+                      )}
+                    </ListItem>
+                  );
+                })}
+              </List>
+              </details>
             </ListDescription>
           )}
         </ListItem>

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -206,9 +206,12 @@ export const useGetProjectsForTeam = ({
   includeArchived?: boolean;
 }) =>
   useQuery({
-    queryKey: ['projectsbyteam', user?.token, teamId],
+    queryKey: ["projectsbyteam", user?.token, teamId, includeArchived],
     queryFn: () =>
-      get<GetNotebookListResponse>(`/api/notebooks?teamId=${teamId}${includeArchived ? '&includeArchived=true' : ''}`, user),
+      get<GetNotebookListResponse>(
+        `/api/notebooks?teamId=${teamId}${includeArchived ? "&includeArchived=true" : ""}`,
+        user,
+      ),
     select: sortNotebookListNewestFirst,
   });
 

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -199,14 +199,16 @@ export const useTemplateSurveyReferences = ({
 export const useGetProjectsForTeam = ({
   teamId,
   user,
+  includeArchived = false,
 }: {
   user: User | null;
   teamId: string;
+  includeArchived?: boolean;
 }) =>
   useQuery({
     queryKey: ['projectsbyteam', user?.token, teamId],
     queryFn: () =>
-      get<GetNotebookListResponse>(`/api/notebooks?teamId=${teamId}`, user),
+      get<GetNotebookListResponse>(`/api/notebooks?teamId=${teamId}${includeArchived ? '&includeArchived=true' : ''}`, user),
     select: sortNotebookListNewestFirst,
   });
 

--- a/web/src/lib/status-display.tsx
+++ b/web/src/lib/status-display.tsx
@@ -1,0 +1,41 @@
+import type {ReactNode} from 'react';
+import {ProjectStatus} from '@faims3/data-model';
+
+/**
+ * Renders a small coloured indicator and label for a project (notebook) status.
+ *
+ * Shared between the project details and team details views so the status badge
+ * looks the same everywhere a project status is shown.
+ */
+export const statusDisplay = (status: ProjectStatus | undefined): ReactNode => {
+  if (status === ProjectStatus.OPEN) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <div className="h-2 w-2 rounded-full bg-emerald-500" />
+        <span className="text-sm text-card-foreground">Open</span>
+      </div>
+    );
+  }
+  if (status === ProjectStatus.CLOSED) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <div className="h-2 w-2 rounded-full bg-muted-foreground" />
+        <span className="text-sm text-muted-foreground">Closed</span>
+      </div>
+    );
+  }
+  if (status === ProjectStatus.ARCHIVED) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <div className="h-2 w-2 rounded-full bg-amber-600/80" />
+        <span className="text-sm text-muted-foreground">Archived</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="h-2 w-2 rounded-full bg-gray-300" />
+      <span className="text-sm text-muted-foreground">Unknown</span>
+    </div>
+  );
+};


### PR DESCRIPTION
# feat: enable notebook and team storage stats

## JIRA Ticket

#1594

## Description

Add some usage statistics to the Team page in web/ and extend the simple record count in notebook pages.

## Proposed Changes

per-notebook size statistic and consequently a per-team size statistic

## How to Test

- Open a project page, details tab, see the new Current byte count section
- Open a team page, details tab, see the new projects section

## Additional Information

- `getUserProjectsDetailed` now has a Promise.all.  not sure if there will be problems when a team has a lot of projects.
- moved `statusDisplay` and added JSDoc

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
