### PR TITLE
feat: removing redundant status display and improving team element of template form + permissions fix

### DIFF
--- a/web/src/components/dialogs/create-template-dialog.tsx
+++ b/web/src/components/dialogs/create-template-dialog.tsx
@@ -40,7 +40,7 @@ export const CreateTemplateDialog = ({
           <span>Create Template</span>
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-lg space-y-6">
+      <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle className="text-lg font-medium">
             Create Template

--- a/web/src/components/dialogs/create-template-dialog.tsx
+++ b/web/src/components/dialogs/create-template-dialog.tsx
@@ -12,8 +12,16 @@ import {CreateTemplateForm} from '../forms/create-template-form';
 import {Plus} from 'lucide-react';
 import {useGetTeam} from '@/hooks/queries';
 import {useAuth} from '@/context/auth-provider';
+import {useCanCreateTemplate} from '@/hooks/auth-hooks';
 import {ErrorComponent} from '@tanstack/react-router';
 
+/**
+ * Dialog entry point for creating a new template.
+ *
+ * Renders nothing when the user lacks create permission, except on team pages
+ * where `specifiedTeam` fixes the owning team and the parent already gates
+ * access via `CREATE_TEMPLATE_IN_TEAM`.
+ */
 export const CreateTemplateDialog = ({
   defaultValues,
   specifiedTeam = undefined,
@@ -23,11 +31,18 @@ export const CreateTemplateDialog = ({
 }) => {
   const [open, setOpen] = useState(false);
   const {user} = useAuth();
+  const canCreateTemplate = useCanCreateTemplate();
+  const {data: team} = useGetTeam({user, teamId: specifiedTeam});
+
   if (!user) {
     return <ErrorComponent error="Unauthenticated" />;
   }
 
-  const {data: team} = useGetTeam({user, teamId: specifiedTeam});
+  // Global list: hide trigger when user cannot create at all.
+  // Team tab passes specifiedTeam and relies on parent permission checks.
+  if (!canCreateTemplate && !specifiedTeam) {
+    return null;
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/dialogs/create-template-from-project-dialog.tsx
+++ b/web/src/components/dialogs/create-template-from-project-dialog.tsx
@@ -43,7 +43,7 @@ export const CreateTemplateFromProjectDialog = ({
           <span>Create Template</span>
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-lg space-y-6">
+      <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle className="text-lg font-medium">
             Create Template

--- a/web/src/components/form.tsx
+++ b/web/src/components/form.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
 } from './ui/select';
 import {Divider} from './ui/word-divider';
+import {X} from 'lucide-react';
 
 export interface Field {
   name: string;
@@ -53,6 +54,8 @@ export interface Field {
   maxLength?: number;
   /** Inline label beside the control when `type` is `checkbox` (defaults to `label`) */
   checkboxLabel?: string;
+  /** When true, optional select fields show a clear button to reset the value. */
+  clearable?: boolean;
 }
 
 interface Divider {
@@ -203,6 +206,7 @@ export function Form<
                 placeholder,
                 maxLength,
                 checkboxLabel,
+                clearable,
               },
               index
             ) => {
@@ -255,28 +259,54 @@ export function Form<
                           )}
                           <FormControl>
                             {options ? (
-                              <Select
-                                onValueChange={field.onChange}
-                                value={field.value ?? ''}
-                                disabled={isDisabled}
-                              >
-                                <SelectTrigger className="w-full">
-                                  <SelectValue placeholder={`Select ${name}`} />
-                                </SelectTrigger>
-                                <SelectContent className="max-w-md">
-                                  {options.map(
-                                    ({label, value, description}) => (
-                                      <SelectItem
-                                        key={value}
-                                        value={value}
-                                        description={description}
-                                      >
-                                        {label}
-                                      </SelectItem>
-                                    )
-                                  )}
-                                </SelectContent>
-                              </Select>
+                              <div className="flex w-full items-center gap-2">
+                                <Select
+                                  // Radix Select does not reliably return to an
+                                  // empty state after clear; remount when cleared.
+                                  key={
+                                    clearable
+                                      ? `${name}-${field.value ?? 'empty'}`
+                                      : name
+                                  }
+                                  onValueChange={field.onChange}
+                                  value={field.value || undefined}
+                                  disabled={isDisabled}
+                                >
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue
+                                      placeholder={
+                                        placeholder ?? `Select ${label ?? name}`
+                                      }
+                                    />
+                                  </SelectTrigger>
+                                  <SelectContent className="max-w-md">
+                                    {options.map(
+                                      ({label, value, description}) => (
+                                        <SelectItem
+                                          key={value}
+                                          value={value}
+                                          description={description}
+                                        >
+                                          {label}
+                                        </SelectItem>
+                                      )
+                                    )}
+                                  </SelectContent>
+                                </Select>
+                                {clearable && field.value ? (
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="shrink-0"
+                                    aria-label={`Clear ${label ?? name}`}
+                                    disabled={isDisabled}
+                                    onClick={() => field.onChange(undefined)}
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </Button>
+                                ) : null}
+                              </div>
                             ) : type === 'file' ? (
                               <Input
                                 type="file"

--- a/web/src/components/forms/create-project-from-template.tsx
+++ b/web/src/components/forms/create-project-from-template.tsx
@@ -1,8 +1,8 @@
-import {Form} from '@/components/form';
+import {Field, Form} from '@/components/form';
 import {NOTEBOOK_NAME, NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
 import {useAuth} from '@/context/auth-provider';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
-import {useGetTeams} from '@/hooks/queries';
+import {useGetTeams, useGetTemplate} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/templates/$templateId';
 import {Action, PostCreateNotebookInput} from '@faims3/data-model';
 import {
@@ -13,30 +13,76 @@ import {ROOT_DESCRIPTION_MAX_LENGTH} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
 import {useMemo} from 'react';
 import {z} from 'zod';
+import {TemplateOwnerCallout} from './template-owner-callout';
+import {
+  buildTeamField,
+  defaultTeamFromOwner,
+  getPossibleTeamsForAction,
+  getTeamFieldState,
+  resolveTeamId,
+} from './template-team-field';
 
 interface CreateProjectFromTemplateFormProps {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 /**
- * Component for rendering a form to create a project from a template.
- * @returns {JSX.Element} The rendered form component.
+ * Form for creating a notebook from a template on the template detail page.
+ *
+ * Team selection mirrors other create flows ({@link getTeamFieldState}). When
+ * the template has `ownedByTeamId` and the user may create projects in that
+ * team, the dropdown defaults to that team; global creators can clear it to
+ * create outside any team.
+ *
+ * @param {CreateProjectFromTemplateFormProps} props - The props for the form.
+ * @returns {JSX.Element | null} The rendered form, or null if unauthenticated.
  */
 export function CreateProjectFromTemplateForm({
   setDialogOpen,
 }: CreateProjectFromTemplateFormProps) {
-  const {user} = useAuth();
+  const {user, refreshToken} = useAuth();
   if (!user) return null;
 
   const {templateId} = Route.useParams();
 
-  const QueryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-  const {data: teams} = useGetTeams({user});
+  const {data: teamsData} = useGetTeams({user});
+  const {data: template} = useGetTemplate({user, templateId});
+
+  /** `CREATE_PROJECT` — may omit teamId on POST /api/notebooks. */
   const canCreateGlobally = useIsAuthorisedTo({action: Action.CREATE_PROJECT});
 
-  const fields = useMemo(
-    () => [
+  const possibleTeams = getPossibleTeamsForAction({
+    teams: teamsData?.teams,
+    canCreateGlobally,
+    createInTeamAction: Action.CREATE_PROJECT_IN_TEAM,
+    decodedToken: user.decodedToken,
+  });
+
+  const {showTeamCallout, showTeamDropdown} = getTeamFieldState({
+    canCreateGlobally,
+    possibleTeams,
+  });
+
+  // Pre-select template owner when accessible; see defaultTeamFromOwner.
+  const defaultTeamId = defaultTeamFromOwner({
+    ownerTeamId: template?.ownedByTeamId,
+    possibleTeams,
+  });
+
+  const teamLabel = `Create ${NOTEBOOK_NAME} in this team${
+    canCreateGlobally ? ' (optional)' : ''
+  }`;
+
+  const teamDescription = canCreateGlobally
+    ? defaultTeamId
+      ? `Defaults to the template's team. Clear the selection to create outside any team.`
+      : `Choose a team for this ${NOTEBOOK_NAME}, or leave blank to create outside any team.`
+    : undefined;
+
+  const fields = useMemo(() => {
+    const result: Field[] = [
       {
         name: 'name',
         label: `${NOTEBOOK_NAME_CAPITALIZED} Name`,
@@ -47,24 +93,28 @@ export function CreateProjectFromTemplateForm({
       optionalRootDescriptionField({
         helperText: `Optional summary of this ${NOTEBOOK_NAME} (up to ${ROOT_DESCRIPTION_MAX_LENGTH} characters)`,
       }),
-      {
-        name: 'team',
-        label: `Create ${NOTEBOOK_NAME} in this team${canCreateGlobally ? ' (optional)' : ''}`,
-        options: teams?.teams.map(({_id, name}) => ({
-          label: name,
-          value: _id,
-        })),
-        schema: canCreateGlobally ? z.string().optional() : z.string(),
-      },
-    ],
-    [teams, canCreateGlobally]
-  );
+    ];
 
-  /**
-   * Handles form submission for creating a project.
-   * @param {{name: string}} params - The submitted form values.
-   * @returns {Promise<{type: string; message: string}>} The result of the form submission.
-   */
+    if (showTeamDropdown) {
+      result.push(
+        buildTeamField({
+          canCreateGlobally,
+          possibleTeams,
+          label: teamLabel,
+          description: teamDescription,
+        })
+      );
+    }
+
+    return result;
+  }, [
+    canCreateGlobally,
+    possibleTeams,
+    showTeamDropdown,
+    teamDescription,
+    teamLabel,
+  ]);
+
   const onSubmit = async ({
     name,
     description,
@@ -74,6 +124,12 @@ export function CreateProjectFromTemplateForm({
     description?: string;
     team?: string;
   }) => {
+    const chosenTeamId = resolveTeamId({
+      canCreateGlobally,
+      possibleTeams,
+      team,
+    });
+
     const response = await fetch(
       `${import.meta.env.VITE_API_URL}/api/notebooks`,
       {
@@ -86,7 +142,7 @@ export function CreateProjectFromTemplateForm({
           template_id: templateId,
           name,
           ...rootDescriptionForApi(description),
-          ...(team ? {teamId: team} : {}),
+          ...(chosenTeamId ? {teamId: chosenTeamId} : {}),
         } satisfies PostCreateNotebookInput),
       }
     );
@@ -94,22 +150,40 @@ export function CreateProjectFromTemplateForm({
     if (!response.ok)
       return {type: 'submit', message: `Error creating ${NOTEBOOK_NAME}.`};
 
-    // Invalidate projects list so the template’s notebook list and sidebar refresh
-    await QueryClient.invalidateQueries({queryKey: ['projects']});
-    if (team) {
-      await QueryClient.invalidateQueries({
-        queryKey: ['projectsbyteam', user.token, team],
-      });
+    // Creator is granted PROJECT_ADMIN server-side; refresh JWT so list APIs
+    // include the new notebook (same as CreateProjectForm).
+    const {message, status} = await refreshToken();
+    if (status === 'error') {
+      console.error(
+        `${NOTEBOOK_NAME_CAPITALIZED} created but failed to refresh user token:`,
+        message
+      );
+    }
+
+    await queryClient.invalidateQueries({queryKey: ['projects']});
+    if (chosenTeamId) {
+      await queryClient.invalidateQueries({queryKey: ['projectsbyteam']});
     }
 
     setDialogOpen(false);
   };
 
+  const calloutTeamName = showTeamCallout ? possibleTeams[0]?.name : undefined;
+
   return (
-    <Form
-      fields={fields}
-      onSubmit={onSubmit}
-      submitButtonText={`Create ${NOTEBOOK_NAME_CAPITALIZED}`}
-    />
+    <div className="flex flex-col gap-4">
+      {showTeamCallout && calloutTeamName ? (
+        <TemplateOwnerCallout
+          heading={`${NOTEBOOK_NAME_CAPITALIZED} will be created in`}
+          teamName={calloutTeamName}
+        />
+      ) : null}
+      <Form
+        fields={fields}
+        onSubmit={onSubmit}
+        submitButtonText={`Create ${NOTEBOOK_NAME_CAPITALIZED}`}
+        defaultValues={defaultTeamId ? {team: defaultTeamId} : undefined}
+      />
+    </div>
   );
 }

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -4,10 +4,9 @@ import {readFileAsText} from '@/lib/utils';
 import {z} from 'zod';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetTeams} from '@/hooks/queries';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useCanCreateTemplate} from '@/hooks/auth-hooks';
 import {
   Action,
-  getUserResourcesForAction,
   prepareNotebookUiSpecificationInputForApi,
 } from '@faims3/data-model';
 
@@ -18,6 +17,12 @@ import {
   rootDescriptionForApi,
 } from '@/lib/rootDescriptionField';
 import {TemplateOwnerCallout} from './template-owner-callout';
+import {
+  buildTemplateTeamField,
+  getPossibleTeamsForAction,
+  getTemplateTeamFieldState,
+  resolveTemplateTeamId,
+} from './template-team-field';
 
 interface CreateTemplateFormProps {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -27,7 +32,10 @@ interface CreateTemplateFormProps {
 
 /**
  * CreateTemplateForm component renders a form for creating a template.
- * It provides a button to open the dialog and a form to create the template.
+ *
+ * Team UI follows {@link getTeamFieldState}: a callout when the user must
+ * create in their only team, or an optional/required dropdown when they have
+ * a choice. Global creators (`CREATE_TEMPLATE`) may omit team ownership.
  *
  * @param {CreateTemplateFormProps} props - The props for the form.
  * @returns {JSX.Element} The rendered CreateTemplateForm component.
@@ -41,7 +49,9 @@ export function CreateTemplateForm({
   const queryClient = useQueryClient();
   const {data: teams} = useGetTeams({user});
 
-  // can they create projects outside team?
+  const canCreateTemplate = useCanCreateTemplate();
+
+  /** `CREATE_TEMPLATE` — may omit teamId on POST /api/templates. */
   const canCreateGlobally = useIsAuthorisedTo({
     action: Action.CREATE_TEMPLATE,
   });
@@ -50,21 +60,18 @@ export function CreateTemplateForm({
     action: Action.CREATE_PUBLIC_TEMPLATE,
   });
 
-  // get the teams that we have permission to create
-  // templates in
-  const teamsAvailable =
-    (canCreateGlobally
-      ? teams?.teams.map(t => t._id)
-      : getUserResourcesForAction({
-          decodedToken: user?.decodedToken,
-          action: Action.CREATE_TEMPLATE_IN_TEAM,
-        })) || [];
+  const possibleTeams = getPossibleTeamsForAction({
+    teams: teams?.teams,
+    canCreateGlobally,
+    createInTeamAction: Action.CREATE_TEMPLATE_IN_TEAM,
+    decodedToken: user?.decodedToken,
+  });
 
-  // filter teams by those we can create templates in
-  const possibleTeams =
-    teams?.teams.filter(team => teamsAvailable.includes(team._id)) || [];
-
-  const justOneTeam = specifiedTeam || possibleTeams.length === 1;
+  const {showTeamCallout, showTeamDropdown} = getTemplateTeamFieldState({
+    canCreateGlobally,
+    specifiedTeam,
+    possibleTeams,
+  });
 
   const fields: Field[] = [
     {
@@ -114,16 +121,10 @@ export function CreateTemplateForm({
     });
   }
 
-  if (!justOneTeam) {
-    fields.push({
-      name: 'team',
-      label: `Team${canCreateGlobally ? ' (optional)' : ''}`,
-      options: possibleTeams?.map(({_id, name}) => ({
-        label: name,
-        value: _id,
-      })),
-      schema: canCreateGlobally ? z.string().optional() : z.string(),
-    });
+  if (showTeamDropdown) {
+    fields.push(
+      buildTemplateTeamField({canCreateGlobally, possibleTeams})
+    );
   }
 
   const onSubmit = async (values: {
@@ -157,12 +158,12 @@ export function CreateTemplateForm({
       uiSpecification = prepared.uiSpecification;
     }
 
-    let chosenTeamId = specifiedTeam;
-    if (justOneTeam && possibleTeams.length > 0) {
-      chosenTeamId = possibleTeams[0]._id;
-    } else if (team) {
-      chosenTeamId = team;
-    }
+    const chosenTeamId = resolveTemplateTeamId({
+      canCreateGlobally,
+      specifiedTeam,
+      possibleTeams,
+      team,
+    });
 
     try {
       const res = await fetch(
@@ -205,16 +206,17 @@ export function CreateTemplateForm({
     setDialogOpen(false);
   };
 
-  if (possibleTeams.length === 0) {
-    // we shouldn't get here but just in case show a message
+  if (!canCreateTemplate) {
     return <p>You do not have permission to create templates.</p>;
-  } else {
-    return (
-      <div className="flex flex-col gap-4">
-        {possibleTeams.length === 1 && (
-          <TemplateOwnerCallout teamName={possibleTeams[0].name} />
-        )}
-        <Form
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Fixed team — user cannot pick another or opt out. */}
+      {showTeamCallout && (
+        <TemplateOwnerCallout teamName={possibleTeams[0].name} />
+      )}
+      <Form
           fields={fields}
           onSubmit={onSubmit}
           submitButtonText="Create Template"
@@ -227,5 +229,4 @@ export function CreateTemplateForm({
         />
       </div>
     );
-  }
 }

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -17,6 +17,7 @@ import {
   optionalRootDescriptionField,
   rootDescriptionForApi,
 } from '@/lib/rootDescriptionField';
+import {TemplateOwnerCallout} from './template-owner-callout';
 
 interface CreateTemplateFormProps {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -209,11 +210,9 @@ export function CreateTemplateForm({
     return <p>You do not have permission to create templates.</p>;
   } else {
     return (
-      <>
+      <div className="flex flex-col gap-4">
         {possibleTeams.length === 1 && (
-          <span>
-            <strong>Template will be owned by:</strong> {possibleTeams[0].name}
-          </span>
+          <TemplateOwnerCallout teamName={possibleTeams[0].name} />
         )}
         <Form
           fields={fields}
@@ -226,7 +225,7 @@ export function CreateTemplateForm({
               : {}),
           }}
         />
-      </>
+      </div>
     );
   }
 }

--- a/web/src/components/forms/create-template-from-project.tsx
+++ b/web/src/components/forms/create-template-from-project.tsx
@@ -3,7 +3,7 @@ import {Field, Form} from '@/components/form';
 import {z} from 'zod';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetProject, useGetTeams} from '@/hooks/queries';
-import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useCanCreateTemplate} from '@/hooks/auth-hooks';
 import {Action} from '@faims3/data-model';
 import {
   optionalRootDescriptionField,
@@ -11,6 +11,12 @@ import {
 } from '@/lib/rootDescriptionField';
 import {ROOT_DESCRIPTION_MAX_LENGTH} from '@faims3/data-model';
 import {TemplateOwnerCallout} from './template-owner-callout';
+import {
+  buildTemplateTeamField,
+  getPossibleTeamsForAction,
+  getTemplateTeamFieldState,
+  resolveTemplateTeamId,
+} from './template-team-field';
 
 interface CreateTemplateFromProjectForm {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -20,11 +26,12 @@ interface CreateTemplateFromProjectForm {
 }
 
 /**
- * CreateTemplateForm component renders a form for creating a template.
- * It provides a button to open the dialog and a form to create the template.
+ * Form for creating a template from an existing project's UI specification.
+ *
+ * Uses the same team callout/dropdown rules as {@link CreateTemplateForm}.
  *
  * @param {CreateTemplateFromProjectForm} props - The props for the form.
- * @returns {JSX.Element} The rendered CreateTemplateForm component.
+ * @returns {JSX.Element} The rendered form component.
  */
 export function CreateTemplateFromProjectForm({
   setDialogOpen,
@@ -37,23 +44,25 @@ export function CreateTemplateFromProjectForm({
   const {data: teams} = useGetTeams({user});
   const {data: projectData} = useGetProject({user, projectId});
 
-  // can they create projects outside team?
+  const canCreateTemplate = useCanCreateTemplate();
+
+  /** `CREATE_TEMPLATE` — may omit teamId on POST /api/templates. */
   const canCreateGlobally = useIsAuthorisedTo({
     action: Action.CREATE_TEMPLATE,
   });
 
-  // filter teams by those we can create templates in
-  const possibleTeams = teams?.teams.filter(team => {
-    return (
-      user &&
-      userCanDo({
-        user,
-        action: Action.CREATE_TEMPLATE_IN_TEAM,
-        resourceId: team._id,
-      })
-    );
+  const possibleTeams = getPossibleTeamsForAction({
+    teams: teams?.teams,
+    canCreateGlobally,
+    createInTeamAction: Action.CREATE_TEMPLATE_IN_TEAM,
+    decodedToken: user?.decodedToken,
   });
-  const justOneTeam = specifiedTeam || possibleTeams?.length === 1;
+
+  const {showTeamCallout, showTeamDropdown} = getTemplateTeamFieldState({
+    canCreateGlobally,
+    specifiedTeam,
+    possibleTeams,
+  });
 
   const fields: Field[] = [
     {
@@ -69,16 +78,10 @@ export function CreateTemplateFromProjectForm({
     }),
   ];
 
-  if (!justOneTeam) {
-    fields.push({
-      name: 'team',
-      label: `Team${canCreateGlobally ? ' (optional)' : ''}`,
-      options: possibleTeams?.map(({_id, name}) => ({
-        label: name,
-        value: _id,
-      })),
-      schema: canCreateGlobally ? z.string().optional() : z.string(),
-    });
+  if (showTeamDropdown) {
+    fields.push(
+      buildTemplateTeamField({canCreateGlobally, possibleTeams})
+    );
   }
 
   const onSubmit = async (values: {
@@ -97,6 +100,13 @@ export function CreateTemplateFromProjectForm({
       };
     }
 
+    const chosenTeamId = resolveTemplateTeamId({
+      canCreateGlobally,
+      specifiedTeam,
+      possibleTeams,
+      team,
+    });
+
     try {
       const res = await fetch(
         `${import.meta.env.VITE_API_URL}/api/templates/`,
@@ -110,7 +120,7 @@ export function CreateTemplateFromProjectForm({
             name,
             ...rootDescriptionForApi(description),
             uiSpecification: projectData.uiSpecification,
-            teamId: team ?? specifiedTeam,
+            teamId: chosenTeamId,
           }),
         }
       );
@@ -137,9 +147,14 @@ export function CreateTemplateFromProjectForm({
     setDialogOpen(false);
   };
 
+  if (!canCreateTemplate) {
+    return <p>You do not have permission to create templates.</p>;
+  }
+
   return (
     <div className="flex flex-col gap-4">
-      {possibleTeams?.length === 1 && (
+      {/* Fixed team — user cannot pick another or opt out. */}
+      {showTeamCallout && (
         <TemplateOwnerCallout teamName={possibleTeams[0].name} />
       )}
       <Form

--- a/web/src/components/forms/create-template-from-project.tsx
+++ b/web/src/components/forms/create-template-from-project.tsx
@@ -10,6 +10,7 @@ import {
   rootDescriptionForApi,
 } from '@/lib/rootDescriptionField';
 import {ROOT_DESCRIPTION_MAX_LENGTH} from '@faims3/data-model';
+import {TemplateOwnerCallout} from './template-owner-callout';
 
 interface CreateTemplateFromProjectForm {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -137,11 +138,9 @@ export function CreateTemplateFromProjectForm({
   };
 
   return (
-    <>
+    <div className="flex flex-col gap-4">
       {possibleTeams?.length === 1 && (
-        <span>
-          <strong>Template will be owned by:</strong> {possibleTeams[0].name}
-        </span>
+        <TemplateOwnerCallout teamName={possibleTeams[0].name} />
       )}
       <Form
         fields={fields}
@@ -149,6 +148,6 @@ export function CreateTemplateFromProjectForm({
         submitButtonText="Create Template"
         defaultValues={{team: defaultValues?.teamId}}
       />
-    </>
+    </div>
   );
 }

--- a/web/src/components/forms/template-owner-callout.tsx
+++ b/web/src/components/forms/template-owner-callout.tsx
@@ -1,0 +1,8 @@
+export function TemplateOwnerCallout({teamName}: {teamName: string}) {
+  return (
+    <div className="rounded-md border border-border bg-muted/50 px-3 py-2">
+      <p className="text-xs text-muted-foreground">Template will be owned by</p>
+      <p className="text-sm font-medium">{teamName}</p>
+    </div>
+  );
+}

--- a/web/src/components/forms/template-owner-callout.tsx
+++ b/web/src/components/forms/template-owner-callout.tsx
@@ -1,7 +1,19 @@
-export function TemplateOwnerCallout({teamName}: {teamName: string}) {
+/**
+ * Read-only team hint shown when the user has no team choice (must create in
+ * the sole team they can access). For optional team selection use the dropdown
+ * from {@link buildTeamField} instead.
+ */
+export function TemplateOwnerCallout({
+  teamName,
+  heading = 'Template will be owned by',
+}: {
+  teamName: string;
+  /** Short label above the team name; defaults to template ownership copy. */
+  heading?: string;
+}) {
   return (
     <div className="rounded-md border border-border bg-muted/50 px-3 py-2">
-      <p className="text-xs text-muted-foreground">Template will be owned by</p>
+      <p className="text-xs text-muted-foreground">{heading}</p>
       <p className="text-sm font-medium">{teamName}</p>
     </div>
   );

--- a/web/src/components/forms/template-team-field.ts
+++ b/web/src/components/forms/template-team-field.ts
@@ -1,0 +1,182 @@
+/**
+ * Shared team-selection helpers for create flows (templates, projects from
+ * templates, etc.).
+ *
+ * The API distinguishes global create (`CREATE_*`) from in-team create
+ * (`CREATE_*_IN_TEAM`). These helpers pick the correct UI (callout vs optional
+ * dropdown) and resolve the `teamId` sent on submit.
+ */
+import type {Field} from '@/components/form';
+import {
+  Action,
+  getUserResourcesForAction,
+  type DecodedTokenPermissions,
+} from '@faims3/data-model';
+import {z} from 'zod';
+
+/** Minimal team shape from GET /api/teams. */
+export type TeamOption = {_id: string; name: string};
+
+/**
+ * Teams the user may assign when creating a resource.
+ *
+ * Global creators see every visible team; team-scoped creators only see teams
+ * where their token grants the relevant `CREATE_*_IN_TEAM` action.
+ */
+export function getPossibleTeamsForAction({
+  teams,
+  canCreateGlobally,
+  createInTeamAction,
+  decodedToken,
+}: {
+  teams?: TeamOption[];
+  canCreateGlobally: boolean;
+  createInTeamAction:
+    | Action.CREATE_TEMPLATE_IN_TEAM
+    | Action.CREATE_PROJECT_IN_TEAM;
+  decodedToken?: DecodedTokenPermissions | null;
+}): TeamOption[] {
+  const teamsAvailable =
+    (canCreateGlobally
+      ? teams?.map(t => t._id)
+      : getUserResourcesForAction({
+          decodedToken: decodedToken ?? {
+            globalRoles: [],
+            resourceRoles: [],
+          },
+          action: createInTeamAction,
+        })) || [];
+
+  return teams?.filter(team => teamsAvailable.includes(team._id)) ?? [];
+}
+
+/**
+ * Whether to show a fixed team callout or an interactive team dropdown.
+ *
+ * - Callout: user must create in a team and has exactly one choice (no global
+ *   create permission, team not fixed by route context).
+ * - Dropdown: user can pick among teams and/or leave blank when global create
+ *   is allowed. Omitted entirely when `specifiedTeam` fixes the team (e.g. team
+ *   tab) or when there are no eligible teams.
+ */
+export function getTeamFieldState({
+  canCreateGlobally,
+  specifiedTeam,
+  possibleTeams,
+}: {
+  canCreateGlobally: boolean;
+  specifiedTeam?: string;
+  possibleTeams: TeamOption[];
+}) {
+  const showTeamCallout =
+    !canCreateGlobally && !specifiedTeam && possibleTeams.length === 1;
+
+  const showTeamDropdown =
+    !specifiedTeam &&
+    possibleTeams.length > 0 &&
+    (canCreateGlobally || possibleTeams.length > 1);
+
+  return {showTeamCallout, showTeamDropdown};
+}
+
+/** @deprecated Prefer {@link getTeamFieldState}. */
+export const getTemplateTeamFieldState = getTeamFieldState;
+
+/**
+ * Resolves the team id for a create request from form values and permissions.
+ *
+ * Priority: route-fixed team → auto-assign when only one in-team option → form
+ * field value (may be undefined for global create).
+ */
+export function resolveTeamId({
+  canCreateGlobally,
+  specifiedTeam,
+  possibleTeams,
+  team,
+}: {
+  canCreateGlobally: boolean;
+  specifiedTeam?: string;
+  possibleTeams: TeamOption[];
+  team?: string;
+}): string | undefined {
+  if (specifiedTeam) {
+    return specifiedTeam;
+  }
+  if (!canCreateGlobally && possibleTeams.length === 1) {
+    return possibleTeams[0]._id;
+  }
+  return team || undefined;
+}
+
+/** @deprecated Prefer {@link resolveTeamId}. */
+export const resolveTemplateTeamId = resolveTeamId;
+
+/**
+ * Suggested default team when creating from an existing owned resource (e.g.
+ * project from template).
+ *
+ * Returns the owner team id only when the user is allowed to create in that
+ * team; otherwise undefined so the form starts with no selection.
+ */
+export function defaultTeamFromOwner({
+  ownerTeamId,
+  possibleTeams,
+}: {
+  ownerTeamId?: string;
+  possibleTeams: TeamOption[];
+}): string | undefined {
+  if (!ownerTeamId) {
+    return undefined;
+  }
+  return possibleTeams.some(t => t._id === ownerTeamId)
+    ? ownerTeamId
+    : undefined;
+}
+
+/**
+ * Builds a {@link Field} definition for an optional or required team select.
+ *
+ * When `canCreateGlobally` is true the field is optional and clearable so the
+ * user can create outside any team.
+ */
+export function buildTeamField({
+  canCreateGlobally,
+  possibleTeams,
+  label,
+  description,
+}: {
+  canCreateGlobally: boolean;
+  possibleTeams: TeamOption[];
+  label: string;
+  description?: string;
+}): Field {
+  return {
+    name: 'team',
+    label,
+    description,
+    options: possibleTeams.map(({_id, name}) => ({
+      label: name,
+      value: _id,
+    })),
+    schema: canCreateGlobally ? z.string().optional() : z.string(),
+    clearable: canCreateGlobally,
+  };
+}
+
+/** Team field preset for the create-template dialog copy. */
+export function buildTemplateTeamField({
+  canCreateGlobally,
+  possibleTeams,
+}: {
+  canCreateGlobally: boolean;
+  possibleTeams: TeamOption[];
+}): Field {
+  return buildTeamField({
+    canCreateGlobally,
+    possibleTeams,
+    label: `Team${canCreateGlobally ? ' (optional)' : ''}`,
+    description: canCreateGlobally
+      ? 'Choose a team to own this template, or leave blank to create outside any team.'
+      : undefined,
+  });
+}

--- a/web/src/components/tables/templates.tsx
+++ b/web/src/components/tables/templates.tsx
@@ -37,16 +37,14 @@ const teamColumn: ColumnDef<Column> = {
   },
 };
 
-const statusColumn: ColumnDef<Column> = {
-  id: 'status',
+const lastUpdatedColumn: ColumnDef<Column> = {
+  accessorKey: 'updatedAt',
   header: ({column}) => (
-    <DataTableColumnHeader column={column} title="Status" />
+    <DataTableColumnHeader column={column} title="Last updated" />
   ),
-  accessorFn: (row: Column & {archived?: boolean}) =>
-    row.archived === true ? 'Archived' : 'Active',
-  cell: ({row}: {row: {original: Column & {archived?: boolean}}}) => {
-    const label = row.original.archived === true ? 'Archived' : 'Active';
-    return <RoleCard>{label}</RoleCard>;
+  cell: ({getValue}) => {
+    const v = getValue<string | undefined>();
+    return v ? displayDateTime({timestamp: new Date(v).getTime()}) : null;
   },
 };
 
@@ -137,7 +135,7 @@ export function getTemplatesTableColumns(options: {
   return [
     nameColumn,
     ...team,
-    statusColumn,
+    lastUpdatedColumn,
     ...visibility,
     createdByColumn,
     createdAtColumn,

--- a/web/src/components/tables/templates.tsx
+++ b/web/src/components/tables/templates.tsx
@@ -37,6 +37,7 @@ const teamColumn: ColumnDef<Column> = {
   },
 };
 
+/** Replaces the status column; archived templates are hidden from this list. */
 const lastUpdatedColumn: ColumnDef<Column> = {
   accessorKey: 'updatedAt',
   header: ({column}) => (

--- a/web/src/components/tabs/project/actions.tsx
+++ b/web/src/components/tabs/project/actions.tsx
@@ -20,12 +20,11 @@ import {
   useDesignerSaveMutation,
 } from '@/designer/integration';
 import type {NotebookWithHistory} from '@/designer/state/initial';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useCanCreateTemplate, useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {useGetProject} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {
   Action,
-  getUserResourcesForAction,
   ProjectStatus,
 } from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
@@ -92,13 +91,8 @@ const ProjectActions = (): JSX.Element => {
     resourceId: projectId,
   });
 
-  /** Matches {@link CreateTemplateFromProjectForm}: global create or any permitted team. */
-  const canCreateTemplateFromProject =
-    useIsAuthorisedTo({action: Action.CREATE_TEMPLATE}) ||
-    getUserResourcesForAction({
-      decodedToken: user?.decodedToken,
-      action: Action.CREATE_TEMPLATE_IN_TEAM,
-    }).length > 0;
+  /** Matches create-from-project form: global create or team-scoped create on any team. */
+  const canCreateTemplateFromProject = useCanCreateTemplate();
 
   const canReadProjectMetadata = useIsAuthorisedTo({
     action: Action.READ_PROJECT_METADATA,

--- a/web/src/hooks/auth-hooks.ts
+++ b/web/src/hooks/auth-hooks.ts
@@ -1,5 +1,10 @@
 import {useAuth, User} from '@/context/auth-provider';
-import {Action, isAuthorized, Role} from '@faims3/data-model';
+import {
+  Action,
+  getUserResourcesForAction,
+  isAuthorized,
+  Role,
+} from '@faims3/data-model';
 import {useMemo} from 'react';
 
 /**
@@ -32,6 +37,43 @@ export const webUserHasGlobalRole = ({
   role: Role;
 }): boolean => {
   return (user.decodedToken?.globalRoles ?? []).includes(role);
+};
+
+/**
+ * True when the user may create a template either globally (`CREATE_TEMPLATE`)
+ * or in at least one team (`CREATE_TEMPLATE_IN_TEAM`).
+ *
+ * Does not require team membership — global creators with zero teams still
+ * return true, matching the API permission model.
+ */
+export const userCanCreateTemplate = (user: User | null): boolean => {
+  if (!user?.decodedToken) {
+    return false;
+  }
+  return (
+    isAuthorized({
+      decodedToken: user.decodedToken,
+      action: Action.CREATE_TEMPLATE,
+    }) ||
+    getUserResourcesForAction({
+      decodedToken: user.decodedToken,
+      action: Action.CREATE_TEMPLATE_IN_TEAM,
+    }).length > 0
+  );
+};
+
+/**
+ * Hook wrapper for {@link userCanCreateTemplate}. Re-renders when the auth
+ * token changes.
+ */
+export const useCanCreateTemplate = (): boolean => {
+  const {user, isExpired} = useAuth();
+
+  if (!user || isExpired()) {
+    return false;
+  }
+
+  return useMemo(() => userCanCreateTemplate(user), [user.token]);
 };
 
 /**

--- a/web/src/routes/_protected/templates/index.tsx
+++ b/web/src/routes/_protected/templates/index.tsx
@@ -13,10 +13,8 @@ import {
   TemplateVisibilityFilterSelect,
   type TemplateVisibilityFilterValue,
 } from '@/components/tables/template-visibility-filter';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {
   Action,
-  getUserResourcesForAction,
   globalRolesGrantAction,
   type GetListTemplatesResponse,
 } from '@faims3/data-model';
@@ -39,17 +37,6 @@ function RouteComponent() {
   const navigate = useNavigate();
   const [visibilityFilter, setVisibilityFilter] =
     useState<TemplateVisibilityFilterValue>('all');
-
-  // can they create templates outside team?
-  const canCreateGlobally = useIsAuthorisedTo({
-    action: Action.CREATE_TEMPLATE,
-  });
-  // or in some team?
-  const canCreateInSomeTeam =
-    getUserResourcesForAction({
-      decodedToken: user?.decodedToken,
-      action: Action.CREATE_TEMPLATE_IN_TEAM,
-    }).length > 0;
 
   // breadcrumbs addition
   const paths = useMemo(
@@ -90,6 +77,7 @@ function RouteComponent() {
   return (
     <div className="flex flex-col gap-6">
       <h1 className="text-2xl font-semibold tracking-tight">Templates</h1>
+      {/* CreateTemplateDialog returns null when the user lacks create permission */}
       <DataTable
         columns={columns as ColumnDef<TemplateListRow, unknown>[]}
         data={filteredTemplates}
@@ -105,9 +93,7 @@ function RouteComponent() {
           row.isPublic === true ? PUBLIC_TEMPLATE_ROW_CLASS : undefined
         }
         onRowClick={({_id}) => navigate({to: `/templates/${_id}`})}
-        button={
-          (canCreateGlobally || canCreateInSomeTeam) && <CreateTemplateDialog />
-        }
+        button={<CreateTemplateDialog />}
       />
     </div>
   );


### PR DESCRIPTION
**Templates list**
- Replace Status column with Last updated (archived templates are hidden anyway)

**Create Template dialog**
- Tighter layout; team ownership shown in a compact highlighted callout
- Fix create button for users with global `CREATE_TEMPLATE` (no team required)
- If team is mandatory and there’s only one option → callout; if global create is allowed → optional team dropdown with clear

**Create project from template**
- Same team callout/dropdown rules as template creation
- Default team to the template’s owner when the user can create there
- Refresh auth token after create so the new project shows on the template’s Projects tab