### PR TITLE
Feat: createRecord allows for initial data

### DIFF
--- a/library/data-model/src/databaseEngine/engine.ts
+++ b/library/data-model/src/databaseEngine/engine.ts
@@ -1137,7 +1137,18 @@ class FormOperations {
     };
 
     // Create the new revision
-    const rev = await this.core.createRevision(revisionDoc);
+    let rev = await this.core.createRevision(revisionDoc);
+
+    // If there is initial data, insert it at this point
+    if (validated.initial) {
+      rev = await this.updateRevision({
+        revisionId: rev._id,
+        recordId: rec._id,
+        update: validated.initial,
+        mode: 'new',
+        updatedBy: validated.createdBy,
+      });
+    }
 
     // Return all the new data
     return {record: rec, revision: rev};

--- a/library/data-model/src/databaseEngine/types.ts
+++ b/library/data-model/src/databaseEngine/types.ts
@@ -593,10 +593,8 @@ export type FormRelationship = z.infer<typeof formRelationshipSchema>;
 const baseFormRecordSchema = z.object({
   /** The ID of the form/viewset this record is an instance of */
   formId: z.string(),
-  /** The actual form data as a map of field IDs to their values */
-  // data: z.record(z.string(), z.unknown()).optional(),
-  /** Annotations for each field, mapped by field ID */
-  // annotations: z.record(z.string(), formAnnotationSchema.optional()).optional(),
+  /** An initial form update, can contain data/annotations/attachments for the initial record */
+  initial: formUpdateDataSchema.optional(),
   /** Username of the user who created this record */
   createdBy: z.string(),
   /** Optional relationship information if this is a related/child record */

--- a/library/data-model/tests/engine.form.test.ts
+++ b/library/data-model/tests/engine.form.test.ts
@@ -158,6 +158,93 @@ describe('Form Operations', () => {
         afterCreate.getTime()
       );
     });
+
+    test('should create record with initial data', async () => {
+      const formRecord: NewFormRecord = {
+        formId: 'A',
+        createdBy: 'test-user',
+        initial: {
+          'First-1': {data: 'Initial value'},
+          'Second-1': {data: 'Another value'},
+        },
+      };
+
+      const result = await engine.form.createRecord(formRecord);
+
+      // Check revision has some AVPs
+      expect(Object.keys(result.revision.avps)).toEqual([
+        'First-1',
+        'Second-1',
+      ]);
+      expect(Object.keys(result.revision.avps).length).toBe(2);
+
+      const firstAvp = await engine.core.getAvp(
+        result.revision.avps['First-1']
+      );
+      const secondAvp = await engine.core.getAvp(
+        result.revision.avps['Second-1']
+      );
+
+      expect(firstAvp.data).toBe('Initial value');
+      expect(secondAvp.data).toBe('Another value');
+    });
+
+    test('should create record with initial annotations', async () => {
+      const formRecord: NewFormRecord = {
+        formId: 'A',
+        createdBy: 'test-user',
+        initial: {
+          'First-1': {
+            data: 'Value with annotation',
+            annotation: {
+              annotation: 'Initial note',
+              uncertainty: true,
+            },
+          },
+        },
+      };
+
+      const result = await engine.form.createRecord(formRecord);
+      const firstAvp = await engine.core.getAvp(
+        result.revision.avps['First-1']
+      );
+
+      expect(firstAvp.data).toBe('Value with annotation');
+      expect(firstAvp.annotations?.annotation).toBe('Initial note');
+      expect(firstAvp.annotations?.uncertainty).toBe(true);
+    });
+
+    test('should create record with initial attachments', async () => {
+      const attachmentId = generateAttID();
+
+      const formRecord: NewFormRecord = {
+        formId: 'A',
+        createdBy: 'test-user',
+        initial: {
+          'First-1': {
+            data: 'Value with attachment',
+            attachments: [
+              {
+                attachmentId,
+                filename: 'initial.txt',
+                fileType: 'text/plain',
+              },
+            ],
+          },
+        },
+      };
+
+      const result = await engine.form.createRecord(formRecord);
+      const firstAvp = await engine.core.getAvp(
+        result.revision.avps['First-1']
+      );
+
+      expect(firstAvp.data).toBe('Value with attachment');
+      expect(firstAvp.faims_attachments).toHaveLength(1);
+      expect(firstAvp.faims_attachments?.[0].attachment_id).toBe(attachmentId);
+      expect(firstAvp.faims_attachments?.[0].filename).toBe('initial.txt');
+      expect(firstAvp.faims_attachments?.[0].file_type).toBe('text/plain');
+    });
   });
 
   describe('createRevision', () => {
@@ -189,40 +276,9 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Add some AVPs to the revision
-      const avpId1 = generateAvpID();
-      const avpId2 = generateAvpID();
-
-      await engine.core.createAvp({
-        _id: avpId1,
-        avp_format_version: 1,
-        type: 'faims-core::String',
-        data: 'test value 1',
-        revision_id: initialResult.revision._id,
-        record_id: initialResult.record._id,
-        created: new Date().toISOString(),
-        created_by: 'user-1',
-      });
-
-      await engine.core.createAvp({
-        _id: avpId2,
-        avp_format_version: 1,
-        type: 'faims-core::String',
-        data: 'test value 2',
-        revision_id: initialResult.revision._id,
-        record_id: initialResult.record._id,
-        created: new Date().toISOString(),
-        created_by: 'user-1',
-      });
-
-      // Update parent revision to include these AVPs
-      await engine.core.updateRevision({
-        ...initialResult.revision,
-        avps: {
-          'field-1': avpId1,
-          'field-2': avpId2,
+        initial: {
+          'field-1': {data: 'test value 1'},
+          'field-2': {data: 'test value 2'},
         },
       });
 
@@ -235,8 +291,8 @@ describe('Form Operations', () => {
 
       // Child should have same AVP map
       expect(childRevision.avps).toEqual({
-        'field-1': avpId1,
-        'field-2': avpId2,
+        'field-1': initialResult.revision.avps['field-1'],
+        'field-2': initialResult.revision.avps['field-2'],
       });
     });
 
@@ -689,19 +745,12 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Set initial data on parent
-      const parentRev = await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {data: 'parent value'},
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
+      const parentRev = initialResult.revision;
       const parentAvpId = parentRev.avps['First-1'];
 
       // Create child revision
@@ -743,19 +792,12 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Set initial data on parent
-      const parentRev = await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {data: 'parent value'},
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
+      const parentRev = initialResult.revision;
       // Create child revision
       const childRev = await engine.form.createRevision({
         recordId: initialResult.record._id,
@@ -799,19 +841,12 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Set initial data on parent
-      const parentRev = await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {data: 'parent value'},
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
+      const parentRev = initialResult.revision;
       const parentAvpId = parentRev.avps['First-1'];
 
       // Create child revision
@@ -853,20 +888,13 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Set initial data on parent
-      const parentRev = await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {data: 'parent value 1'},
           'Second-1': {data: 'parent value 2'},
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
+      const parentRev = initialResult.revision;
       const parentAvp1Id = parentRev.avps['First-1'];
       const parentAvp2Id = parentRev.avps['Second-1'];
 
@@ -916,22 +944,15 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Set initial data on parent with annotation
-      const parentRev = await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {
             data: 'value',
             annotation: {annotation: 'parent note', uncertainty: false},
           },
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
+      const parentRev = initialResult.revision;
       const parentAvpId = parentRev.avps['First-1'];
 
       // Create child revision
@@ -973,20 +994,12 @@ describe('Form Operations', () => {
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      // Add some data
-      await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {
             data: 'test value',
             annotation: {annotation: 'test note', uncertainty: true},
           },
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
       const formData = await engine.form.getExistingFormData({
@@ -1096,17 +1109,12 @@ describe('Form Operations', () => {
     });
 
     test('should include attachment information', async () => {
+      const attachmentId = generateAttID();
+
       const initialResult = await engine.form.createRecord({
         formId: 'A',
         createdBy: 'user-1',
-      });
-
-      const attachmentId = generateAttID();
-
-      await engine.form.updateRevision({
-        revisionId: initialResult.revision._id,
-        recordId: initialResult.record._id,
-        update: {
+        initial: {
           'First-1': {
             data: 'value',
             attachments: [
@@ -1118,8 +1126,6 @@ describe('Form Operations', () => {
             ],
           },
         },
-        mode: 'new',
-        updatedBy: 'user-1',
       });
 
       const formData = await engine.form.getExistingFormData({


### PR DESCRIPTION
# Feat: createRecord allows for initial data

## Ticket

[Groundsite #54](https://github.com/FAIMS/GroundSight-FAIMS/issues/54)

## Description

We need to be able to create records with initial data.

## Proposed Changes

Extends `NewFormRecord` to include an optional `initial` property containing `FormUpdateData`.  If present, this is used to update the initial revision immediately after creation.  The new updated revision is returned in this case. 

This allows for adding initial values, annotations and attachments on records at creation time.

Adds some tests for this and rewrites existing tests that were adding initial data to records via separate calls.

## How to Test

Not used yet in this codebase but tests in data-model should still pass including new tests of this functionality.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
