### PR TITLE
Remove unnecessary Android permission claims

### DIFF
--- a/app/android/app/src/main/AndroidManifest-dist.xml
+++ b/app/android/app/src/main/AndroidManifest-dist.xml
@@ -61,8 +61,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <!-- Geolocation API -->


### PR DESCRIPTION
# Remove unnecessary Android permission claims

## Ticket

None

## Description

Android App store rejected the app because we requested READ_MEDIA_IMAGES/READ_MEDIA_VIDEO permissions.  


## Proposed Changes

Recent versions of the Capacitor Camera plugin don't need these permissions so just remove them here.

## How to Test

We can only test by trying to publish on the Play Store.


## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
