### PR TITLE
fix: persist and enable editing of field labels for templated string …

### DIFF
--- a/web/src/designer/components/Fields/RichTextEditor.tsx
+++ b/web/src/designer/components/Fields/RichTextEditor.tsx
@@ -21,6 +21,7 @@ import {RichTextProps} from '@faims3/forms';
 import {FieldType} from '../../state/initial';
 import {MdxEditor} from '../mdx-editor';
 import {fieldUpdated} from '../../store/slices/uiSpec';
+import {BaseFieldEditor} from './BaseFieldEditor';
 
 /** RichText display field: MDX body stored in `component-parameters.content`. */
 export const RichTextEditor = ({fieldName}: {fieldName: string}) => {
@@ -58,19 +59,25 @@ export const RichTextEditor = ({fieldName}: {fieldName: string}) => {
   };
 
   return (
-    <Grid container size={{xs: 12, sm: 8}} sx={{m: 'auto'}}>
-      <Grid size={12}>
-        <MdxEditor
-          initialMarkdown={initContent}
-          editorRef={ref}
-          handleChange={() =>
-            updateProperty('content', ref.current?.getMarkdown())
-          }
-        />
-        <FormHelperText>
-          {`Use this editor to add rich text to your ${NOTEBOOK_NAME}.`}
-        </FormHelperText>
+    <BaseFieldEditor
+      fieldName={fieldName}
+      showHelperText={false}
+      showExtraConfig={false}
+    >
+      <Grid container size={{xs: 12, sm: 8}} sx={{m: 'auto'}}>
+        <Grid size={12}>
+          <MdxEditor
+            initialMarkdown={initContent}
+            editorRef={ref}
+            handleChange={() =>
+              updateProperty('content', ref.current?.getMarkdown())
+            }
+          />
+          <FormHelperText>
+            {`Use this editor to add rich text to your ${NOTEBOOK_NAME}.`}
+          </FormHelperText>
+        </Grid>
       </Grid>
-    </Grid>
+    </BaseFieldEditor>
   );
 };

--- a/web/src/designer/components/Fields/TemplatedStringFieldEditor.tsx
+++ b/web/src/designer/components/Fields/TemplatedStringFieldEditor.tsx
@@ -71,7 +71,7 @@ export const TemplatedStringFieldEditor = ({
 
   const getFieldLabel = (f: FieldType) => {
     const params = f['component-parameters'] as TemplatedStringProps;
-    return params.InputLabelProps?.label || params.name || '';
+    return params.label || params.InputLabelProps?.label || params.name || '';
   };
 
   const fieldVariables = viewSetFields.map(name => {
@@ -86,6 +86,9 @@ export const TemplatedStringFieldEditor = ({
   const updateFieldFromState = (newState: TemplatedStringProps) => {
     const newField = JSON.parse(JSON.stringify(field)) as FieldType;
     const newParams = newField['component-parameters'] as TemplatedStringProps;
+    // label is the canonical property the rest of the designer reads;
+    // mirror to InputLabelProps.label for older consumers.
+    newParams.label = newState.label || fieldName;
     newParams.InputLabelProps = {
       label: newState.label || fieldName,
     };


### PR DESCRIPTION
# fix: persist and enable editing of field labels for Templated String and RichText fields (#2145)

## JIRA Ticket

N/A (GitHub issue #2145)

## Description

Two related defects prevented field labels from being edited in the designer:

- **Templated String fields:** editing the Label had no effect — the change reverted as soon as the field was closed and reopened. The Label input read the label from `component-parameters.label`, but the editor's save path wrote it only to `component-parameters.InputLabelProps.label`, so the read and write paths never met. The displayed name (which also reads `component-parameters.label` first) never updated.

- **RichText fields:** the editor exposed no Label or Field ID control at all, so every RichText field was stuck on its scaffolded name (e.g. `New-Field`) with no way to rename it.

Both are fixed by routing the label through `component-parameters.label`, the property the rest of the designer already treats as canonical (the accordion header, form settings, and `BaseFieldEditor` all read it).

## Proposed Changes

- `web/src/designer/components/Fields/TemplatedStringFieldEditor.tsx`
  - Write the label to `component-parameters.label` (the canonical property) in `updateFieldFromState`, while keeping `InputLabelProps.label` mirrored for backward compatibility with existing notebooks.
  - Updated the variable-picker label helper to prefer `label` before falling back to `InputLabelProps.label` and `name`, so the Mustache builder lists fields by their actual labels.

- `web/src/designer/components/Fields/RichTextEditor.tsx`
  - Wrapped `BaseFieldEditor` so RichText inherits the shared Label and Field ID controls (including the label → Field ID sync), rather than hand-rolling a label input. `showHelperText` and `showExtraConfig` are disabled to keep the panel appropriate for a display field. The MDX content editor is passed through as children and continues to manage `component-parameters.content`.

## How to Test

1. Start the web manager and open the designer.
2. **Templated String:** add a Templated String field, change its Label to something distinct, then collapse and reopen the field. The label persists, and the accordion header reflects it. (Previously it reverted.)
3. **RichText:** add a RichText field. It now shows a Label and Field ID box above the content editor. Set a label; the Field ID auto-syncs to a slug and the header updates.
4. **Backward compatibility:** open an existing notebook containing a Templated String field whose label was saved the old way (only `InputLabelProps.label`); confirm it still displays and is editable.

## Additional Information
Templated String Field fixed
<img width="883" height="544" alt="templatedstringfield 1" src="https://github.com/user-attachments/assets/5ac1fda0-6e03-4438-8823-304dc50bb6be" />

Rich Text Field fixed
<img width="1779" height="499" alt="richtext 1" src="https://github.com/user-attachments/assets/26ebaa03-24bd-4fbd-bec3-8e5a118798ae" />


Closes #2145

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.