### PR TITLE
fix: restoring map layout after MUI v9

### DIFF
--- a/app/src/gui/components/notebook/OverviewMap.tsx
+++ b/app/src/gui/components/notebook/OverviewMap.tsx
@@ -36,7 +36,6 @@ import {
   Card,
   CardContent,
   CircularProgress,
-  Grid,
   Popover,
   Typography,
 } from '@mui/material';
@@ -786,14 +785,14 @@ export const OverviewMap = (props: OverviewMapProps) => {
   }
 
   return (
-    <Grid
-      container
-      spacing={2}
+    <Box
       sx={{
-        height: '600px',
-        width: '90vw',
-        marginTop: '20px',
-        marginLeft: '20px',
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        minWidth: 0,
+        height: {xs: 'clamp(320px, 55vh, 600px)', sm: 'clamp(400px, 60vh, 600px)'},
+        mt: {xs: 1, sm: 2.5},
       }}
     >
       <MapComponent
@@ -832,6 +831,6 @@ export const OverviewMap = (props: OverviewMapProps) => {
           </Box>
         )}
       </Popover>
-    </Grid>
+    </Box>
   );
 };

--- a/library/forms/lib/components/maps/MapComponent.tsx
+++ b/library/forms/lib/components/maps/MapComponent.tsx
@@ -24,7 +24,7 @@
  */
 
 import {Geolocation, Position} from '@capacitor/geolocation';
-import {Box, Grid} from '@mui/material';
+import {Box} from '@mui/material';
 import {View} from 'ol';
 import {Zoom} from 'ol/control';
 import {Extent} from 'ol/extent';
@@ -496,33 +496,39 @@ export const MapComponent = (props: MapComponentProps) => {
   );
 
   return (
-    <>
-      <Box sx={{height: '100%', width: '100%'}}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        width: '100%',
+        minHeight: 0,
+        minWidth: 0,
+      }}
+    >
+      <Box
+        ref={refCallback} // will create the map
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+        }}
+      />
+      {attribution && (
         <Box
-          ref={refCallback} // will create the map
+          component="div"
+          dangerouslySetInnerHTML={{__html: attribution}}
           sx={{
-            height: '97%',
-            width: '100%',
+            flexShrink: 0,
+            fontSize: '10px',
+            lineHeight: 1.3,
+            color: '#666',
+            py: 0.25,
+            px: {xs: 0.5, sm: 1},
+            wordBreak: 'break-word',
           }}
         />
-        <Box
-          sx={{
-            height: '3%',
-            paddingLeft: '50px',
-          }}
-        >
-          {attribution && (
-            <div
-              dangerouslySetInnerHTML={{__html: attribution}}
-              style={{
-                fontSize: '10px',
-                lineHeight: 1.1,
-                color: '#666',
-              }}
-            />
-          )}
-        </Box>
-      </Box>
-    </>
+      )}
+    </Box>
   );
 };


### PR DESCRIPTION
The map layout got off-centred, excessive padding, and cutoff the attribution on smaller phones. Just doing some css to try and get it looking the same as before. Seems good now.