### PR TITLE
feat: local android apk build helper script

### DIFF
--- a/app/scripts/.env.example
+++ b/app/scripts/.env.example
@@ -1,0 +1,154 @@
+# Android APK build configuration
+# Copy this file to .env in the same directory and edit values:
+#   cp app/scripts/.env.example app/scripts/.env
+#
+# The build script (build-android-apk.sh) loads this file and exports all
+# variables into the environment before running pnpm/turbo/capacitor/gradle.
+#
+# Quote values that contain spaces, e.g. VITE_APP_NAME="My App Name"
+
+# =============================================================================
+# REQUIRED — app identity and backend
+# =============================================================================
+
+# Reverse-domain app identifier used for Android package name and OAuth redirect.
+# Must match the conductor OAuth client configuration for mobile login.
+VITE_APP_ID=au.edu.faims.fieldmark
+
+# Display name shown on the device home screen and in-app title areas.
+VITE_APP_NAME="Fieldmark"
+
+# Conductor URL the app connects to for auth and API calls.
+# Use your testing/staging URL for pen-test builds; comma-separate for multi-server login.
+VITE_CONDUCTOR_URL=https://your-conductor.example.com
+
+# Theme controlling icons, splash screens, and branding assets.
+# One of: default, fieldmark, bssTheme
+VITE_THEME=fieldmark
+
+# =============================================================================
+# REQUIRED — Android Gradle (defaults to VITE_APP_ID if unset)
+# =============================================================================
+
+# Android applicationId / namespace passed to Gradle. Usually same as VITE_APP_ID.
+APP_ID=au.edu.faims.fieldmark
+
+# =============================================================================
+# RECOMMENDED — build metadata (auto-filled from git if left empty)
+# =============================================================================
+
+# Shown on the About Build page. Leave empty to use git describe output.
+# VITE_COMMIT_VERSION=v1.6.1-android-pentest
+
+# Build tag recorded in build metadata. CI uses prodAndroid for Play Store builds.
+VITE_TAG=prodAndroid
+
+# =============================================================================
+# OPTIONAL — build script behaviour (not consumed by Vite)
+# =============================================================================
+
+# APK build type: debug (default, debug keystore, easy sideload) or release.
+BUILD_TYPE=debug
+
+# Skip steps when iterating locally (true/false).
+SKIP_INSTALL=false
+SKIP_TURBO_BUILD=false
+SKIP_CAP_UPDATE=false
+SKIP_CAP_SYNC=false
+SKIP_GRADLE=false
+
+# Use frozen lockfile for reproducible installs (true/false).
+PNPM_FROZEN_LOCKFILE=true
+
+# Override path to env file (default: app/scripts/.env).
+# ENV_FILE=/path/to/custom.env
+
+# =============================================================================
+# OPTIONAL — release APK signing (only needed when BUILD_TYPE=release)
+# =============================================================================
+
+# JAVA_KEYSTORE=/path/to/android-signing-keystore.jks
+# JAVA_KEYSTORE_PASSWORD=
+# JAVA_KEY=
+# JAVA_KEY_PASSWORD=
+
+# =============================================================================
+# OPTIONAL — PouchDB / sync tuning
+# =============================================================================
+
+VITE_POUCH_BATCHES_LIMIT=10
+VITE_POUCH_BATCH_SIZE=10
+# VITE_POUCHDB_DEBUG=false
+
+# =============================================================================
+# OPTIONAL — maps and geocoding
+# =============================================================================
+
+# Map tile source: osm, maptiler, or empty string to disable.
+VITE_MAP_SOURCE=maptiler
+VITE_MAP_SOURCE_KEY=
+VITE_MAP_STYLE=basic
+VITE_OFFLINE_MAPS=true
+# VITE_SATELLITE_SOURCE=maptiler
+
+# Address autosuggest: NONE (default), MAPBOX, or MAPTILER.
+# VITE_AUTOSUGGEST_SOURCE=NONE
+# VITE_AUTOSUGGEST_MAPBOX_KEY=
+# VITE_AUTOSUGGEST_MAPTILER_KEY=
+# VITE_MAPBOX_ADDRESS_COUNTRY=AU
+# VITE_MAPTILER_ADDRESS_COUNTRY=AU
+
+# =============================================================================
+# OPTIONAL — UI / feature flags
+# =============================================================================
+
+VITE_CLUSTER_ADMIN_GROUP_NAME=cluster-admin
+VITE_NOTEBOOK_LIST_TYPE=tabs
+VITE_NOTEBOOK_NAME=survey
+VITE_HEADING_APP_NAME=Fieldmark
+VITE_NAVIGATION=breadcrumbs
+VITE_SHOW_RECORD_LINKS=false
+VITE_SHOW_RECORD_SUMMARY_COUNTS=false
+VITE_SHOW_WIPE=true
+VITE_SHOW_POUCHDB_BROWSER=true
+VITE_SHOW_NEW_NOTEBOOK=true
+VITE_DEBUG_APP=false
+VITE_ATTACHMENT_SERVICE_TYPE=COUCH
+
+# =============================================================================
+# OPTIONAL — auth token behaviour
+# =============================================================================
+
+VITE_TOKEN_REFRESH_INTERVAL_MS=15000
+VITE_TOKEN_REFRESH_WINDOW_MS=60000
+VITE_LOGIN_BANNER_GRACE_MS=10000
+VITE_IGNORE_TOKEN_EXP=false
+
+# =============================================================================
+# OPTIONAL — data lifecycle
+# =============================================================================
+
+VITE_MIGRATE_OLD_DATABASES=false
+# VITE_FORCE_REMOTE_DELETION=never
+# VITE_DELETE_ON_DEACTIVATION=false
+
+# =============================================================================
+# OPTIONAL — support / legal links
+# =============================================================================
+
+VITE_SUPPORT_EMAIL=support@fieldmark.au
+VITE_APP_PRIVACY_POLICY_URL=https://fieldnote.au/privacy
+VITE_APP_CONTACT_URL=https://fieldnote.au/contact
+
+# =============================================================================
+# OPTIONAL — error reporting (omit or leave empty to disable Bugsnag)
+# =============================================================================
+
+# VITE_BUGSNAG_KEY=
+
+# =============================================================================
+# OPTIONAL — iOS-only (ignored for Android builds, kept for shared .env files)
+# =============================================================================
+
+# VITE_APPLE_BUNDLE_IDENTIFIER=au.edu.faims.electronicfieldnotebook
+# VITE_APP_STORE_CONNECT_TEAM_ID=

--- a/app/scripts/build-android-apk.sh
+++ b/app/scripts/build-android-apk.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# Build a sideloadable Android APK from the FAIMS3 Capacitor app.
+#
+# Usage:
+#   cp app/scripts/.env.example app/scripts/.env   # first time only
+#   ./app/scripts/build-android-apk.sh
+#
+# Requires: Node 24, pnpm, Java 21, Android SDK (ANDROID_HOME), and Gradle
+# wrapper at app/android/gradlew.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+APP_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${APP_DIR}/.." &>/dev/null && pwd)"
+ANDROID_DIR="${APP_DIR}/android"
+
+ENV_FILE="${ENV_FILE:-${SCRIPT_DIR}/.env}"
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  if ! command -v "$1" &>/dev/null; then
+    die "Required command not found on PATH: $1"
+  fi
+}
+
+is_truthy() {
+  case "${1,,}" in
+    true | 1 | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+load_env_file() {
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    die "Env file not found: ${ENV_FILE}
+Copy the example and edit it:
+  cp ${SCRIPT_DIR}/.env.example ${SCRIPT_DIR}/.env"
+  fi
+
+  log "Loading environment from ${ENV_FILE}"
+
+  # Source line-by-line so we can give a clear error for unquoted spaces.
+  set -a
+  local line_number=0
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line_number=$((line_number + 1))
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+
+    if [[ "${line}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      # shellcheck disable=SC2163
+      eval "export ${line}"
+    else
+      die "${ENV_FILE}:${line_number}: invalid env line (quote values containing spaces): ${line}"
+    fi
+  done < "${ENV_FILE}"
+  set +a
+}
+
+validate_required_vars() {
+  local missing=()
+
+  [[ -n "${VITE_APP_ID:-}" ]] || missing+=("VITE_APP_ID")
+  [[ -n "${VITE_APP_NAME:-}" ]] || missing+=("VITE_APP_NAME")
+  [[ -n "${VITE_CONDUCTOR_URL:-}" ]] || missing+=("VITE_CONDUCTOR_URL")
+  [[ -n "${VITE_THEME:-}" ]] || missing+=("VITE_THEME")
+
+  if ((${#missing[@]} > 0)); then
+    die "Missing required variables in ${ENV_FILE}: ${missing[*]}"
+  fi
+
+  export APP_ID="${APP_ID:-${VITE_APP_ID}}"
+
+  if [[ -z "${VITE_COMMIT_VERSION:-}" ]]; then
+    if command -v git &>/dev/null && git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree &>/dev/null; then
+      local sha_short
+      sha_short="$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+      export VITE_COMMIT_VERSION="local-android-$(date +%Y%m%d)-${sha_short}"
+      log "VITE_COMMIT_VERSION not set; using ${VITE_COMMIT_VERSION}"
+    else
+      export VITE_COMMIT_VERSION="local-android-build"
+      log "VITE_COMMIT_VERSION not set; using ${VITE_COMMIT_VERSION}"
+    fi
+  fi
+
+  export VITE_TAG="${VITE_TAG:-prodAndroid}"
+  export BUILD_TYPE="${BUILD_TYPE:-debug}"
+  export PNPM_FROZEN_LOCKFILE="${PNPM_FROZEN_LOCKFILE:-true}"
+}
+
+check_prerequisites() {
+  require_command node
+  require_command pnpm
+
+  local node_major
+  node_major="$(node -p "process.versions.node.split('.')[0]")"
+  if [[ "${node_major}" -lt 24 ]]; then
+    die "Node 24+ is required (found Node $(node -v)). See package.json engines."
+  fi
+
+  if [[ -z "${JAVA_HOME:-}" ]]; then
+    if command -v java &>/dev/null; then
+      log "JAVA_HOME is not set; relying on java on PATH: $(command -v java)"
+    else
+      die "Java is required. Install JDK 21 and set JAVA_HOME."
+    fi
+  fi
+
+  if [[ -z "${ANDROID_HOME:-}" && -z "${ANDROID_SDK_ROOT:-}" ]]; then
+    die "ANDROID_HOME or ANDROID_SDK_ROOT must be set to your Android SDK path."
+  fi
+
+  [[ -x "${ANDROID_DIR}/gradlew" ]] || die "Gradle wrapper not found: ${ANDROID_DIR}/gradlew"
+}
+
+run_pnpm_install() {
+  if is_truthy "${SKIP_INSTALL:-false}"; then
+    log "Skipping pnpm install (SKIP_INSTALL=true)"
+    return
+  fi
+
+  log "Installing dependencies at repo root"
+  cd "${REPO_ROOT}"
+  if is_truthy "${PNPM_FROZEN_LOCKFILE}"; then
+    pnpm install --frozen-lockfile
+  else
+    pnpm install
+  fi
+}
+
+run_turbo_build() {
+  if is_truthy "${SKIP_TURBO_BUILD:-false}"; then
+    log "Skipping turbo build (SKIP_TURBO_BUILD=true)"
+    return
+  fi
+
+  log "Building workspace packages for @faims3/app"
+  cd "${REPO_ROOT}"
+  pnpm exec turbo build --filter=@faims3/app --force
+}
+
+run_cap_update() {
+  if is_truthy "${SKIP_CAP_UPDATE:-false}"; then
+    log "Skipping cap update (SKIP_CAP_UPDATE=true)"
+    return
+  fi
+
+  log "Updating Capacitor Android native dependencies"
+  cd "${APP_DIR}"
+  pnpm run app-update android
+}
+
+run_cap_sync() {
+  if is_truthy "${SKIP_CAP_SYNC:-false}"; then
+    log "Skipping cap sync (SKIP_CAP_SYNC=true)"
+    return
+  fi
+
+  log "Syncing web assets into Android project (rebuilds app with current env)"
+  cd "${APP_DIR}"
+  pnpm run webapp-sync -- android
+}
+
+run_gradle_assemble() {
+  if is_truthy "${SKIP_GRADLE:-false}"; then
+    log "Skipping Gradle assemble (SKIP_GRADLE=true)"
+    return
+  fi
+
+  local build_type gradle_task apk_path
+
+  build_type="${BUILD_TYPE,,}"
+  case "${build_type}" in
+    debug)
+      gradle_task="assembleDebug"
+      apk_path="${ANDROID_DIR}/app/build/outputs/apk/debug/app-debug.apk"
+      ;;
+    release)
+      gradle_task="assembleRelease"
+      apk_path="${ANDROID_DIR}/app/build/outputs/apk/release/app-release.apk"
+      ;;
+    *)
+      die "BUILD_TYPE must be 'debug' or 'release' (got: ${BUILD_TYPE})"
+      ;;
+  esac
+
+  log "Running Gradle ${gradle_task} (APP_ID=${APP_ID})"
+  cd "${ANDROID_DIR}"
+
+  if [[ "${build_type}" == "release" ]]; then
+    [[ -n "${JAVA_KEYSTORE:-}" ]] || die "BUILD_TYPE=release requires JAVA_KEYSTORE in ${ENV_FILE}"
+    [[ -n "${JAVA_KEYSTORE_PASSWORD:-}" ]] || die "BUILD_TYPE=release requires JAVA_KEYSTORE_PASSWORD"
+    [[ -n "${JAVA_KEY:-}" ]] || die "BUILD_TYPE=release requires JAVA_KEY"
+    [[ -n "${JAVA_KEY_PASSWORD:-}" ]] || die "BUILD_TYPE=release requires JAVA_KEY_PASSWORD"
+
+    ./gradlew "clean" "${gradle_task}" \
+      -PversionCode="$(date +%s)" \
+      -PversionName="${VITE_COMMIT_VERSION}" \
+      -Pandroid.injected.signing.store.file="${JAVA_KEYSTORE}" \
+      -Pandroid.injected.signing.store.password="${JAVA_KEYSTORE_PASSWORD}" \
+      -Pandroid.injected.signing.key.alias="${JAVA_KEY}" \
+      -Pandroid.injected.signing.key.password="${JAVA_KEY_PASSWORD}"
+  else
+    ./gradlew "clean" "${gradle_task}" \
+      -PversionCode="$(date +%s)" \
+      -PversionName="${VITE_COMMIT_VERSION}"
+  fi
+
+  if [[ -f "${apk_path}" ]]; then
+    log "APK ready: ${apk_path}"
+    log "Install with: adb install -r ${apk_path}"
+  else
+    die "Expected APK not found at ${apk_path}"
+  fi
+}
+
+main() {
+  load_env_file
+  validate_required_vars
+  check_prerequisites
+
+  log "Building Android APK"
+  log "  App:       ${VITE_APP_NAME} (${APP_ID})"
+  log "  Conductor: ${VITE_CONDUCTOR_URL}"
+  log "  Theme:     ${VITE_THEME}"
+  log "  Type:      ${BUILD_TYPE}"
+
+  run_pnpm_install
+  run_turbo_build
+  run_cap_update
+  run_cap_sync
+  run_gradle_assemble
+
+  log "Done"
+}
+
+main "$@"


### PR DESCRIPTION
A script which helps build apks - can be run from the home path. Setup the .env file and then run it with `./app/scripts/build-android-apk.sh` you can then install it with `adb install -r app/android/app/build/outputs/apk/debug/app-debug.apk`. Tested and working for our dev build.