### PR TITLE
feat: filter forms which are visible in the overview map

### DIFF
--- a/app/src/gui/components/notebook/OverviewMap.tsx
+++ b/app/src/gui/components/notebook/OverviewMap.tsx
@@ -23,6 +23,7 @@ import {
   DatabaseInterface,
   DataDocument,
   DataEngine,
+  getOverviewMapTypes,
   MinimalRecordMetadata,
   NotebookUiSpec,
   ProjectID,
@@ -397,6 +398,16 @@ export const OverviewMap = (props: OverviewMapProps) => {
   // Memoize GIS fields
   const gisFields = useMemo(() => getGISFields(uiSpec), [uiSpec]);
 
+  const overviewMapTypes = useMemo(() => getOverviewMapTypes(uiSpec), [uiSpec]);
+
+  const mapRecords = useMemo(
+    () =>
+      records.allRecords?.filter(record =>
+        overviewMapTypes.includes(record.type)
+      ) ?? [],
+    [records.allRecords, overviewMapTypes]
+  );
+
   /**
    * Extract features from a single record for the given GIS fields
    */
@@ -471,7 +482,7 @@ export const OverviewMap = (props: OverviewMapProps) => {
    * Query function to fetch all features from all records
    */
   const fetchAllFeatures = useCallback(async (): Promise<FeatureCollection> => {
-    if (gisFields.length === 0 || !records.allRecords?.length) {
+    if (gisFields.length === 0 || mapRecords.length === 0) {
       return {type: 'FeatureCollection', features: []};
     }
 
@@ -479,8 +490,8 @@ export const OverviewMap = (props: OverviewMapProps) => {
     const BATCH_SIZE = 10;
     const allFeatures: GeoJSONFeature[] = [];
 
-    for (let i = 0; i < records.allRecords.length; i += BATCH_SIZE) {
-      const batch = records.allRecords.slice(i, i + BATCH_SIZE);
+    for (let i = 0; i < mapRecords.length; i += BATCH_SIZE) {
+      const batch = mapRecords.slice(i, i + BATCH_SIZE);
       const batchResults = await Promise.all(
         batch.map(record => extractFeaturesFromRecord(record, gisFields))
       );
@@ -491,7 +502,7 @@ export const OverviewMap = (props: OverviewMapProps) => {
       type: 'FeatureCollection',
       features: allFeatures,
     };
-  }, [gisFields, records.allRecords, extractFeaturesFromRecord]);
+  }, [gisFields, mapRecords, extractFeaturesFromRecord]);
 
   // Use React Query to manage the async feature fetching
   const {
@@ -503,11 +514,12 @@ export const OverviewMap = (props: OverviewMapProps) => {
     queryKey: [
       'overview-map-features',
       project_id,
-      records.allRecords?.map(r => `${r.recordId}:${r.revisionId}`).join(','),
+      mapRecords.map(r => `${r.recordId}:${r.revisionId}`).join(','),
       gisFields.join(','),
+      overviewMapTypes.join(','),
     ],
     queryFn: fetchAllFeatures,
-    enabled: gisFields.length > 0 && records.allRecords?.length > 0,
+    enabled: gisFields.length > 0 && mapRecords.length > 0,
     staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
     gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes
     retry: 2,

--- a/library/data-model/src/uiSpecification/types.ts
+++ b/library/data-model/src/uiSpecification/types.ts
@@ -173,6 +173,8 @@ export const UiSpecFormSchema = z
     hridField: z.string().optional(),
     /** How the form's sections are laid out. */
     layout: z.enum(['inline', 'tabs']).optional(),
+    /** Whether records of this form type appear on the notebook overview map. */
+    displayInOverviewMap: z.boolean().optional(),
   })
   .passthrough();
 export type UiSpecForm = z.infer<typeof UiSpecFormSchema>;

--- a/library/data-model/src/uiSpecification/utils.ts
+++ b/library/data-model/src/uiSpecification/utils.ts
@@ -633,13 +633,13 @@ export function getVisibleTypes(ui_specification: UiSpecModel) {
 
 /** Whether a form type's records should appear on the notebook overview map. */
 export function isFormDisplayedInOverviewMap(
-  ui_specification: UiSpecModel,
+  uiSpec: UiSpecModel,
   formId: string
 ): boolean {
-  if (!ui_specification || !(formId in ui_specification.viewsets)) {
+  if (!uiSpec || !(formId in uiSpec.viewsets)) {
     return false;
   }
-  return ui_specification.viewsets[formId].displayInOverviewMap !== false;
+  return uiSpec.viewsets[formId].displayInOverviewMap !== false;
 }
 
 /** Form type ids whose records should appear on the notebook overview map. */

--- a/library/data-model/src/uiSpecification/utils.ts
+++ b/library/data-model/src/uiSpecification/utils.ts
@@ -631,6 +631,27 @@ export function getVisibleTypes(ui_specification: UiSpecModel) {
   else return [];
 }
 
+/** Whether a form type's records should appear on the notebook overview map. */
+export function isFormDisplayedInOverviewMap(
+  ui_specification: UiSpecModel,
+  formId: string
+): boolean {
+  if (!ui_specification || !(formId in ui_specification.viewsets)) {
+    return false;
+  }
+  return ui_specification.viewsets[formId].displayInOverviewMap !== false;
+}
+
+/** Form type ids whose records should appear on the notebook overview map. */
+export function getOverviewMapTypes(ui_specification: UiSpecModel): string[] {
+  if (!ui_specification) {
+    return [];
+  }
+  return Object.getOwnPropertyNames(ui_specification.viewsets).filter(formId =>
+    isFormDisplayedInOverviewMap(ui_specification, formId)
+  );
+}
+
 /**
  * Retrieves and processes summary field information for a specific viewset
  *

--- a/library/data-model/tests/overviewMapTypes.test.ts
+++ b/library/data-model/tests/overviewMapTypes.test.ts
@@ -1,0 +1,35 @@
+import type {UiSpecModel} from '../src/uiSpecification/types';
+import {
+  getOverviewMapTypes,
+  isFormDisplayedInOverviewMap,
+} from '../src/uiSpecification/utils';
+
+const createUiSpec = (
+  viewsets: UiSpecModel['viewsets']
+): UiSpecModel => ({
+  fields: {},
+  views: {},
+  viewsets,
+  visible_types: Object.keys(viewsets),
+});
+
+describe('overview map form type visibility', () => {
+  it('includes form types by default when displayInOverviewMap is unset', () => {
+    const uiSpec = createUiSpec({
+      site: {views: [], label: 'Site'},
+      photo: {views: [], label: 'Photo', displayInOverviewMap: false},
+    });
+
+    expect(isFormDisplayedInOverviewMap(uiSpec, 'site')).toBe(true);
+    expect(isFormDisplayedInOverviewMap(uiSpec, 'photo')).toBe(false);
+    expect(getOverviewMapTypes(uiSpec)).toEqual(['site']);
+  });
+
+  it('returns false for unknown form types', () => {
+    const uiSpec = createUiSpec({
+      site: {views: [], label: 'Site'},
+    });
+
+    expect(isFormDisplayedInOverviewMap(uiSpec, 'missing')).toBe(false);
+  });
+});

--- a/web/src/designer/components/form-settings.tsx
+++ b/web/src/designer/components/form-settings.tsx
@@ -16,9 +16,7 @@ import {
   Box,
   Card,
   CardContent,
-  Checkbox,
   Collapse,
-  FormControlLabel,
   IconButton,
   MenuItem,
   Select,
@@ -26,6 +24,7 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
+import {NOTEBOOK_NAME} from '@/constants';
 import {useAppDispatch, useAppSelector} from '../state/hooks';
 import {FieldType} from '../state/initial';
 import {designerInfoIconSx} from './designer-style';
@@ -65,7 +64,7 @@ const isValidHridField = (field: FieldType): boolean => {
 const SettingSection = ({
   title,
   description,
-  tooltipText = 'Configure how this form behaves and appears to data collectors.',
+  tooltipText,
   children,
 }: {
   title: string;
@@ -78,13 +77,15 @@ const SettingSection = ({
       <Typography variant="subtitle1" sx={{fontWeight: 'bold'}}>
         {title}
       </Typography>
-      <Tooltip title={tooltipText}>
-        <InfoIcon
-          sx={{
-            ...(designerInfoIconSx as Record<string, unknown>),
-          }}
-        />
-      </Tooltip>
+      {tooltipText ? (
+        <Tooltip title={tooltipText}>
+          <InfoIcon
+            sx={{
+              ...(designerInfoIconSx as Record<string, unknown>),
+            }}
+          />
+        </Tooltip>
+      ) : null}
     </Box>
     <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
       {description}
@@ -251,25 +252,23 @@ export const FormSettingsContent = ({viewSetId}: {viewSetId: string}) => {
       {/* Overview map visibility */}
       <SettingSection
         title="Overview Map"
-        description="Choose whether records of this form type appear as points on the notebook overview map."
-        tooltipText="When enabled, GIS data from records of this form type is shown on the overview map tab. Disable to hide this form type from the map while keeping its records in the record list."
+        description={`Choose whether to show spatial features from this form in the ${NOTEBOOK_NAME} overview map e.g. points, lines, polygons.`}
       >
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={viewSet.displayInOverviewMap !== false}
-              onChange={e =>
-                dispatch(
-                  viewSetDisplayInOverviewMapUpdated({
-                    viewSetId,
-                    displayInOverviewMap: e.target.checked,
-                  })
-                )
-              }
-            />
+        <Select
+          fullWidth
+          value={viewSet.displayInOverviewMap !== false ? 'show' : 'hide'}
+          onChange={event =>
+            dispatch(
+              viewSetDisplayInOverviewMapUpdated({
+                viewSetId,
+                displayInOverviewMap: event.target.value === 'show',
+              })
+            )
           }
-          label="Show this form type on the overview map"
-        />
+        >
+          <MenuItem value="show">Show spatial features</MenuItem>
+          <MenuItem value="hide">Don&apos;t show spatial features</MenuItem>
+        </Select>
       </SettingSection>
     </>
   );

--- a/web/src/designer/components/form-settings.tsx
+++ b/web/src/designer/components/form-settings.tsx
@@ -16,7 +16,9 @@ import {
   Box,
   Card,
   CardContent,
+  Checkbox,
   Collapse,
+  FormControlLabel,
   IconButton,
   MenuItem,
   Select,
@@ -28,6 +30,7 @@ import {useAppDispatch, useAppSelector} from '../state/hooks';
 import {FieldType} from '../state/initial';
 import {designerInfoIconSx} from './designer-style';
 import {
+  viewSetDisplayInOverviewMapUpdated,
   viewSetHridUpdated,
   viewSetLayoutUpdated,
   viewSetSummaryFieldsUpdated,
@@ -40,6 +43,7 @@ type ViewSetType = {
   summary_fields?: string[];
   layout?: 'inline' | 'tabs';
   hridField?: string;
+  displayInOverviewMap?: boolean;
   publishButtonBehaviour?: 'always' | 'visited' | 'noErrors';
 };
 
@@ -241,6 +245,30 @@ export const FormSettingsContent = ({viewSetId}: {viewSetId: string}) => {
           renderInput={params => (
             <DebouncedTextField {...params} onChange={() => {}} />
           )}
+        />
+      </SettingSection>
+
+      {/* Overview map visibility */}
+      <SettingSection
+        title="Overview Map"
+        description="Choose whether records of this form type appear as points on the notebook overview map."
+        tooltipText="When enabled, GIS data from records of this form type is shown on the overview map tab. Disable to hide this form type from the map while keeping its records in the record list."
+      >
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={viewSet.displayInOverviewMap !== false}
+              onChange={e =>
+                dispatch(
+                  viewSetDisplayInOverviewMapUpdated({
+                    viewSetId,
+                    displayInOverviewMap: e.target.checked,
+                  })
+                )
+              }
+            />
+          }
+          label="Show this form type on the overview map"
         />
       </SettingSection>
     </>

--- a/web/src/designer/store/slices/uiSpec/index.ts
+++ b/web/src/designer/store/slices/uiSpec/index.ts
@@ -76,5 +76,6 @@ export const {
   viewSetLayoutUpdated,
   viewSetSummaryFieldsUpdated,
   viewSetHridUpdated,
+  viewSetDisplayInOverviewMapUpdated,
   settingsUpdated,
 } = uiSpecificationReducer.actions;

--- a/web/src/designer/store/slices/uiSpec/uiSpec-reducer.test.ts
+++ b/web/src/designer/store/slices/uiSpec/uiSpec-reducer.test.ts
@@ -20,6 +20,7 @@ import {
   viewSetDeleted,
   viewSetHridUpdated,
   viewSetLayoutUpdated,
+  viewSetDisplayInOverviewMapUpdated,
   viewSetSummaryFieldsUpdated,
 } from '.';
 
@@ -226,6 +227,15 @@ describe('uiSpecificationReducer', () => {
       viewSetLayoutUpdated({viewSetId: 'formA', layout: 'tabs'})
     );
     expect(layoutUpdated.viewsets.formA.layout).toBe('tabs');
+
+    const mapHidden = uiSpecificationReducer.reducer(
+      layoutUpdated,
+      viewSetDisplayInOverviewMapUpdated({
+        viewSetId: 'formA',
+        displayInOverviewMap: false,
+      })
+    );
+    expect(mapHidden.viewsets.formA.displayInOverviewMap).toBe(false);
 
     expect(layoutUpdated.visible_types).toEqual(['formA', 'formB']);
 

--- a/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
+++ b/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
@@ -132,6 +132,16 @@ export const viewSetReducers = {
       state.viewsets[viewSetId].hridField = hridField;
     }
   },
+  /** Whether records of this form type appear on the notebook overview map. */
+  viewSetDisplayInOverviewMapUpdated: (
+    state: NotebookUISpec,
+    action: PayloadAction<{viewSetId: string; displayInOverviewMap: boolean}>
+  ) => {
+    const {viewSetId, displayInOverviewMap} = action.payload;
+    if (viewSetId in state.viewsets) {
+      state.viewsets[viewSetId].displayInOverviewMap = displayInOverviewMap;
+    }
+  },
   /** Add/remove form id from `visible_types` when user toggles form in notebook chrome. */
   formVisibilityUpdated: (
     state: NotebookUISpec,

--- a/web/src/designer/store/undoConfig.ts
+++ b/web/src/designer/store/undoConfig.ts
@@ -51,6 +51,7 @@ export const UNDOABLE_UI_SPEC_ACTIONS = [
   'uiSpec/viewSetLayoutUpdated',
   'uiSpec/viewSetSummaryFieldsUpdated',
   'uiSpec/viewSetHridUpdated',
+  'uiSpec/viewSetDisplayInOverviewMapUpdated',
 ] as const;
 
 /** Passed to `undoable(uiSpecificationReducer.reducer, uiSpecUndoConfig)`. */


### PR DESCRIPTION
Adds a new setting the form settings to show/hide elements from the overview map. 

Later this would be part of a more expansive spatial settings for forms (and fields). Right now you can't control anything, this allows form level visibility, but future work would change iconography, conditional visibility, per-field visibility etc.