### PR TITLE
fix: attachments stuck on saving... and navigation no longer locked

### DIFF
--- a/app/src/logging.tsx
+++ b/app/src/logging.tsx
@@ -20,6 +20,7 @@
 
 import Bugsnag from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
+import {setAttachmentSaveTraceEnabled} from '@faims3/data-model';
 import {FormLogger, LoggingService} from '@faims3/forms';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import {Button, Grid, Typography} from '@mui/material';
@@ -262,9 +263,11 @@ const createBugsnagFormLogger = (
 const registerFormsLogger = (): void => {
   const formLogger = createBugsnagFormLogger(Bugsnag, BUGSNAG_KEY);
   LoggingService.register(formLogger);
+  setAttachmentSaveTraceEnabled(DEBUG_APP);
   console.debug('[FormLogger] Registered with LoggingService', {
     bugsnagEnabled: !!BUGSNAG_KEY,
     debugEnabled: DEBUG_APP,
+    attachmentSaveTraceEnabled: DEBUG_APP,
   });
 };
 

--- a/library/data-model/src/databaseEngine/engine.ts
+++ b/library/data-model/src/databaseEngine/engine.ts
@@ -1,3 +1,4 @@
+import {attachmentSaveTrace} from '../logging';
 import {isEqualFAIMS} from '../datamodel';
 import {DatabaseInterface} from '../types';
 import {
@@ -521,13 +522,23 @@ export class CoreOperations {
   async createAttachment(
     attachment: NewPendingAttachmentDBDocument
   ): Promise<ExistingAttachmentDBDocument> {
+    attachmentSaveTrace('core.createAttachment:start', {
+      id: attachment._id,
+      recordId: attachment.record_id,
+      revisionId: attachment.revision_id,
+    });
     await this.createDocument(
       attachment,
       pendingAttachmentDocumentSchema.parse
     );
 
+    attachmentSaveTrace('core.createAttachment:before-getAttachment', {
+      id: attachment._id,
+    });
     // Fetch it back out to get the existing version (where it should be encoded nicely)
-    return this.getAttachment(attachment._id);
+    const result = await this.getAttachment(attachment._id);
+    attachmentSaveTrace('core.createAttachment:complete', {id: attachment._id});
+    return result;
   }
 
   // ============================================================================

--- a/library/data-model/src/databaseEngine/services/attachments/couch.ts
+++ b/library/data-model/src/databaseEngine/services/attachments/couch.ts
@@ -14,6 +14,7 @@ import {
   StorageMetadata,
   StoreAttachmentResult,
 } from './types';
+import {attachmentSaveTrace} from '../../../logging';
 import {base64ToBlob, fileToBase64} from './utils';
 
 // The default att- prefix
@@ -110,16 +111,28 @@ export class CouchAttachmentService extends BaseAttachmentService {
       attach_format_version: 1,
     };
 
+    attachmentSaveTrace('couch.storeAttachmentFromFile:before-createAttachment', {
+      id,
+      fileSize: file.size,
+      contentType: metadata.attachmentDetails.contentType,
+    });
+
     // Now write it using special core op
     try {
       await this.core.createAttachment(attachmentDocument);
     } catch (e) {
+      attachmentSaveTrace('couch.storeAttachmentFromFile:createAttachment-error', {
+        id,
+        error: String(e),
+      });
       console.error(
         'Failed to create attachment in couch DB attachment service. Error: ',
         e
       );
       throw e;
     }
+
+    attachmentSaveTrace('couch.storeAttachmentFromFile:complete', {id});
 
     // Return info about the new document
     return {
@@ -146,6 +159,14 @@ export class CouchAttachmentService extends BaseAttachmentService {
     const {blob, metadata} = params;
     const id = generateAttID();
 
+    attachmentSaveTrace('couch.storeAttachmentFromBlob:start', {
+      id,
+      blobSize: blob.size,
+      contentType: metadata.attachmentDetails.contentType,
+      recordId: metadata.recordContext.recordId,
+      revisionId: metadata.recordContext.revisionId,
+    });
+
     // Create the document shell first (no attachment data)
     const attachmentDocument: Omit<AttachmentDBDocument, '_attachments'> = {
       _id: id,
@@ -158,10 +179,19 @@ export class CouchAttachmentService extends BaseAttachmentService {
     };
 
     // Create doc without attachment
+    attachmentSaveTrace('couch.storeAttachmentFromBlob:before-db.put', {id});
     const result = await this.core.db.put(attachmentDocument);
+    attachmentSaveTrace('couch.storeAttachmentFromBlob:after-db.put', {
+      id,
+      rev: result.rev,
+    });
 
     // This attaches the document directly using the blob interface - more
     // efficient
+    attachmentSaveTrace('couch.storeAttachmentFromBlob:before-putAttachment', {
+      id,
+      rev: result.rev,
+    });
     await this.core.db.putAttachment(
       id,
       id, // attachment name
@@ -169,6 +199,9 @@ export class CouchAttachmentService extends BaseAttachmentService {
       blob,
       metadata.attachmentDetails.contentType
     );
+    attachmentSaveTrace('couch.storeAttachmentFromBlob:after-putAttachment', {
+      id,
+    });
 
     return {
       identifier: {id, metadata: {}},
@@ -193,6 +226,10 @@ export class CouchAttachmentService extends BaseAttachmentService {
   }): Promise<LoadAttachmentResult> {
     const {identifier} = params;
 
+    attachmentSaveTrace('couch.loadAttachmentAsBlob:start', {
+      id: identifier.id,
+    });
+
     // Fetch the record, load attachments
     const attachment = await this.core.db.get<AttachmentDBDocument>(
       identifier.id,
@@ -204,6 +241,14 @@ export class CouchAttachmentService extends BaseAttachmentService {
       }
     );
 
+    attachmentSaveTrace('couch.loadAttachmentAsBlob:after-get', {
+      id: identifier.id,
+      hasAttachments: Boolean(attachment._attachments),
+      attachmentKeys: attachment._attachments
+        ? Object.keys(attachment._attachments)
+        : [],
+    });
+
     const attachmentDetails = attachment._attachments?.[identifier.id] as
       | (PouchDB.Core.Attachment & {
           // Base 64 encoded (include_attachments = true, binary = false)
@@ -213,6 +258,11 @@ export class CouchAttachmentService extends BaseAttachmentService {
 
     // Check if attachment exists
     if (!attachmentDetails || !attachmentDetails.data) {
+      attachmentSaveTrace('couch.loadAttachmentAsBlob:no-data', {
+        id: identifier.id,
+        hasDetails: Boolean(attachmentDetails),
+        hasData: Boolean(attachmentDetails?.data),
+      });
       throw new Error(
         `Attachment with ID "${identifier.id}" not found or has no data`
       );
@@ -226,6 +276,11 @@ export class CouchAttachmentService extends BaseAttachmentService {
 
     // Extract metadata from the attachment document
     const filename = attachment.filename || 'unknown';
+
+    attachmentSaveTrace('couch.loadAttachmentAsBlob:complete', {
+      id: identifier.id,
+      blobSize: blob.size,
+    });
 
     return {
       blob,
@@ -306,16 +361,31 @@ export class CouchAttachmentService extends BaseAttachmentService {
       attach_format_version: 1,
     };
 
+    attachmentSaveTrace(
+      'couch.storeAttachmentFromBase64:before-createAttachment',
+      {
+        id,
+        base64Length: base64.length,
+        contentType: metadata.attachmentDetails.contentType,
+      }
+    );
+
     // Now write it using special core op
     try {
       await this.core.createAttachment(attachmentDocument);
     } catch (e) {
+      attachmentSaveTrace(
+        'couch.storeAttachmentFromBase64:createAttachment-error',
+        {id, error: String(e)}
+      );
       console.error(
         'Failed to create attachment in couch DB attachment service. Error: ',
         e
       );
       throw e;
     }
+
+    attachmentSaveTrace('couch.storeAttachmentFromBase64:complete', {id});
 
     // Return info about the new document
     return {

--- a/library/data-model/src/logging.ts
+++ b/library/data-model/src/logging.ts
@@ -24,3 +24,30 @@
 export const logError = (error: any) => {
   console.error(error);
 };
+
+let attachmentSaveTraceEnabled = false;
+
+/** Enable or disable attachment-save trace output (typically from DEBUG_APP). */
+export function setAttachmentSaveTraceEnabled(enabled: boolean): void {
+  attachmentSaveTraceEnabled = enabled;
+}
+
+export function isAttachmentSaveTraceEnabled(): boolean {
+  return attachmentSaveTraceEnabled;
+}
+
+/** Writes attachment-save pipeline stages to stdout when tracing is enabled. */
+export function attachmentSaveTrace(
+  stage: string,
+  details?: Record<string, unknown>
+): void {
+  if (!attachmentSaveTraceEnabled) {
+    return;
+  }
+  const line = `[attachment-save-trace] ${new Date().toISOString()} ${stage}`;
+  if (details !== undefined) {
+    console.log(line, details);
+  } else {
+    console.log(line);
+  }
+}

--- a/library/forms/lib/fieldRegistry/fields/AudioRecorder/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/AudioRecorder/index.tsx
@@ -476,7 +476,7 @@ const AudioRecorderFull: React.FC<FullAudioRecorderFieldProps> = props => {
     isRecordingRef.current = false;
     setIsPaused(false);
     releaseRecordingLock(fieldId);
-    setAttachmentSaving?.(false);
+    // Keep the attachment lock (set on handleStart) through blob conversion and save.
     try {
       const result = await CapacitorAudioRecorder.stopRecording();
       const blob = await blobFromResult(result);
@@ -497,21 +497,15 @@ const AudioRecorderFull: React.FC<FullAudioRecorderFieldProps> = props => {
         fileFormat: extensionFromMime(mime),
       });
 
-      const currentData = state.value?.data as string[] | undefined;
-      setFieldData([...(currentData ?? []), newId]);
+      setFieldData((prev: string[] | undefined) => [...(prev ?? []), newId]);
       setElapsed(0);
     } catch (e) {
       logError(e);
       setError(e instanceof Error ? e.message : 'Failed to save recording.');
+    } finally {
+      setAttachmentSaving?.(false);
     }
-  }, [
-    stopTimer,
-    addAttachment,
-    setFieldData,
-    state.value?.data,
-    fieldId,
-    setAttachmentSaving,
-  ]);
+  }, [stopTimer, addAttachment, setFieldData, fieldId, setAttachmentSaving]);
 
   /** Removes a saved recording by attachment ID. */
   const handleRemove = useCallback(

--- a/library/forms/lib/fieldRegistry/fields/FileUploader/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/FileUploader/index.tsx
@@ -1,4 +1,4 @@
-import {formatFileSize, logError} from '@faims3/data-model';
+import {formatFileSize, attachmentSaveTrace, logError} from '@faims3/data-model';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CloseIcon from '@mui/icons-material/Close';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -23,7 +23,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import Dropzone, {FileRejection} from 'react-dropzone';
 import {z} from 'zod';
 import {FullFormConfig} from '../../../formModule/formManagers/types';
@@ -228,18 +228,32 @@ const FileUploaderPreview: React.FC<FileUploaderFieldProps> = props => {
 const DropzoneArea: React.FC<{
   onDrop: (files: File[]) => void;
   onReject: (rejections: FileRejection[]) => void;
+  onFileDialogOpen?: () => void;
+  onFileDialogCancel?: () => void;
   disabled: boolean;
   multiple: boolean;
   maxFiles: number;
   maxSize?: number;
   minSize?: number;
-}> = ({onDrop, onReject, disabled, multiple, maxFiles, maxSize, minSize}) => {
+}> = ({
+  onDrop,
+  onReject,
+  onFileDialogOpen,
+  onFileDialogCancel,
+  disabled,
+  multiple,
+  maxFiles,
+  maxSize,
+  minSize,
+}) => {
   const theme = useTheme();
 
   return (
     <Dropzone
       onDrop={onDrop}
       onDropRejected={onReject}
+      onFileDialogOpen={onFileDialogOpen}
+      onFileDialogCancel={onFileDialogCancel}
       disabled={disabled}
       multiple={multiple}
       maxFiles={maxFiles}
@@ -507,6 +521,7 @@ const FileList: React.FC<{
  */
 const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
   const {
+    fieldId,
     label,
     helperText,
     required,
@@ -527,6 +542,8 @@ const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
   const [viewingAttachment, setViewingAttachment] = useState<number | null>(
     null
   );
+  /** True while the native file picker is open (click-to-select path). */
+  const filePickerLockHeldRef = useRef(false);
 
   // Get attachment service
   const attachmentService = context.attachmentEngine();
@@ -540,6 +557,18 @@ const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
   /**
    * Handle file drop/selection
    */
+  const handleFileDialogOpen = useCallback(() => {
+    setAttachmentSaving?.(true);
+    filePickerLockHeldRef.current = true;
+  }, [setAttachmentSaving]);
+
+  const handleFileDialogCancel = useCallback(() => {
+    if (filePickerLockHeldRef.current) {
+      setAttachmentSaving?.(false);
+      filePickerLockHeldRef.current = false;
+    }
+  }, [setAttachmentSaving]);
+
   const handleDrop = useCallback(
     async (acceptedFiles: File[]) => {
       setError(null);
@@ -559,12 +588,26 @@ const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
           return;
         }
 
-        // Block section navigation until all files are stored in PouchDB
-        setAttachmentSaving?.(true);
+        // Block section navigation until all files are stored in PouchDB.
+        // Drag-and-drop sets the lock here; click-to-select sets it on dialog open.
+        const lockFromPicker = filePickerLockHeldRef.current;
+        if (!lockFromPicker) {
+          setAttachmentSaving?.(true);
+        }
+
+        attachmentSaveTrace('FileUploader:save-start', {
+          fieldId,
+          fileCount: acceptedFiles.length,
+        });
         try {
           // Upload each file
-          const newAttachments = [];
+          const newAttachments: string[] = [];
           for (const file of acceptedFiles) {
+            attachmentSaveTrace('FileUploader:upload-file', {
+              fieldId,
+              fileName: file.name,
+              fileSize: file.size,
+            });
             newAttachments.push(
               await addAttachment({
                 blob: file,
@@ -577,18 +620,25 @@ const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
             );
           }
 
-          // Update field value
-          const currentData = props.state.value?.data as string[] | undefined;
-          props.setFieldData([...(currentData ?? []), ...newAttachments]);
+          props.setFieldData((prev: string[] | undefined) => [
+            ...(prev ?? []),
+            ...newAttachments,
+          ]);
+
+          attachmentSaveTrace('FileUploader:save-complete', {
+            fieldId,
+            attachmentIds: newAttachments,
+          });
         } finally {
           setAttachmentSaving?.(false);
+          filePickerLockHeldRef.current = false;
         }
       } catch (err: any) {
         logError(err);
         setError('Failed to upload file(s). Please try again.');
       }
     },
-    [state.value, addAttachment, setAttachmentSaving, maximumNumberOfFiles]
+    [state.value, addAttachment, setAttachmentSaving, maximumNumberOfFiles, fieldId]
   );
 
   /**
@@ -690,6 +740,8 @@ const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
           <DropzoneArea
             onDrop={handleDrop}
             onReject={handleReject}
+            onFileDialogOpen={handleFileDialogOpen}
+            onFileDialogCancel={handleFileDialogCancel}
             disabled={disabled}
             multiple={multiple}
             maxFiles={maxFiles}

--- a/library/forms/lib/fieldRegistry/fields/TakePhoto/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/TakePhoto/index.tsx
@@ -23,7 +23,7 @@ import {z} from 'zod';
 import {CameraPermissionIssue} from '../../../components/PermissionAlerts';
 import {PhotoLightbox} from '../../../components/PhotoLightbox';
 import {FullFormConfig} from '../../../formModule/formManagers/types';
-import {BaseFieldParametersSchema} from '@faims3/data-model';
+import {attachmentSaveTrace, BaseFieldParametersSchema} from '@faims3/data-model';
 import {FormFieldContextProps} from '../../../formModule/types';
 import {
   LoadedPhoto,
@@ -310,12 +310,14 @@ const PhotoItem: React.FC<{
 
 /**
  * Pending photo item - shows optimistic preview while saving to database.
- * Displays a sync indicator overlay to show the photo is being processed.
+ * Displays a sync indicator overlay only while storage is still in progress.
  */
 const PendingPhotoItem: React.FC<{
   url: string;
   onClick: () => void;
-}> = ({url, onClick}) => {
+  /** False once the attachment is stored in PouchDB (load may still be in progress). */
+  isSaving?: boolean;
+}> = ({url, onClick, isSaving = true}) => {
   const theme = useTheme();
 
   return (
@@ -343,7 +345,8 @@ const PendingPhotoItem: React.FC<{
             cursor: 'pointer',
           }}
         />
-        {/* Saving indicator overlay */}
+        {/* Saving indicator overlay — only while blob is being written to PouchDB */}
+        {isSaving && (
         <ImageListItemBar
           sx={{background: 'rgba(0, 0, 0, 0.7)'}}
           position="top"
@@ -367,6 +370,7 @@ const PendingPhotoItem: React.FC<{
           }
           actionPosition="right"
         />
+        )}
       </Box>
     </ImageItemContainer>
   );
@@ -504,6 +508,7 @@ const PhotoGallery: React.FC<{
                   key={`pending-${entry.tempId}`}
                   url={entry.pending.url}
                   onClick={() => setLightboxUrl(entry.pending.url)}
+                  isSaving={entry.pending.attachmentId === null}
                 />
               );
             }
@@ -591,6 +596,7 @@ const PhotoGallery: React.FC<{
  */
 const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
   const {
+    fieldId,
     label,
     helperText,
     required,
@@ -673,6 +679,7 @@ const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
    * the database write happens in the background.
    */
   const takePhoto = useCallback(async () => {
+    let attachmentLockHeld = false;
     try {
       const isWeb = Capacitor.getPlatform() === 'web';
 
@@ -694,6 +701,12 @@ const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
           return;
         }
       }
+
+      // Block section navigation for the entire capture flow. Must be set
+      // before getPhoto so the lock is already active when the native camera
+      // closes (blob fetch, EXIF, and PouchDB write all run under this lock).
+      setAttachmentSaving?.(true);
+      attachmentLockHeld = true;
 
       // Capture photo
       const photoResult = await Camera.getPhoto({
@@ -758,21 +771,22 @@ const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
         }
       }
 
-      // Block section navigation until photo is stored in PouchDB (prevents data loss)
-      setAttachmentSaving?.(true);
+      attachmentSaveTrace('TakePhoto:save-start', {
+        fieldId,
+        blobSize: photoBlob.size,
+        format: photoResult.format,
+      });
 
-      try {
-        // Now do the async storage
-        const newId = await addAttachment({
-          // Blob attachments are faster - especially on native
-          blob: photoBlob,
-          contentType: `image/${photoResult.format}`,
-          type: 'photo',
-          fileFormat: photoResult.format,
-        });
+      const newId = await addAttachment({
+        // Blob attachments are faster - especially on native
+        blob: photoBlob,
+        contentType: `image/${photoResult.format}`,
+        type: 'photo',
+        fileFormat: photoResult.format,
+      });
 
-        // Update pending photo with the real attachment ID
-        // This allows the cleanup effect to know when to remove it
+      // Mark storage complete; keep optimistic preview until useAttachments loads.
+      // The Saving overlay hides once attachmentId is set (see PendingPhotoItem).
         setPendingPhotos(current => {
           const updated = new Map(current);
           const pending = updated.get(tempId);
@@ -782,18 +796,20 @@ const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
           return updated;
         });
 
-        // Update field value using a functional updater to avoid races
         props.setFieldData((prev: string[] | undefined) => [
           ...(prev ?? []),
           newId,
         ]);
-      } finally {
-        setAttachmentSaving?.(false);
-      }
+
+        attachmentSaveTrace('TakePhoto:save-complete', {fieldId, attachmentId: newId});
     } catch (err: any) {
       logError(new Error('Failed to capture photo:'), {error: err});
+    } finally {
+      if (attachmentLockHeld) {
+        setAttachmentSaving?.(false);
+      }
     }
-  }, [state.value, addAttachment, setAttachmentSaving, context]);
+  }, [fieldId, addAttachment, setAttachmentSaving]);
 
   /**
    * Deletes a photo at the specified index from the field's attachments.
@@ -810,7 +826,8 @@ const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
   );
 
   // Determine if we have any photos to show (either pending or loaded)
-  const hasAnyPhotos = loadedPhotos.length > 0 || pendingPhotos.size > 0;
+  const hasAnyPhotos =
+    (state.value?.attachments?.length ?? 0) > 0 || pendingPhotos.size > 0;
 
   return (
     <FieldWrapper

--- a/library/forms/lib/formModule/Field.tsx
+++ b/library/forms/lib/formModule/Field.tsx
@@ -40,34 +40,31 @@ export const Field = React.memo((props: FieldProps) => {
       name={props.fieldSpec['component-parameters'].name}
       children={field => {
         const setFieldData = (value: any) => {
-          // Allow functional updates for race-safe concurrent writes
-          const current = (field.state.value || {}) as
-            | FormDataEntry
-            | undefined;
-          const nextData =
-            typeof value === 'function'
-              ? value((current?.data ?? undefined) as any)
-              : value;
-
-          const newValue: FormDataEntry = {
-            ...(current || {}),
-            data: nextData,
-          };
-          field.handleChange(newValue as any);
+          // Functional updater merges against latest field value so a write
+          // here cannot clobber a concurrent attachments update (or vice versa).
+          field.handleChange((prev: FormDataEntry | undefined) => {
+            const current = prev || {};
+            const nextData =
+              typeof value === 'function'
+                ? value((current?.data ?? undefined) as any)
+                : value;
+            return {
+              ...current,
+              data: nextData,
+            };
+          });
         };
         const setFieldAnnotation = (value: FormAnnotation) => {
-          const newValue: FormDataEntry = {
-            ...(field.state.value || {}),
+          field.handleChange((prev: FormDataEntry | undefined) => ({
+            ...(prev || {}),
             annotation: value,
-          };
-          field.handleChange(newValue as any);
+          }));
         };
         const setFieldAttachment = (value: FaimsAttachments) => {
-          const newValue: FormDataEntry = {
-            ...(field.state.value || {}),
+          field.handleChange((prev: FormDataEntry | undefined) => ({
+            ...(prev || {}),
             attachments: value,
-          };
-          field.handleChange(newValue as any);
+          }));
         };
 
         // TODO clean this up - duplicating the mode check here is ugly

--- a/library/forms/lib/formModule/formManagers/EditableFormManager.tsx
+++ b/library/forms/lib/formModule/formManagers/EditableFormManager.tsx
@@ -1,7 +1,7 @@
 import {
   AvpUpdateMode,
+  attachmentSaveTrace,
   currentlyVisibleMap,
-  FaimsAttachments,
   FormDataEntry,
   getFormLabel,
   HydratedRecordDocument,
@@ -162,15 +162,27 @@ export const EditableFormManager: React.FC<
   const pendingValuesRef = useRef(false);
   const isSavingRef = useRef(false);
   const [isSaving, setIsSaving] = useState(false);
+  /** Drives save-status UI; refs alone do not trigger re-renders. */
+  const [hasPendingSave, setHasPendingSave] = useState(false);
 
   // ---------------------------------------------------------------------------
   // Revision Management
   // ---------------------------------------------------------------------------
   const ensureWorkingRevision = useCallback(async (): Promise<string> => {
+    attachmentSaveTrace('ensureWorkingRevision:start', {
+      edited,
+      workingRevisionId,
+      mode: props.mode,
+      recordId: props.recordId,
+    });
     let relevantRevisionId = workingRevisionId;
 
     if (!edited && props.mode === 'parent') {
       try {
+        attachmentSaveTrace('ensureWorkingRevision:before-createRevision', {
+          recordId: props.recordId,
+          revisionId: workingRevisionId,
+        });
         const newRevision = await dataEngine.form.createRevision({
           recordId: props.recordId,
           revisionId: workingRevisionId,
@@ -178,7 +190,13 @@ export const EditableFormManager: React.FC<
         });
         setWorkingRevisionId(newRevision._id);
         relevantRevisionId = newRevision._id;
+        attachmentSaveTrace('ensureWorkingRevision:after-createRevision', {
+          newRevisionId: newRevision._id,
+        });
       } catch (error) {
+        attachmentSaveTrace('ensureWorkingRevision:createRevision-error', {
+          error: String(error),
+        });
         logError(new Error('Failed to create revision:'), {error});
         throw error;
       }
@@ -188,6 +206,9 @@ export const EditableFormManager: React.FC<
       setEdited(true);
     }
 
+    attachmentSaveTrace('ensureWorkingRevision:complete', {
+      revisionId: relevantRevisionId,
+    });
     return relevantRevisionId;
   }, [
     edited,
@@ -224,6 +245,10 @@ export const EditableFormManager: React.FC<
   // Save Implementation
   // ---------------------------------------------------------------------------
   const performSave = useCallback(async () => {
+    attachmentSaveTrace('performSave:start', {
+      pendingValues: pendingValuesRef.current,
+      isSaving: isSavingRef.current,
+    });
     if (debugMode) {
       logInfo('[EditableFormManager] performSave called');
     }
@@ -248,6 +273,10 @@ export const EditableFormManager: React.FC<
         context: getRecordContextFromRecord({record: props.existingRecord}),
       });
 
+      attachmentSaveTrace('performSave:before-updateRevision', {
+        revisionId: revisionToUpdate,
+        recordId: props.recordId,
+      });
       await dataEngine.form.updateRevision({
         revisionId: revisionToUpdate,
         recordId: props.recordId,
@@ -257,11 +286,19 @@ export const EditableFormManager: React.FC<
       });
 
       pendingValuesRef.current = false;
+      setHasPendingSave(false);
+      attachmentSaveTrace('performSave:complete', {
+        revisionId: revisionToUpdate,
+      });
     } catch (error) {
+      attachmentSaveTrace('performSave:error', {error: String(error)});
       logError(new Error('Failed to update revision:'), {error});
     } finally {
       isSavingRef.current = false;
       setIsSaving(false);
+      attachmentSaveTrace('performSave:finally', {
+        pendingValues: pendingValuesRef.current,
+      });
     }
   }, [
     debugMode,
@@ -308,6 +345,7 @@ export const EditableFormManager: React.FC<
   // ---------------------------------------------------------------------------
   const onChange = useCallback(() => {
     pendingValuesRef.current = true;
+    setHasPendingSave(true);
     debouncedUpdateVisibility();
     debouncedSave();
   }, [debouncedSave, debouncedUpdateVisibility]);
@@ -316,6 +354,10 @@ export const EditableFormManager: React.FC<
   // Flush Save
   // ---------------------------------------------------------------------------
   const flushSave = useCallback(async (): Promise<void> => {
+    attachmentSaveTrace('flushSave:start', {
+      pendingValues: pendingValuesRef.current,
+      isSaving: isSavingRef.current,
+    });
     if (debugMode) {
       logInfo('[EditableFormManager] flushSave called');
     }
@@ -323,13 +365,22 @@ export const EditableFormManager: React.FC<
     debouncedSave.cancel();
 
     if (pendingValuesRef.current) {
+      attachmentSaveTrace('flushSave:awaiting-performSave');
       await performSaveRef.current();
     }
 
     // Poll the saving ref
+    let waitIterations = 0;
     while (isSavingRef.current) {
+      waitIterations += 1;
+      if (waitIterations === 1 || waitIterations % 20 === 0) {
+        attachmentSaveTrace('flushSave:waiting-for-isSavingRef', {
+          waitIterations,
+        });
+      }
       await new Promise(resolve => setTimeout(resolve, 50));
     }
+    attachmentSaveTrace('flushSave:complete', {waitIterations});
   }, [debouncedSave, debugMode]);
 
   const hasPendingChanges = useCallback((): boolean => {
@@ -403,6 +454,14 @@ export const EditableFormManager: React.FC<
           next.delete(fieldId);
         }
 
+        attachmentSaveTrace('setAttachmentSaving', {
+          fieldId,
+          saving,
+          previousCount: current,
+          updatedCount: updated,
+          activeFields: [...next.keys()],
+        });
+
         return next;
       });
     },
@@ -455,10 +514,26 @@ export const EditableFormManager: React.FC<
         throw new Error('Either blob or base64 data must be provided');
       }
 
+      attachmentSaveTrace('handleAddAttachment:start', {
+        fieldId,
+        type,
+        fileFormat,
+        contentType,
+        hasBlob: Boolean(blob),
+        blobSize: blob?.size,
+        hasBase64: Boolean(base64),
+        base64Length: base64?.length,
+      });
+
       const revisionToUse = await ensureWorkingRevision();
       if (!revisionToUse) {
         throw new Error('No working revision available for attachment');
       }
+
+      attachmentSaveTrace('handleAddAttachment:revision-ready', {
+        fieldId,
+        revisionId: revisionToUse,
+      });
 
       const timestamp = new Date().toISOString();
       const filename = `${type === 'photo' ? 'photo' : 'file'}_${timestamp}.${fileFormat}`;
@@ -475,34 +550,57 @@ export const EditableFormManager: React.FC<
       };
 
       if (base64) {
+        attachmentSaveTrace('handleAddAttachment:before-storeBase64', {
+          fieldId,
+        });
         attachmentResult = await props.config
           .attachmentEngine()
           .storeAttachmentFromBase64({base64, metadata});
+        attachmentSaveTrace('handleAddAttachment:after-storeBase64', {
+          fieldId,
+          attachmentId: attachmentResult.identifier.id,
+        });
       } else if (blob) {
+        attachmentSaveTrace('handleAddAttachment:before-storeBlob', {
+          fieldId,
+        });
         attachmentResult = await props.config
           .attachmentEngine()
           .storeAttachmentFromBlob({blob, metadata});
+        attachmentSaveTrace('handleAddAttachment:after-storeBlob', {
+          fieldId,
+          attachmentId: attachmentResult.identifier.id,
+        });
       } else {
         throw new Error('Either blob or base64 data must be provided');
       }
 
-      const state = form.state.values[fieldId];
-      const newAttachments: FaimsAttachments = [
-        {
-          attachmentId: attachmentResult.identifier.id,
-          filename: attachmentResult.metadata.filename,
-          fileType: attachmentResult.metadata.contentType,
-        },
-        ...(state?.attachments ?? []),
-      ];
+      const attachmentId = attachmentResult.identifier.id;
 
-      const newValue: FormDataEntry = {
-        ...(state || {}),
-        attachments: newAttachments,
-      };
-
-      form.setFieldValue(fieldId, newValue);
-      return attachmentResult.identifier.id;
+      attachmentSaveTrace('handleAddAttachment:before-setFieldValue', {
+        fieldId,
+        attachmentId,
+      });
+      // Attachments metadata only — fields own how the id is written into `data`.
+      form.setFieldValue(fieldId, (prev: FormDataEntry | undefined) => {
+        const state = prev || {};
+        return {
+          ...state,
+          attachments: [
+            {
+              attachmentId,
+              filename: attachmentResult.metadata.filename,
+              fileType: attachmentResult.metadata.contentType,
+            },
+            ...(state.attachments ?? []),
+          ],
+        };
+      });
+      attachmentSaveTrace('handleAddAttachment:complete', {
+        fieldId,
+        attachmentId,
+      });
+      return attachmentId;
     },
     [
       ensureWorkingRevision,
@@ -526,22 +624,18 @@ export const EditableFormManager: React.FC<
         throw new Error('No working revision available for attachment removal');
       }
 
-      const state = form.state.values[fieldId];
-      if (!state?.attachments) {
-        logWarn('No attachments found in field');
-        return;
-      }
-
-      const newAttachments: FaimsAttachments = state.attachments.filter(
-        attachment => attachment.attachmentId !== attachmentId
-      );
-
-      const newValue: FormDataEntry = {
-        ...(state || {}),
-        attachments: newAttachments,
-      };
-
-      form.setFieldValue(fieldId, newValue);
+      form.setFieldValue(fieldId, (prev: FormDataEntry | undefined) => {
+        const state = prev || {};
+        if (!state.attachments) {
+          return state;
+        }
+        return {
+          ...state,
+          attachments: state.attachments.filter(
+            attachment => attachment.attachmentId !== attachmentId
+          ),
+        };
+      });
     },
     [ensureWorkingRevision, form]
   );
@@ -578,7 +672,8 @@ export const EditableFormManager: React.FC<
       navigateToViewRecord: props.config.navigation.navigateToViewRecord,
     },
     flushSave,
-    hasPendingChanges,
+    hasPendingSave,
+    isFormSaving: isSaving,
     impliedParents: navigationData.impliedParents,
     createAnotherChild: navigationData.createAnotherChild,
   });
@@ -801,7 +896,7 @@ export const EditableFormManager: React.FC<
               gap: 0.5,
             }}
           >
-            {isSaving || pendingValuesRef.current ? (
+            {isSaving || hasPendingSave ? (
               <>
                 <CircularProgress size={14} color="inherit" />
                 <Typography variant="body2" color="text.secondary">

--- a/library/forms/lib/formModule/formManagers/navigation/types.tsx
+++ b/library/forms/lib/formModule/formManagers/navigation/types.tsx
@@ -186,8 +186,10 @@ export interface UseNavigationLogicParams {
   navigationService: NavigationService;
   /** Function to flush pending form saves before navigation */
   flushSave: () => Promise<void>;
-  /** Function to check for pending unsaved changes */
-  hasPendingChanges: () => boolean;
+  /** Reactive pending-save flag for status text (refs alone do not re-render). */
+  hasPendingSave: boolean;
+  /** Whether the form manager is actively persisting changes. */
+  isFormSaving: boolean;
   /** Inferred parent records when no explicit navigation history exists */
   impliedParents?: ImpliedParentNavInfo[];
   /** Configuration for creating another sibling record */

--- a/library/forms/lib/formModule/formManagers/navigation/useNavigationLogic.tsx
+++ b/library/forms/lib/formModule/formManagers/navigation/useNavigationLogic.tsx
@@ -35,7 +35,8 @@ export function useNavigationLogic({
   explicitParentInfo,
   navigationService,
   flushSave,
-  hasPendingChanges,
+  hasPendingSave,
+  isFormSaving,
   impliedParents = [],
   createAnotherChild,
 }: UseNavigationLogicParams): UseNavigationLogicResult {
@@ -128,9 +129,9 @@ export function useNavigationLogic({
 
   const statusText = useMemo(() => {
     if (isSaving) return undefined; // Loading spinner handles this
-    if (hasPendingChanges()) return 'saving...';
+    if (hasPendingSave || isFormSaving) return 'saving...';
     return undefined;
-  }, [isSaving, hasPendingChanges]);
+  }, [isSaving, hasPendingSave, isFormSaving]);
 
   // ===========================================================================
   // Button Configuration Builder

--- a/library/forms/lib/hooks/useAttachment.ts
+++ b/library/forms/lib/hooks/useAttachment.ts
@@ -1,4 +1,4 @@
-import {IAttachmentService, LoadAttachmentResult} from '@faims3/data-model';
+import {attachmentSaveTrace, IAttachmentService, LoadAttachmentResult} from '@faims3/data-model';
 import {useQueries, useQuery} from '@tanstack/react-query';
 
 /**
@@ -22,8 +22,13 @@ export const useAttachment = (
   return useQuery({
     queryKey: useAttachmentsQueryKey.attachment(attachmentId),
     queryFn: async () => {
+      attachmentSaveTrace('useAttachment:load-start', {attachmentId});
       const result = await attachmentService.loadAttachmentAsBlob({
         identifier: {id: attachmentId},
+      });
+      attachmentSaveTrace('useAttachment:load-complete', {
+        attachmentId,
+        blobSize: result.blob.size,
       });
       // Create object URL for display
       const url = URL.createObjectURL(result.blob);
@@ -49,8 +54,13 @@ export const useAttachments = (
     queries: attachmentIds.map(attachmentId => ({
       queryKey: useAttachmentsQueryKey.attachment(attachmentId),
       queryFn: async () => {
+        attachmentSaveTrace('useAttachment:load-start', {attachmentId});
         const result = await attachmentService.loadAttachmentAsBlob({
           identifier: {id: attachmentId},
+        });
+        attachmentSaveTrace('useAttachment:load-complete', {
+          attachmentId,
+          blobSize: result.blob.size,
         });
         // Create object URL for display
         const url = URL.createObjectURL(result.blob);


### PR DESCRIPTION
## Summary

Fixes attachment field save/display bugs and navigation race windows affecting TakePhoto, FileUploader, and AudioRecorder. Maintains contract that **fields own `data`** while **`handleAddAttachment` only manages PouchDB storage and `attachments` metadata**.

## Problem

After the Node v24 update (though uncertain if related or coincedental), seeing:

- **"Saving…" stuck indefinitely** (header, nav buttons, or photo thumbnail overlay)
- **Photos disappearing** from the gallery after capture, despite successful PouchDB writes
- **Brief window where section navigation was allowed** immediately after closing the Capacitor camera or file picker, before the save lock engaged

Debug tracing confirmed attachment storage (`putAttachment`) and `performSave` were completing successfully — the failures were in **UI state management and field value merging**, not PouchDB.

## Root cause

Three separate issues:

### 1. Stale read-modify-write on field values (photos vanishing)

Attachment fields store two related pieces of state on each field:

- `attachments` — metadata used by `useAttachments` to load/display files
- `data` — field-specific value (for these fields, a `string[]` of attachment IDs)

The flow was:

1. `handleAddAttachment` → `form.setFieldValue({ …, attachments })`
2. Field → `setFieldData([…, newId])` immediately after `await addAttachment()`

TakePhoto **did** wait for `addAttachment`. The bug was that `setFieldData` spread **`field.state.value` from the last render**, which didn't yet include the new `attachments`. That second write **overwrote** the first, dropping `attachments` from field state. The file remained in PouchDB but the UI lost the reference and the gallery went empty.

### 2. Non-reactive save indicators (header / nav "Saving…")

The header used `pendingValuesRef.current` directly in JSX, and nav status text read `hasPendingChanges()` inside a `useMemo` keyed only on nav-local state. Refs don't trigger re-renders, so the UI could remain on "Saving…" (or fail to update) after save completed.

### 3. Navigation lock applied too late

`setAttachmentSaving(true)` was called **after** camera/file-picker returned and sometimes **after** blob conversion, EXIF tagging, etc. During that gap, section Next/Back was enabled. AudioRecorder had the inverse bug — it released the lock **before** `addAttachment` on stop.

## Fix

### Field value merging (`Field.tsx`, `EditableFormManager.tsx`)

- **`setFieldData` / `setFieldAttachment` / `setFieldAnnotation`** now use TanStack Form **functional updaters** (`field.handleChange(prev => …)`) so merges always apply to the latest pending value.
- **`handleAddAttachment`** writes **`attachments` only** via `form.setFieldValue(fieldId, prev => …)`.
- **Fields** restore responsibility for writing into `data` after `await addAttachment()`, using functional `setFieldData(prev => …)` updaters.

### Save status UI (`EditableFormManager.tsx`, `useNavigationLogic.tsx`)

- Added `hasPendingSave` React state to drive the header save indicator.
- Pass `hasPendingSave` + `isFormSaving` into navigation logic instead of reading refs inside a stale memo.

### TakePhoto pending overlay (`TakePhoto/index.tsx`)

- "Saving…" overlay only shown while `attachmentId === null` (during PouchDB write).
- Pending preview kept until `useAttachments` confirms load (avoids eternal overlay without removing the photo prematurely).

### Navigation lock timing (all attachment fields)

| Field | Change |
|-------|--------|
| **TakePhoto** | Lock set **before** `Camera.getPhoto` (after permissions) |
| **FileUploader** | Lock on `onFileDialogOpen`; drag-and-drop path sets lock at drop |
| **AudioRecorder** | Lock held from record start through `addAttachment` on stop; released in `finally` |

### Debug tracing (`logging.ts`, gated by `DEBUG_APP`)

- Added opt-in `[attachment-save-trace]` logging across the save pipeline, toggled via `setAttachmentSaveTraceEnabled(DEBUG_APP)` at app startup.

## Test plan

- [ ] Take photo on native (Capacitor): photo stays visible, header shows Saved, cannot tap Next during camera/processing/save
- [ ] Upload file via picker and drag-and-drop: files appear in list, navigation blocked during picker/save
- [ ] Record and stop audio: attachment saved, navigation blocked through save
- [ ] Confirm no regression on form debounced save ("Saving…" clears ~1s after last edit)
- [ ] With `VITE_DEBUG_APP=false`, no attachment trace noise in console
- [ ] With `VITE_DEBUG_APP=true`, traces show full save → load → performSave pipeline