### PR TITLE
fix(app): sort workspace survey list newest-first

### DIFF
--- a/app/src/gui/components/ui/heading-grid.tsx
+++ b/app/src/gui/components/ui/heading-grid.tsx
@@ -16,6 +16,7 @@ import {
   notebookListDataGridSx,
 } from '../workspace/notebooks';
 import {Project} from '../../../context/slices/projectSlice';
+import {sortProjectsByNewest} from '../../../lib/notebookListDisplay';
 
 /**
  * Renders a grid with two sections: Active and Not Active.
@@ -37,12 +38,12 @@ export default function HeadingProjectGrid({
   serverId: string;
 }) {
   // pull out active/inactive notebooks
-  const activatedProjects = projects
-    .filter(({isActivated}) => isActivated)
-    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
-  const availableProjects = projects
-    .filter(({isActivated}) => !isActivated)
-    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
+  const activatedProjects = sortProjectsByNewest(
+    projects.filter(({isActivated}) => isActivated)
+  );
+  const availableProjects = sortProjectsByNewest(
+    projects.filter(({isActivated}) => !isActivated)
+  );
 
   const history = useNavigate();
 

--- a/app/src/gui/components/ui/heading-grid.tsx
+++ b/app/src/gui/components/ui/heading-grid.tsx
@@ -40,8 +40,12 @@ export default function HeadingProjectGrid({
   serverId: string;
 }) {
   // pull out active/inactive notebooks
-  const activatedProjects = projects.filter(({isActivated}) => isActivated);
-  const availableProjects = projects.filter(({isActivated}) => !isActivated);
+  const activatedProjects = projects
+    .filter(({isActivated}) => isActivated)
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
+  const availableProjects = projects
+    .filter(({isActivated}) => !isActivated)
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
 
   const history = useNavigate();
 

--- a/app/src/gui/components/ui/tab-grid.tsx
+++ b/app/src/gui/components/ui/tab-grid.tsx
@@ -18,6 +18,7 @@ import {
   notebookListDataGridSx,
 } from '../workspace/notebooks';
 import {Project} from '../../../context/slices/projectSlice';
+import {sortProjectsByNewest} from '../../../lib/notebookListDisplay';
 
 /**
  * Renders a tabbed grid component.
@@ -41,12 +42,12 @@ export default function TabProjectGrid({
   activatedColumns: GridColDef<Project>[];
   notActivatedColumns: GridColDef<Project>[];
 }) {
-  const activatedProjects = projects
-    .filter(({isActivated}) => isActivated)
-    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
-  const availableProjects = projects
-    .filter(({isActivated}) => !isActivated)
-    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
+  const activatedProjects = sortProjectsByNewest(
+    projects.filter(({isActivated}) => isActivated)
+  );
+  const availableProjects = sortProjectsByNewest(
+    projects.filter(({isActivated}) => !isActivated)
+  );
 
   // we need a state variable to track pagination model since we want to use a
   // controlled component style to force pagination to behave how we want

--- a/app/src/gui/components/ui/tab-grid.tsx
+++ b/app/src/gui/components/ui/tab-grid.tsx
@@ -41,8 +41,12 @@ export default function TabProjectGrid({
   activatedColumns: GridColDef<Project>[];
   notActivatedColumns: GridColDef<Project>[];
 }) {
-  const activatedProjects = projects.filter(({isActivated}) => isActivated);
-  const availableProjects = projects.filter(({isActivated}) => !isActivated);
+  const activatedProjects = projects
+    .filter(({isActivated}) => isActivated)
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
+  const availableProjects = projects
+    .filter(({isActivated}) => !isActivated)
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
 
   // we need a state variable to track pagination model since we want to use a
   // controlled component style to force pagination to behave how we want

--- a/app/src/lib/notebookListDisplay.test.ts
+++ b/app/src/lib/notebookListDisplay.test.ts
@@ -1,7 +1,9 @@
 import {describe, expect, it} from 'vitest';
+import type {Project} from '../context/slices/projectSlice';
 import {
   formatNotebookListDescription,
   isNotebookListDescriptionTruncated,
+  sortProjectsByNewest,
 } from './notebookListDisplay';
 
 describe('notebookListDisplay', () => {
@@ -19,5 +21,41 @@ describe('notebookListDisplay', () => {
     const long = 'a'.repeat(60);
     expect(formatNotebookListDescription(long)).toBe(`${'a'.repeat(50)}…`);
     expect(isNotebookListDescriptionTruncated(long)).toBe(true);
+  });
+});
+
+describe('sortProjectsByNewest', () => {
+  const p = (updatedAt?: string): Project =>
+    ({updatedAt}) as unknown as Project;
+
+  it('sorts by last-updated, newest first', () => {
+    const sorted = sortProjectsByNewest([
+      p('2024-01-01T00:00:00Z'),
+      p('2024-03-01T00:00:00Z'),
+      p('2024-02-01T00:00:00Z'),
+    ]);
+    expect(sorted.map(x => x.updatedAt)).toEqual([
+      '2024-03-01T00:00:00Z',
+      '2024-02-01T00:00:00Z',
+      '2024-01-01T00:00:00Z',
+    ]);
+  });
+
+  it('sorts projects without a timestamp to the end', () => {
+    const sorted = sortProjectsByNewest([
+      p(undefined),
+      p('2024-01-01T00:00:00Z'),
+    ]);
+    expect(sorted.map(x => x.updatedAt)).toEqual([
+      '2024-01-01T00:00:00Z',
+      undefined,
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [p('2024-01-01T00:00:00Z'), p('2024-03-01T00:00:00Z')];
+    const before = [...input];
+    sortProjectsByNewest(input);
+    expect(input).toEqual(before);
   });
 });

--- a/app/src/lib/notebookListDisplay.ts
+++ b/app/src/lib/notebookListDisplay.ts
@@ -1,4 +1,5 @@
 import {NOTEBOOK_LIST_DESCRIPTION_MAX_LENGTH} from '../buildconfig';
+import type {Project} from '../context/slices/projectSlice';
 
 /** Text for the notebook listing grid, or null when absent. */
 export function formatNotebookListDescription(
@@ -17,4 +18,10 @@ export function isNotebookListDescriptionTruncated(
 ): boolean {
   const trimmed = description?.trim();
   return !!trimmed && trimmed.length > NOTEBOOK_LIST_DESCRIPTION_MAX_LENGTH;
+}
+
+export function sortProjectsByNewest(projects: Project[]): Project[] {
+  return [...projects].sort((a, b) =>
+    (b.updatedAt ?? '').localeCompare(a.updatedAt ?? '')
+  );
 }


### PR DESCRIPTION


## Ticket

[<JIRA_TICKET>](https://jira.csiro.com/browse/<JIRA_TICKET>)
https://jira.csiro.au/browse/BSS-1357

## Description

Sort the app's survey lists (Active + Not Active, by updatedAt descending, so newly added/updated surveys appear at
the top instead of the bottom.

<img width="1626" height="1034" alt="Screenshot 2026-07-13 131423" src="https://github.com/user-attachments/assets/71e77ad3-745c-45c3-bd9a-592338211d60" />


## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
