### PR TITLE
chore: formatting, CI, linting, type checks

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -51,8 +51,14 @@ jobs:
             echo "TURBO_TEAM and/or TURBO_TOKEN not set. Remote caching may not be available."
           fi
 
+      - name: Format check
+        run: pnpm run format:check
+
       - name: Lint
         run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run typecheck
 
       - name: Build
         run: pnpm run build

--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,7 @@
   "main": "build/src/index.js",
   "scripts": {
     "lint": "oxlint -c ../.oxlintrc.json .",
+    "typecheck": "tsc --noEmit",
     "clean": "gts clean",
     "compile": "tsc",
     "build": "tsc && copyfiles views/* views/**/* public/* public/**/* build/src",

--- a/api/src/couchdb/notebooks.ts
+++ b/api/src/couchdb/notebooks.ts
@@ -71,7 +71,6 @@ import {COUCHDB_PUBLIC_URL, MIGRATE_NOTEBOOKS_ON_STARTUP} from '../buildconfig';
 import * as Exceptions from '../exceptions';
 import {userCanDo} from '../middleware';
 import {nowIso} from '../time';
-import { use } from "chai";
 
 /**
  * Migrate legacy notebook JSON when needed, validate as {@link NotebookDefinition},
@@ -261,7 +260,7 @@ const BYTE_COUNT_BATCH_SIZE = 10;
 export const getUserProjectsDetailed = async (
   user: Express.User,
   teamId: string | undefined = undefined,
-  includeArchived = false,
+  includeArchived = false
 ): Promise<APINotebookList[]> => {
   const projectsDb = localGetProjectsDb();
 
@@ -276,18 +275,18 @@ export const getUserProjectsDetailed = async (
           PROJECTS_LISTING_BY_PROJECT_ID,
           {
             include_docs: false,
-          },
+          }
         );
   } catch (error) {
     throw new Exceptions.InternalSystemError(
-      "An error occurred while reading projects from the Project DB.",
+      'An error occurred while reading projects from the Project DB.'
     );
   }
 
   const userProjects = resultList.rows
-    .filter((row) => row.value != null && row.id && !row.id.startsWith("_"))
-    .map((row) => row.value!)
-    .filter((project) => {
+    .filter(row => row.value != null && row.id && !row.id.startsWith('_'))
+    .map(row => row.value!)
+    .filter(project => {
       if (!includeArchived && project.status === ProjectStatus.ARCHIVED) {
         return false;
       }
@@ -303,7 +302,7 @@ export const getUserProjectsDetailed = async (
     const batch = userProjects.slice(p, p + BYTE_COUNT_BATCH_SIZE);
     detailed.push(
       ...(await Promise.all(
-        batch.map(async (project) => {
+        batch.map(async project => {
           const projectId = project._id;
           return {
             ...project,
@@ -314,8 +313,8 @@ export const getUserProjectsDetailed = async (
             }),
             byteCount: await getByteCount(projectId),
           };
-        }),
-      )),
+        })
+      ))
     );
   }
   return detailed;
@@ -720,9 +719,7 @@ export async function countRecordsInNotebook(
  * the value shown in CouchDB Fauxton. (Use `sizes.file` instead if you want the
  * on-disk size including view indexes and not-yet-compacted revisions.)
  */
-export async function getByteCount(
-  project_id: ProjectID
-): Promise<number> {
+export async function getByteCount(project_id: ProjectID): Promise<number> {
   try {
     const dataDb = await getNanoDataDb(project_id);
     const info = await dataDb.info();

--- a/api/test/notebookStorageStats.test.ts
+++ b/api/test/notebookStorageStats.test.ts
@@ -52,12 +52,16 @@ describe('notebook storage stats', () => {
 
     // Replace the real nano data DB (which would hit CouchDB) with a fake whose
     // info() returns the per-project size we seeded, so byteCount is deterministic.
-    sinon.stub(couchdb, 'getNanoDataDb').callsFake((async (projectId: string) => {
+    sinon.stub(couchdb, 'getNanoDataDb').callsFake((async (
+      projectId: string
+    ) => {
       return {
         info: async () => {
           infoCallCount++;
           if (erroringProjects.has(projectId)) {
-            throw new Error(`simulated CouchDB info() failure for ${projectId}`);
+            throw new Error(
+              `simulated CouchDB info() failure for ${projectId}`
+            );
           }
           return {sizes: {active: byteCountByProject.get(projectId) ?? 0}};
         },

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "webapp-sync": "cap sync",
     "app-update": "cap update",
     "lint": "oxlint -c ../.oxlintrc.json .",
+    "typecheck": "tsc --noEmit",
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "oxlint -c ../.oxlintrc.json --fix . && oxfmt -c ../.oxfmtrc.json .",

--- a/app/src/gui/components/notebook/OverviewMap.tsx
+++ b/app/src/gui/components/notebook/OverviewMap.tsx
@@ -791,7 +791,10 @@ export const OverviewMap = (props: OverviewMapProps) => {
         flexDirection: 'column',
         width: '100%',
         minWidth: 0,
-        height: {xs: 'clamp(320px, 55vh, 600px)', sm: 'clamp(400px, 60vh, 600px)'},
+        height: {
+          xs: 'clamp(320px, 55vh, 600px)',
+          sm: 'clamp(400px, 60vh, 600px)',
+        },
         mt: {xs: 1, sm: 2.5},
       }}
     >

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,6 +2,7 @@
   "name": "e2e",
   "type": "module",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test:e2e": "wdio run wdio.conf.ts",
     "test:e2e:mobile": "VIEWPORT=mobile pnpm run test:e2e",
     "test:e2e:tablet": "VIEWPORT=tablet pnpm run test:e2e",
@@ -29,12 +30,15 @@
     "@testing-library/webdriverio": "^3.2.1",
     "@wdio/appium-service": "^9.27.2",
     "@wdio/cli": "^9.27.2",
+    "@wdio/globals": "^9.27.2",
     "@wdio/local-runner": "^9.27.2",
     "@wdio/mocha-framework": "^9.27.2",
     "@wdio/spec-reporter": "^9.27.2",
+    "@wdio/types": "^9.27.2",
     "appium": "^2.11.5",
     "appium-uiautomator2-driver": "^3.10.0",
     "chromedriver": "^138.0.4",
+    "expect-webdriverio": "^5.6.8",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "wdio-wait-for": "^3.1.0"

--- a/e2e/test/pageobjects/api-register.ts
+++ b/e2e/test/pageobjects/api-register.ts
@@ -1,5 +1,5 @@
 import {$, $$} from '@wdio/globals';
-import {Page} from './page';
+import {Page} from './page.ts';
 
 /**
  * Page object for the API register page (register.handlebars)

--- a/e2e/test/pageobjects/page.ts
+++ b/e2e/test/pageobjects/page.ts
@@ -148,14 +148,18 @@ export class Page {
 
         // Try to find any elements with data-testid
         const testElements = await $$('[data-testid]');
-        console.log(`Found ${testElements.length} elements with data-testid`);
+        const testElementCount = await testElements.length;
+        console.log(`Found ${testElementCount} elements with data-testid`);
 
-        for (let i = 0; i < Math.min(testElements.length, 5); i++) {
+        for (let i = 0; i < Math.min(testElementCount, 5); i++) {
           const testId = await testElements[i].getAttribute('data-testid');
           console.log(`  - data-testid="${testId}"`);
         }
       } catch (error) {
-        console.log('Debug info failed:', error.message);
+        console.log(
+          'Debug info failed:',
+          error instanceof Error ? error.message : error
+        );
       }
     } else {
       await browser.waitUntil(

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -1,18 +1,10 @@
-import type {Options} from '@wdio/types';
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   //
   // ====================
   // Runner Configuration
   // ====================
   // WebdriverIO supports running e2e tests as well as unit and component tests.
   runner: 'local',
-  autoCompileOpts: {
-    autoCompile: true,
-    tsNodeOpts: {
-      project: './tsconfig.json',
-      transpileOnly: true,
-    },
-  },
 
   //
   // ==================

--- a/infrastructure/aws-cdk/package.json
+++ b/infrastructure/aws-cdk/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "build-src": "cd src && pnpm install && pnpm run build",
     "package": "cd src && pnpm run package",
     "init-api": "CONFIG_FILE_NAME=${CONFIG_FILE_NAME:-dev.json} && curl -X POST https://conductor.$(jq -r .hostedZone.name < \"configs/${CONFIG_FILE_NAME}\")/api/initialise",

--- a/library/data-model/package.json
+++ b/library/data-model/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "pnpm run build:cjs && pnpm run build:esm",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "clean": "gts clean && rm -rf build",

--- a/library/data-model/src/databaseEngine/services/attachments/couch.ts
+++ b/library/data-model/src/databaseEngine/services/attachments/couch.ts
@@ -111,20 +111,26 @@ export class CouchAttachmentService extends BaseAttachmentService {
       attach_format_version: 1,
     };
 
-    attachmentSaveTrace('couch.storeAttachmentFromFile:before-createAttachment', {
-      id,
-      fileSize: file.size,
-      contentType: metadata.attachmentDetails.contentType,
-    });
+    attachmentSaveTrace(
+      'couch.storeAttachmentFromFile:before-createAttachment',
+      {
+        id,
+        fileSize: file.size,
+        contentType: metadata.attachmentDetails.contentType,
+      }
+    );
 
     // Now write it using special core op
     try {
       await this.core.createAttachment(attachmentDocument);
     } catch (e) {
-      attachmentSaveTrace('couch.storeAttachmentFromFile:createAttachment-error', {
-        id,
-        error: String(e),
-      });
+      attachmentSaveTrace(
+        'couch.storeAttachmentFromFile:createAttachment-error',
+        {
+          id,
+          error: String(e),
+        }
+      );
       console.error(
         'Failed to create attachment in couch DB attachment service. Error: ',
         e

--- a/library/data-model/src/utils.ts
+++ b/library/data-model/src/utils.ts
@@ -32,14 +32,14 @@ export const slugify = (str: string) => {
  * Formats file size in human-readable format
  */
 export function formatFileSize(bytes: number): string {
-  if (bytes === 0) return "0 Bytes";
-  if (bytes < 0) return "Invalid size";
-  if (!isFinite(bytes)) return "Invalid size";
+  if (bytes === 0) return '0 Bytes';
+  if (bytes < 0) return 'Invalid size';
+  if (!isFinite(bytes)) return 'Invalid size';
   const k = 1024;
-  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
   const i = Math.min(
     sizes.length - 1,
-    Math.floor(Math.log(bytes) / Math.log(k)),
+    Math.floor(Math.log(bytes) / Math.log(k))
   );
   return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
 }

--- a/library/data-model/tests/overviewMapTypes.test.ts
+++ b/library/data-model/tests/overviewMapTypes.test.ts
@@ -4,9 +4,7 @@ import {
   isFormDisplayedInOverviewMap,
 } from '../src/uiSpecification/utils';
 
-const createUiSpec = (
-  viewsets: UiSpecModel['viewsets']
-): UiSpecModel => ({
+const createUiSpec = (viewsets: UiSpecModel['viewsets']): UiSpecModel => ({
   fields: {},
   views: {},
   viewsets,

--- a/library/forms/lib/fieldRegistry/fields/FileUploader/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/FileUploader/index.tsx
@@ -1,4 +1,8 @@
-import {formatFileSize, attachmentSaveTrace, logError} from '@faims3/data-model';
+import {
+  formatFileSize,
+  attachmentSaveTrace,
+  logError,
+} from '@faims3/data-model';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CloseIcon from '@mui/icons-material/Close';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -638,7 +642,13 @@ const FileUploaderFull: React.FC<FullFileUploaderFieldProps> = props => {
         setError('Failed to upload file(s). Please try again.');
       }
     },
-    [state.value, addAttachment, setAttachmentSaving, maximumNumberOfFiles, fieldId]
+    [
+      state.value,
+      addAttachment,
+      setAttachmentSaving,
+      maximumNumberOfFiles,
+      fieldId,
+    ]
   );
 
   /**

--- a/library/forms/lib/fieldRegistry/fields/TakePhoto/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/TakePhoto/index.tsx
@@ -23,7 +23,10 @@ import {z} from 'zod';
 import {CameraPermissionIssue} from '../../../components/PermissionAlerts';
 import {PhotoLightbox} from '../../../components/PhotoLightbox';
 import {FullFormConfig} from '../../../formModule/formManagers/types';
-import {attachmentSaveTrace, BaseFieldParametersSchema} from '@faims3/data-model';
+import {
+  attachmentSaveTrace,
+  BaseFieldParametersSchema,
+} from '@faims3/data-model';
 import {FormFieldContextProps} from '../../../formModule/types';
 import {
   LoadedPhoto,
@@ -347,29 +350,29 @@ const PendingPhotoItem: React.FC<{
         />
         {/* Saving indicator overlay — only while blob is being written to PouchDB */}
         {isSaving && (
-        <ImageListItemBar
-          sx={{background: 'rgba(0, 0, 0, 0.7)'}}
-          position="top"
-          actionIcon={
-            <Box sx={{display: 'flex', alignItems: 'center', pr: 1}}>
-              <SyncIcon
-                sx={{
-                  color: 'white',
-                  fontSize: 20,
-                  animation: 'spin 1s linear infinite',
-                  '@keyframes spin': {
-                    '0%': {transform: 'rotate(0deg)'},
-                    '100%': {transform: 'rotate(360deg)'},
-                  },
-                }}
-              />
-              <Typography variant="caption" sx={{color: 'white', ml: 0.5}}>
-                Saving...
-              </Typography>
-            </Box>
-          }
-          actionPosition="right"
-        />
+          <ImageListItemBar
+            sx={{background: 'rgba(0, 0, 0, 0.7)'}}
+            position="top"
+            actionIcon={
+              <Box sx={{display: 'flex', alignItems: 'center', pr: 1}}>
+                <SyncIcon
+                  sx={{
+                    color: 'white',
+                    fontSize: 20,
+                    animation: 'spin 1s linear infinite',
+                    '@keyframes spin': {
+                      '0%': {transform: 'rotate(0deg)'},
+                      '100%': {transform: 'rotate(360deg)'},
+                    },
+                  }}
+                />
+                <Typography variant="caption" sx={{color: 'white', ml: 0.5}}>
+                  Saving...
+                </Typography>
+              </Box>
+            }
+            actionPosition="right"
+          />
         )}
       </Box>
     </ImageItemContainer>
@@ -787,21 +790,24 @@ const TakePhotoFull: React.FC<FullTakePhotoFieldProps> = props => {
 
       // Mark storage complete; keep optimistic preview until useAttachments loads.
       // The Saving overlay hides once attachmentId is set (see PendingPhotoItem).
-        setPendingPhotos(current => {
-          const updated = new Map(current);
-          const pending = updated.get(tempId);
-          if (pending) {
-            updated.set(tempId, {...pending, attachmentId: newId});
-          }
-          return updated;
-        });
+      setPendingPhotos(current => {
+        const updated = new Map(current);
+        const pending = updated.get(tempId);
+        if (pending) {
+          updated.set(tempId, {...pending, attachmentId: newId});
+        }
+        return updated;
+      });
 
-        props.setFieldData((prev: string[] | undefined) => [
-          ...(prev ?? []),
-          newId,
-        ]);
+      props.setFieldData((prev: string[] | undefined) => [
+        ...(prev ?? []),
+        newId,
+      ]);
 
-        attachmentSaveTrace('TakePhoto:save-complete', {fieldId, attachmentId: newId});
+      attachmentSaveTrace('TakePhoto:save-complete', {
+        fieldId,
+        attachmentId: newId,
+      });
     } catch (err: any) {
       logError(new Error('Failed to capture photo:'), {error: err});
     } finally {

--- a/library/forms/lib/hooks/useAttachment.ts
+++ b/library/forms/lib/hooks/useAttachment.ts
@@ -1,4 +1,8 @@
-import {attachmentSaveTrace, IAttachmentService, LoadAttachmentResult} from '@faims3/data-model';
+import {
+  attachmentSaveTrace,
+  IAttachmentService,
+  LoadAttachmentResult,
+} from '@faims3/data-model';
 import {useQueries, useQuery} from '@tanstack/react-query';
 
 /**

--- a/library/forms/lib/validationModule/validation.test.ts
+++ b/library/forms/lib/validationModule/validation.test.ts
@@ -3,6 +3,7 @@ import {
   currentlyVisibleFields,
   getFieldNamesForViewset,
   normalizeNotebookUiSpecification,
+  type CompiledNotebookUiSpec,
 } from '@faims3/data-model';
 import {describe, expect, it} from 'vitest';
 import {z} from 'zod';
@@ -15,8 +16,10 @@ import {
 
 // Sample fixture is a v4 {@link NotebookDefinition}; normalize is idempotent and
 // still accepts legacy uploads during the metadata migration window.
-const {uiSpec} = normalizeNotebookUiSpecification(sampleNotebook);
-compileUiSpecConditionals(uiSpec);
+const {uiSpec: rawUiSpec} = normalizeNotebookUiSpecification(sampleNotebook);
+compileUiSpecConditionals(rawUiSpec);
+// compileUiSpecConditionals attaches conditionFn/conditional_sources in place
+const uiSpec = rawUiSpec as CompiledNotebookUiSpec;
 
 const SAMPLE_VALID_DATA = {
   'First-name': 'John',

--- a/library/forms/package.json
+++ b/library/forms/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --p ./tsconfig-build.json && vite build",
+    "typecheck": "tsc --noEmit",
     "watch": "pnpm run watch:types & pnpm run watch:build",
     "watch:types": "tsc --p ./tsconfig-build.json --watch",
     "watch:build": "vite build --watch",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build-web": "turbo build --filter @faims3/web",
     "dev": "turbo dev --filter=@faims3/app --filter=@faims3/web --filter=@faims3/api --filter=@faims3/data-model --parallel",
     "lint": "turbo lint",
+    "typecheck": "turbo typecheck",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "clean": "turbo clean",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,6 +621,9 @@ importers:
       '@wdio/cli':
         specifier: ^9.27.2
         version: 9.27.2(@types/node@24.13.1)(expect-webdriverio@5.6.8)
+      '@wdio/globals':
+        specifier: ^9.27.2
+        version: 9.27.2(expect-webdriverio@5.6.8)(webdriverio@9.27.2)
       '@wdio/local-runner':
         specifier: ^9.27.2
         version: 9.27.2(@wdio/globals@9.27.2)(webdriverio@9.27.2)
@@ -628,6 +631,9 @@ importers:
         specifier: ^9.27.2
         version: 9.27.2
       '@wdio/spec-reporter':
+        specifier: ^9.27.2
+        version: 9.27.2
+      '@wdio/types':
         specifier: ^9.27.2
         version: 9.27.2
       appium:
@@ -639,6 +645,9 @@ importers:
       chromedriver:
         specifier: ^138.0.4
         version: 138.0.5
+      expect-webdriverio:
+        specifier: ^5.6.8
+        version: 5.6.8(@wdio/globals@9.27.2)(@wdio/logger@9.18.0)(webdriverio@9.27.2)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)
@@ -7842,7 +7851,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -7852,7 +7861,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -17282,7 +17291,7 @@ snapshots:
   '@vitest/browser-webdriverio@4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)(webdriverio@9.27.2)':
     dependencies:
       '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       webdriverio: 9.27.2
     transitivePeerDependencies:
       - bufferutil
@@ -17317,7 +17326,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,10 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "lint": {},
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "fix": {},
     "clean": {
       "cache": false

--- a/web/src/components/forms/teams/create-team-invite-form.tsx
+++ b/web/src/components/forms/teams/create-team-invite-form.tsx
@@ -1,6 +1,10 @@
 import {ExpirySelector} from '@/components/expiry-selector';
 import {Field, Form} from '@/components/form';
-import {EXCLUDED_TEAM_ROLES, INVITE_TOKEN_HINTS, brandNotebook} from '@/constants';
+import {
+  EXCLUDED_TEAM_ROLES,
+  INVITE_TOKEN_HINTS,
+  brandNotebook,
+} from '@/constants';
 import {useAuth} from '@/context/auth-provider';
 import {userCanDo} from '@/hooks/auth-hooks';
 import {

--- a/web/src/components/tabs/project/details.tsx
+++ b/web/src/components/tabs/project/details.tsx
@@ -90,7 +90,6 @@ const ProjectDetails = ({projectId}: {projectId: string}) => {
         label: 'Current byte count',
         getValue: p => formatFileSize(p.byteCount),
       },
-
     ],
     []
   );

--- a/web/src/components/tabs/teams/team-details.tsx
+++ b/web/src/components/tabs/teams/team-details.tsx
@@ -6,9 +6,9 @@ import {Card} from '@/components/ui/card';
 import {useGetProjectsForTeam, useGetTeam} from '@/hooks/queries';
 import {useMemo} from 'react';
 import {displayDateTime} from '@/lib/time';
-import {NOTEBOOK_NAME_PLURAL_CAPITALIZED} from "@/constants";
-import {formatFileSize, ProjectStatus} from "@faims3/data-model";
-import {statusDisplay} from "@/lib/status-display";
+import {NOTEBOOK_NAME_PLURAL_CAPITALIZED} from '@/constants';
+import {formatFileSize, ProjectStatus} from '@faims3/data-model';
+import {statusDisplay} from '@/lib/status-display';
 
 const detailsFields = [
   {field: 'name', label: 'Name'},
@@ -28,7 +28,11 @@ const detailsFields = [
 const TeamDetails = ({teamId}: {teamId: string}) => {
   const {user} = useAuth();
   const {data: rawData, isPending} = useGetTeam({user, teamId});
-  const {isPending: isProjectsPending, data: projects} = useGetProjectsForTeam({user, teamId, includeArchived: true});
+  const {isPending: isProjectsPending, data: projects} = useGetProjectsForTeam({
+    user,
+    teamId,
+    includeArchived: true,
+  });
 
   const data = useMemo(() => {
     return rawData
@@ -62,27 +66,41 @@ const TeamDetails = ({teamId}: {teamId: string}) => {
         <ListItem>
           <ListLabel>{NOTEBOOK_NAME_PLURAL_CAPITALIZED}</ListLabel>
           {isProjectsPending ? (
-            <Skeleton/>
+            <Skeleton />
           ) : (
             <ListDescription>
               <details>
                 <summary>
-              {projects ? `${projects.length} - ${formatFileSize(projects.reduce((acc, p) => acc + (p.byteCount), 0))}` : 'Unknown...'}
+                  {projects
+                    ? `${projects.length} - ${formatFileSize(projects.reduce((acc, p) => acc + p.byteCount, 0))}`
+                    : 'Unknown...'}
                 </summary>
-              <List className="pt-2 pl-4">
-                {[ProjectStatus.OPEN, ProjectStatus.ARCHIVED, ProjectStatus.CLOSED].map(status => {
-                  const projectsWithStatus = projects ? projects.filter(p => p.status === status) : [];
-                  const byteCount = projectsWithStatus.reduce((acc, p) => acc + (p.byteCount), 0);
-                  return (
-                    <ListItem key={status}>
-                      <ListLabel>{statusDisplay(status)}</ListLabel>
-                      <ListDescription>
-                        {projects ? projects.filter(p => p.status === status).length : 'Unknown...'} - {formatFileSize(byteCount)}
-                      </ListDescription>
-                    </ListItem>
-                  );
-                })}
-              </List>
+                <List className="pt-2 pl-4">
+                  {[
+                    ProjectStatus.OPEN,
+                    ProjectStatus.ARCHIVED,
+                    ProjectStatus.CLOSED,
+                  ].map(status => {
+                    const projectsWithStatus = projects
+                      ? projects.filter(p => p.status === status)
+                      : [];
+                    const byteCount = projectsWithStatus.reduce(
+                      (acc, p) => acc + p.byteCount,
+                      0
+                    );
+                    return (
+                      <ListItem key={status}>
+                        <ListLabel>{statusDisplay(status)}</ListLabel>
+                        <ListDescription>
+                          {projects
+                            ? projects.filter(p => p.status === status).length
+                            : 'Unknown...'}{' '}
+                          - {formatFileSize(byteCount)}
+                        </ListDescription>
+                      </ListItem>
+                    );
+                  })}
+                </List>
               </details>
             </ListDescription>
           )}

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -45,12 +45,11 @@ const VALID_TEAM_ROLES = new Set(
   resourceRoles[Resource.TEAM].map(r => r.role as string)
 );
 
-const requestedExcludedTeamRoles = (
-  import.meta.env.VITE_EXCLUDED_TEAM_ROLES as string | undefined
-)
-  ?.split(',')
-  .map(s => s.trim())
-  .filter(Boolean) ?? [];
+const requestedExcludedTeamRoles =
+  (import.meta.env.VITE_EXCLUDED_TEAM_ROLES as string | undefined)
+    ?.split(',')
+    .map(s => s.trim())
+    .filter(Boolean) ?? [];
 
 const invalidExcludedTeamRoles = requestedExcludedTeamRoles.filter(
   r => !VALID_TEAM_ROLES.has(r)

--- a/web/src/designer/DesignerWidget.tsx
+++ b/web/src/designer/DesignerWidget.tsx
@@ -86,7 +86,7 @@ export function DesignerWidget({
   animationScale = 0.95,
 }: DesignerWidgetProps) {
   const baseTheme = useMemo(() => createDesignerTheme(THEME), []);
-  const notebookIdentity = notebook?.metadata?.project_id ?? '__none__';
+  const notebookIdentity = notebook?.metadata?.custom?.project_id ?? '__none__';
 
   // 1. Hydrate + inject designerIdentifiers + reset undo history on each new notebook
   // (schema migration runs in notebookAdapters before the parent passes `notebook` here)

--- a/web/src/designer/components/info-panel.tsx
+++ b/web/src/designer/components/info-panel.tsx
@@ -97,7 +97,7 @@ export const InfoPanel = () => {
 
       <Card variant="outlined" sx={{mt: 2}}>
         <Grid container spacing={3} sx={{p: 3}}>
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Typography variant="h6">Settings</Typography>
             <Typography variant="body2" color="text.secondary" sx={{mb: 1}}>
               Functional options that affect how the mobile app behaves for this
@@ -121,11 +121,11 @@ export const InfoPanel = () => {
             </FormHelperText>
           </Grid>
 
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Divider />
           </Grid>
 
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Typography variant="h6">Notebook information</Typography>
             <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
               Optional details about this {NOTEBOOK_NAME}, such as who leads the
@@ -212,8 +212,8 @@ export const InfoPanel = () => {
             </Typography>
           </Grid>
 
-          <Grid container item xs={12} spacing={2.5}>
-            <Grid item xs={12} sm={5}>
+          <Grid container size={12} spacing={2.5}>
+            <Grid size={{xs: 12, sm: 5}}>
               <form
                 onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
                   e.preventDefault();
@@ -261,9 +261,9 @@ export const InfoPanel = () => {
               </form>
             </Grid>
 
-            <Grid container item xs={12} sm={7} rowGap={1}>
+            <Grid container size={{xs: 12, sm: 7}} sx={{rowGap: 1}}>
               {Object.keys(custom).map(key => (
-                <Grid item xs={12} key={key}>
+                <Grid size={12} key={key}>
                   <DebouncedTextField
                     fullWidth
                     label={key}

--- a/web/src/designer/state/initial.ts
+++ b/web/src/designer/state/initial.ts
@@ -98,6 +98,7 @@ export type NotebookUISpec = {
       summary_fields?: string[];
       layout?: 'inline' | 'tabs';
       hridField?: string;
+      displayInOverviewMap?: boolean;
     };
   };
   visible_types: string[];

--- a/web/src/designer/store/undoConfig.ts
+++ b/web/src/designer/store/undoConfig.ts
@@ -57,7 +57,7 @@ export const UNDOABLE_UI_SPEC_ACTIONS = [
 /** Passed to `undoable(uiSpecificationReducer.reducer, uiSpecUndoConfig)`. */
 export const uiSpecUndoConfig = {
   limit: 10,
-  filter: includeAction(UNDOABLE_UI_SPEC_ACTIONS),
+  filter: includeAction([...UNDOABLE_UI_SPEC_ACTIONS]),
   clearHistoryType: 'CLEAR_HISTORY',
   initTypes: [],
 };

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -206,11 +206,11 @@ export const useGetProjectsForTeam = ({
   includeArchived?: boolean;
 }) =>
   useQuery({
-    queryKey: ["projectsbyteam", user?.token, teamId, includeArchived],
+    queryKey: ['projectsbyteam', user?.token, teamId, includeArchived],
     queryFn: () =>
       get<GetNotebookListResponse>(
-        `/api/notebooks?teamId=${teamId}${includeArchived ? "&includeArchived=true" : ""}`,
-        user,
+        `/api/notebooks?teamId=${teamId}${includeArchived ? '&includeArchived=true' : ''}`,
+        user
       ),
     select: sortNotebookListNewestFirst,
   });


### PR DESCRIPTION
## CI: formatting + typecheck enforcement

Extends the Build & Lint workflow to run `oxfmt --check` and a new `turbo typecheck` task across all packages, and fixes the issues these surfaced.

### Changes

- **CI**: added `Format check` and `Typecheck` steps to `build-lint.yml`
- **Tooling**: added `typecheck` scripts to every package, a `typecheck` turbo task (depends on `^build`), and a root `pnpm run typecheck`
- **Formatting**: ran `oxfmt` over the repo (14 files reformatted)
- **web**: fixed type errors — MUI Grid v2 `size` prop migration in `info-panel.tsx`, added missing `displayInOverviewMap` to the designer viewset type, readonly-array fix in `undoConfig.ts`, metadata `project_id` lookup via `metadata.custom`
- **forms**: fixed `validation.test.ts` to cast the ui-spec to `CompiledNotebookUiSpec` after compiling conditionals
- **e2e**: added missing `@wdio/globals`, `expect-webdriverio`, `@wdio/types` dev deps; typed config as `WebdriverIO.Config` and dropped unsupported `autoCompileOpts`; minor type fixes in page objects

### Verification

`format:check`, `lint`, `typecheck` (all 7 packages), and affected unit tests all pass locally.