### PR TITLE
refactor: rule-of-hooks follow-ups — static registry fallback, useRequiredUser

### DIFF
--- a/library/forms/lib/fieldRegistry/registry.ts
+++ b/library/forms/lib/fieldRegistry/registry.ts
@@ -26,7 +26,6 @@ import {emailFieldSpec, textFieldSpec} from './fields/TextFields';
 import {
   buildRegistryKey,
   FIELD_REGISTRY,
-  setRegistryFallback,
   splitRegistryKey,
 } from './registryApi';
 import {FieldInfo} from './types';
@@ -119,7 +118,6 @@ for (const alias of LEGACY_FIELD_ALIASES) {
     alias.spec
   );
 }
-setRegistryFallback(textFieldSpec);
 
 /**
  * Validate the registry on load. Legacy alias keys are intentionally allowed

--- a/library/forms/lib/fieldRegistry/registryApi.ts
+++ b/library/forms/lib/fieldRegistry/registryApi.ts
@@ -1,15 +1,18 @@
+import {textFieldSpec} from './fields/TextFields';
 import {FieldInfo} from './types';
 
 /**
  * Lookup surface for the field registry.
  *
- * Kept free of field-spec imports so modules like DataView can resolve
+ * Kept free of the full field-spec list so modules like DataView can resolve
  * renderers without forming a static cycle:
  * RelatedRecord field → RelatedRecord view → DataView → registry → RelatedRecord.
+ * Importing the text-field spec alone is safe: its import chain (form types,
+ * fallback renderer types, MUI wrappers) never reaches DataView.
  *
- * {@link ./registry.ts} populates {@link FIELD_REGISTRY} and the fallback at
- * module load. Package entry exports fieldRegistry before rendering, so the
- * map is ready before DataView runs.
+ * {@link ./registry.ts} populates {@link FIELD_REGISTRY} at module load.
+ * Package entry exports fieldRegistry before rendering, so the map is ready
+ * before DataView runs.
  */
 
 /**
@@ -20,26 +23,6 @@ import {FieldInfo} from './types';
  * registry setup.
  */
 export const FIELD_REGISTRY: Map<string, FieldInfo<any>> = new Map();
-
-/**
- * Fallback {@link FieldInfo} used when a notebook references an unknown field
- * type (typically the unified text field). Set once via
- * {@link setRegistryFallback} during registry initialisation.
- */
-let fallbackFieldInfo: FieldInfo<any> | undefined;
-
-/**
- * Sets the fallback field spec returned by {@link getFieldInfo} when a
- * `namespace::name` key is missing from {@link FIELD_REGISTRY}.
- *
- * Called by {@link ./registry.ts} after registering canonical specs (with the
- * text-field spec). Must run before any render path calls {@link getFieldInfo}.
- *
- * @param spec - Field info to use as the unknown-type fallback
- */
-export function setRegistryFallback(spec: FieldInfo<any>): void {
-  fallbackFieldInfo = spec;
-}
 
 /**
  * Builds the registry lookup key for a component namespace and name.
@@ -85,14 +68,13 @@ export function splitRegistryKey(key: string): {
  * Resolves field info for a UI-spec component namespace and name.
  *
  * Looks up {@link FIELD_REGISTRY} first. If the key is missing, returns the
- * configured fallback (see {@link setRegistryFallback}) and sets
- * `fallback: true` so callers can warn about unrecognised types.
+ * text-field spec and sets `fallback: true` so callers can warn about
+ * unrecognised types.
  *
  * @param args - Component identity from the UI specification
  * @param args.namespace - UI-spec `component-namespace`
  * @param args.name - UI-spec `component-name`
  * @returns `fieldInfo` for rendering/validation, and whether it was a fallback
- * @throws If the fallback has not been initialised yet (registry not loaded)
  */
 export const getFieldInfo = ({
   namespace,
@@ -104,12 +86,7 @@ export const getFieldInfo = ({
   const key = buildRegistryKey({namespace, name});
   const fieldInfo = FIELD_REGISTRY.get(key);
   if (fieldInfo) return {fieldInfo, fallback: false};
-  if (!fallbackFieldInfo) {
-    throw new Error(
-      'Field registry fallback is not initialised. Import @faims3/forms (or fieldRegistry/registry) before rendering.'
-    );
-  }
-  return {fieldInfo: fallbackFieldInfo, fallback: true};
+  return {fieldInfo: textFieldSpec, fallback: true};
 };
 
 /**

--- a/web/src/components/alerts/impersonation-banner.tsx
+++ b/web/src/components/alerts/impersonation-banner.tsx
@@ -1,4 +1,5 @@
 import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {Button} from '@/components/ui/button';
 import {VenetianMask} from 'lucide-react';
 
@@ -7,14 +8,14 @@ import {VenetianMask} from 'lucide-react';
  * session. Provides a clear way to return to the admin's own account.
  */
 export function ImpersonationBanner() {
-  const {isImpersonating, user, impersonatorName, stopImpersonation} =
-    useAuth();
+  const {isImpersonating, impersonatorName, stopImpersonation} = useAuth();
+  const user = useRequiredUser();
 
   if (!isImpersonating) {
     return null;
   }
 
-  const impersonatedName = user?.user.name ?? user?.user.email ?? 'this user';
+  const impersonatedName = user.user.name ?? user.user.email ?? 'this user';
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border-2 border-warning bg-warning-background px-4 py-2 text-sm text-foreground">

--- a/web/src/components/dialogs/add-project-to-team-dialog.tsx
+++ b/web/src/components/dialogs/add-project-to-team-dialog.tsx
@@ -9,18 +9,10 @@ import {
 import {Button} from '../ui/button';
 import {useState} from 'react';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {ErrorComponent} from '@tanstack/react-router';
 import {AddProjectToTeamForm} from '../forms/add-project-to-team-form';
 
 export const AddProjectToTeamDialog = ({projectId}: {projectId: string}) => {
   const [open, setOpen] = useState(false);
-
-  const {user} = useAuth();
-
-  if (!user) {
-    return <ErrorComponent error="Unauthenticated" />;
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/dialogs/add-template-to-team-dialog.tsx
+++ b/web/src/components/dialogs/add-template-to-team-dialog.tsx
@@ -8,8 +8,6 @@ import {
 } from '@/components/ui/dialog';
 import {Button} from '../ui/button';
 import {useState} from 'react';
-import {useAuth} from '@/context/auth-provider';
-import {ErrorComponent} from '@tanstack/react-router';
 import {AddTemplateToTeamForm} from '../forms/add-template-to-team-form';
 import {
   Tooltip,
@@ -27,12 +25,6 @@ export const AddTemplateToTeamDialog = ({
   disabled?: boolean;
 }) => {
   const [open, setOpen] = useState(false);
-
-  const {user} = useAuth();
-
-  if (!user) {
-    return <ErrorComponent error="Unauthenticated" />;
-  }
 
   if (disabled) {
     return (

--- a/web/src/components/dialogs/archive-project-dialog.tsx
+++ b/web/src/components/dialogs/archive-project-dialog.tsx
@@ -11,7 +11,6 @@ import {Button} from '@/components/ui/button';
 import {Checkbox} from '@/components/ui/checkbox';
 import {Label} from '@/components/ui/label';
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
-import {useAuth} from '@/context/auth-provider';
 import {useArchiveProject} from '@/hooks/archive-hooks';
 import {useNavigate} from '@tanstack/react-router';
 import {useState} from 'react';
@@ -29,7 +28,6 @@ export function ArchiveProjectDialog({
   projectId,
   disabled = false,
 }: ArchiveProjectDialogProps) {
-  const {user} = useAuth();
   const {mutate, isPending} = useArchiveProject();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
@@ -43,7 +41,6 @@ export function ArchiveProjectDialog({
   };
 
   const onConfirm = () => {
-    if (!user) return;
     mutate(
       {projectId},
       {

--- a/web/src/components/dialogs/archive-template-dialog.tsx
+++ b/web/src/components/dialogs/archive-template-dialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import {Button} from '../ui/button';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {Route} from '@/routes/_protected/templates/$templateId';
 import {useNavigate} from '@tanstack/react-router';
 import {useQueryClient} from '@tanstack/react-query';
@@ -22,7 +22,7 @@ import {config} from '@/constants';
  * @returns {JSX.Element} The rendered ArchiveTemplateDialog component.
  */
 export const ArchiveTemplateDialog = ({archived}: {archived: boolean}) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {templateId} = Route.useParams();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -37,7 +37,7 @@ export const ArchiveTemplateDialog = ({archived}: {archived: boolean}) => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${user?.token}`,
+            Authorization: `Bearer ${user.token}`,
           },
           body: JSON.stringify({
             archive: willArchive,

--- a/web/src/components/dialogs/change-project-status-dialog.tsx
+++ b/web/src/components/dialogs/change-project-status-dialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {ProjectStatus} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
 import {AlertCircle, CheckCircle, Info} from 'lucide-react';
@@ -16,7 +16,7 @@ import {Button} from '../ui/button';
 import {useGetProject} from '@/hooks/queries';
 
 export const ProjectStatusDialog = ({projectId}: {projectId: string}) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
 
@@ -30,7 +30,7 @@ export const ProjectStatusDialog = ({projectId}: {projectId: string}) => {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${user?.token}`,
+          Authorization: `Bearer ${user.token}`,
         },
         body: JSON.stringify({
           status: isOpen ? ProjectStatus.CLOSED : ProjectStatus.OPEN,

--- a/web/src/components/dialogs/create-project-dialog.tsx
+++ b/web/src/components/dialogs/create-project-dialog.tsx
@@ -11,11 +11,9 @@ import {useState} from 'react';
 import {CreateProjectForm} from '../forms/create-project-form';
 import {config} from '@/constants';
 import {Plus} from 'lucide-react';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeam} from '@/hooks/queries';
 import {Action, getUserResourcesForAction} from '@faims3/data-model';
-import {ErrorComponent} from '@tanstack/react-router';
 
 export const CreateProjectDialog = ({
   defaultValues,
@@ -26,7 +24,7 @@ export const CreateProjectDialog = ({
 }) => {
   const [open, setOpen] = useState(false);
 
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {data: team} = useGetTeam({user, teamId: specifiedTeam});
   const canCreateGlobally = useIsAuthorisedTo({action: Action.CREATE_PROJECT});
   const canCreateInSpecifiedTeam = useIsAuthorisedTo({
@@ -35,16 +33,12 @@ export const CreateProjectDialog = ({
   });
   const canCreateInSomeTeam =
     getUserResourcesForAction({
-      decodedToken: user?.decodedToken,
+      decodedToken: user.decodedToken,
       action: Action.CREATE_PROJECT_IN_TEAM,
     }).length > 0;
   const canCreate =
     canCreateGlobally ||
     (specifiedTeam ? canCreateInSpecifiedTeam : canCreateInSomeTeam);
-
-  if (!user) {
-    return <ErrorComponent error="Unauthenticated" />;
-  }
 
   if (!canCreate) {
     return null;

--- a/web/src/components/dialogs/create-template-dialog.tsx
+++ b/web/src/components/dialogs/create-template-dialog.tsx
@@ -11,9 +11,7 @@ import {useState} from 'react';
 import {CreateTemplateForm} from '../forms/create-template-form';
 import {Plus} from 'lucide-react';
 import {useGetTeam} from '@/hooks/queries';
-import {useAuth} from '@/context/auth-provider';
-import {useCanCreateTemplate} from '@/hooks/auth-hooks';
-import {ErrorComponent} from '@tanstack/react-router';
+import {useCanCreateTemplate, useRequiredUser} from '@/hooks/auth-hooks';
 
 /**
  * Dialog entry point for creating a new template.
@@ -30,13 +28,9 @@ export const CreateTemplateDialog = ({
   specifiedTeam?: string;
 }) => {
   const [open, setOpen] = useState(false);
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const canCreateTemplate = useCanCreateTemplate();
   const {data: team} = useGetTeam({user, teamId: specifiedTeam});
-
-  if (!user) {
-    return <ErrorComponent error="Unauthenticated" />;
-  }
 
   // Global list: hide trigger when user cannot create at all.
   // Team tab passes specifiedTeam and relies on parent permission checks.

--- a/web/src/components/dialogs/create-template-from-project-dialog.tsx
+++ b/web/src/components/dialogs/create-template-from-project-dialog.tsx
@@ -10,8 +10,7 @@ import {Button} from '../ui/button';
 import {useState} from 'react';
 import {Plus} from 'lucide-react';
 import {useGetTeam} from '@/hooks/queries';
-import {useAuth} from '@/context/auth-provider';
-import {ErrorComponent} from '@tanstack/react-router';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {CreateTemplateFromProjectForm} from '../forms/create-template-from-project';
 import {config} from '@/constants';
 
@@ -25,12 +24,8 @@ export const CreateTemplateFromProjectDialog = ({
   specifiedTeam?: string;
 }) => {
   const [open, setOpen] = useState(false);
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {data: team} = useGetTeam({user, teamId: specifiedTeam});
-
-  if (!user) {
-    return <ErrorComponent error="Unauthenticated" />;
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/dialogs/disable-user.tsx
+++ b/web/src/components/dialogs/disable-user.tsx
@@ -1,5 +1,4 @@
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useDisableUserAccount} from '@/hooks/user-hooks';
 import {
   Dialog,
@@ -22,7 +21,7 @@ import {cn} from '@/lib/utils';
  */
 export function DisableUserDialog({rowUser}: {rowUser: GetListAllUsersItem}) {
   const [open, setOpen] = useState(false);
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const disableUser = useDisableUserAccount();
   const canDisable = useIsAuthorisedTo({
     action: Action.DISABLE_USER_ACCOUNT,
@@ -30,7 +29,7 @@ export function DisableUserDialog({rowUser}: {rowUser: GetListAllUsersItem}) {
   });
 
   const blocked =
-    rowUser._id === user?.user.id ||
+    rowUser._id === user.user.id ||
     (rowUser.globalRoles ?? []).includes(Role.GENERAL_ADMIN);
 
   if (!canDisable || blocked) {

--- a/web/src/components/dialogs/generate-password-reset.tsx
+++ b/web/src/components/dialogs/generate-password-reset.tsx
@@ -6,7 +6,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useMutation} from '@tanstack/react-query';
 import {AlertCircle, LinkIcon, QrCode, RefreshCw} from 'lucide-react';
 import QRCode from 'qrcode';
@@ -63,7 +63,7 @@ const QRCodeViewDialog = ({qrData}: {qrData: string}) => {
  * @param userId - The ID of the user requesting password reset
  * @param open - Controls the visibility of the dialog
  * @param setOpen - Function to update dialog visibility
- * @returns Returns null if user is not authenticated or userId is missing
+ * @returns Returns null if userId is missing
  */
 export const GeneratePasswordReset = ({
   userId,
@@ -74,7 +74,7 @@ export const GeneratePasswordReset = ({
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const [qrCodeData, setQrCodeData] = useState<string>('');
   const {data, isPending, mutate, error, isError, reset} = useMutation({
@@ -84,7 +84,7 @@ export const GeneratePasswordReset = ({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${user!.token}`,
+          Authorization: `Bearer ${user.token}`,
         },
         body: JSON.stringify({
           email: id,
@@ -116,8 +116,7 @@ export const GeneratePasswordReset = ({
     mutate({id: userId!});
   };
 
-  // early returns are here because we need the hooks above to always run in the same order.
-  if (!user) return null;
+  // early return is here because we need the hooks above to always run in the same order.
   if (!userId) return null;
 
   return (

--- a/web/src/components/dialogs/impersonate-user.tsx
+++ b/web/src/components/dialogs/impersonate-user.tsx
@@ -1,5 +1,4 @@
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useImpersonateUser} from '@/hooks/user-hooks';
 import {
   Dialog,
@@ -31,7 +30,7 @@ export function ImpersonateUserDialog({
   rowUser: GetListAllUsersItem;
 }) {
   const [open, setOpen] = useState(false);
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const impersonate = useImpersonateUser();
   const canImpersonate = useIsAuthorisedTo({
     action: Action.IMPERSONATE_USER,
@@ -39,7 +38,7 @@ export function ImpersonateUserDialog({
   });
 
   const blocked =
-    rowUser._id === user?.user.id ||
+    rowUser._id === user.user.id ||
     (rowUser.globalRoles ?? []).includes(Role.GENERAL_ADMIN);
 
   if (!canImpersonate || blocked) {

--- a/web/src/components/dialogs/remove-user-from-project-dialog.tsx
+++ b/web/src/components/dialogs/remove-user-from-project-dialog.tsx
@@ -9,7 +9,7 @@ import {
 import {Button} from '../ui/button';
 import {config} from '@/constants';
 import {useState} from 'react';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {Trash} from 'lucide-react';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {useQueryClient} from '@tanstack/react-query';
@@ -28,7 +28,7 @@ export const RemoveUserFromProjectDialog = ({
   admin: boolean;
 }) => {
   const [error, setError] = useState('');
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {projectId} = Route.useParams();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
@@ -59,7 +59,7 @@ export const RemoveUserFromProjectDialog = ({
                   method: 'DELETE',
                   headers: {
                     'Content-Type': 'application/json',
-                    Authorization: `Bearer ${user?.token}`,
+                    Authorization: `Bearer ${user.token}`,
                   },
                 }
               );

--- a/web/src/components/dialogs/remove-user.tsx
+++ b/web/src/components/dialogs/remove-user.tsx
@@ -11,7 +11,7 @@ import {useState} from 'react';
 import {Trash} from 'lucide-react';
 import {useQueryClient} from '@tanstack/react-query';
 import {Alert, AlertDescription, AlertTitle} from '../ui/alert';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {config} from '@/constants';
 
 /**
@@ -30,7 +30,7 @@ export const RemoveUserDialog = ({
   disabled?: boolean;
 }) => {
   const [open, setOpen] = useState(false);
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
 
   return (
@@ -61,7 +61,7 @@ export const RemoveUserDialog = ({
                 method: 'DELETE',
                 headers: {
                   'Content-Type': 'application/json',
-                  Authorization: `Bearer ${user?.token}`,
+                  Authorization: `Bearer ${user.token}`,
                 },
               });
 

--- a/web/src/components/dialogs/restore-archived-project-dialog.tsx
+++ b/web/src/components/dialogs/restore-archived-project-dialog.tsx
@@ -8,7 +8,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import {Button} from '@/components/ui/button';
-import {useAuth} from '@/context/auth-provider';
 import {useRestoreArchivedProject} from '@/hooks/archive-hooks';
 import {useState} from 'react';
 import {toast} from 'sonner';
@@ -26,7 +25,6 @@ export function RestoreArchivedProjectDialog({
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
 }: RestoreArchivedProjectDialogProps) {
-  const {user} = useAuth();
   const {mutate, isPending} = useRestoreArchivedProject();
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOnOpenChange !== undefined;
@@ -34,7 +32,6 @@ export function RestoreArchivedProjectDialog({
   const setOpen = isControlled ? controlledOnOpenChange! : setInternalOpen;
 
   const onRestore = () => {
-    if (!user) return;
     mutate(
       {projectId},
       {

--- a/web/src/components/dialogs/teams/add-team-user-dialog.tsx
+++ b/web/src/components/dialogs/teams/add-team-user-dialog.tsx
@@ -7,8 +7,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {useAuth} from '@/context/auth-provider';
-import {ErrorComponent} from '@tanstack/react-router';
 import React, {useState} from 'react';
 import {Button} from '../../ui/button';
 
@@ -19,12 +17,7 @@ export const AddTeamUserDialog = ({
   teamId: string;
   buttonContent: React.ReactNode;
 }) => {
-  const {user} = useAuth();
   const [open, setOpen] = useState(false);
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated." />;
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/dialogs/teams/update-team-dialog.tsx
+++ b/web/src/components/dialogs/teams/update-team-dialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeam} from '@/hooks/queries';
 import {ErrorComponent} from '@tanstack/react-router';
 import {LoaderCircleIcon} from 'lucide-react';
@@ -21,13 +21,9 @@ export const UpdateTeamDialog = ({
   teamId: string;
   buttonContent?: React.ReactNode;
 }) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {data, isLoading, isError} = useGetTeam({user, teamId});
   const [open, setOpen] = useState(false);
-
-  if (!user) {
-    return <p>Not authenticated...</p>;
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/dialogs/template-visibility-dialog.tsx
+++ b/web/src/components/dialogs/template-visibility-dialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTemplate} from '@/hooks/queries';
 import {putTemplateSetVisibility} from '@/hooks/template-hooks';
 import {useQueryClient} from '@tanstack/react-query';
@@ -16,7 +16,7 @@ import {Button} from '../ui/button';
 import {List, ListItem, ListLabel} from '../ui/list';
 
 export function TemplateVisibilityDialog({templateId}: {templateId: string}) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
 
@@ -24,7 +24,6 @@ export function TemplateVisibilityDialog({templateId}: {templateId: string}) {
   const isPublic = template?.isPublic === true;
 
   const onConfirmToggle = async () => {
-    if (!user) return;
     await putTemplateSetVisibility({
       user,
       templateId,
@@ -34,10 +33,6 @@ export function TemplateVisibilityDialog({templateId}: {templateId: string}) {
     await queryClient.invalidateQueries({queryKey: ['templates']});
     setOpen(false);
   };
-
-  if (!user) {
-    return null;
-  }
 
   const toggleVisibilityDialog = isPublic ? (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/forms/add-project-to-team-form.tsx
+++ b/web/src/components/forms/add-project-to-team-form.tsx
@@ -1,7 +1,6 @@
 import {Field, Form} from '@/components/form';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {modifyTeamForProject} from '@/hooks/project-hooks';
 import {useGetProject, useGetTeams} from '@/hooks/queries';
 import {Action} from '@faims3/data-model';
@@ -23,7 +22,7 @@ export function AddProjectToTeamForm({
   setDialogOpen,
   projectId,
 }: AddProjectToTeamFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
   const teams = useGetTeams({user});
   const {data: project} = useGetProject({user, projectId});
@@ -73,8 +72,6 @@ export function AddProjectToTeamForm({
    * Handles the form submission
    */
   const onSubmit = async ({teamId}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await modifyTeamForProject({
       projectId,
       teamId,

--- a/web/src/components/forms/add-template-to-team-form.tsx
+++ b/web/src/components/forms/add-template-to-team-form.tsx
@@ -1,6 +1,5 @@
 import {Field, Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeams} from '@/hooks/queries';
 import {
   errorMessageFromTemplateJsonBody,
@@ -27,7 +26,7 @@ export function AddTemplateToTeamForm({
   setDialogOpen,
   templateId,
 }: AddTemplateToTeamFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
   const teams = useGetTeams({user});
   const {data: template} = useGetTemplate({user, templateId});
@@ -63,8 +62,6 @@ export function AddTemplateToTeamForm({
    * Handles the form submission
    */
   const onSubmit = async ({teamId}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await modifyTeamForTemplate({
       templateId,
       teamId,

--- a/web/src/components/forms/create-global-invite-form.tsx
+++ b/web/src/components/forms/create-global-invite-form.tsx
@@ -10,8 +10,21 @@ import {
   RoleScope,
 } from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
-import {useMemo, useState} from 'react';
+import {useState} from 'react';
 import {z} from 'zod';
+
+// Global-scope roles offered by the invite form; static because roleDetails is
+// a module-level constant
+const roleOptions = Object.entries(roleDetails)
+  .filter(
+    ([role, detail]) =>
+      detail.scope === RoleScope.GLOBAL && role !== Role.GENERAL_ADMIN
+  )
+  .map(([value, {name: label, description}]) => ({
+    label,
+    value,
+    description,
+  }));
 
 /**
  * Form to create a new global invite
@@ -29,20 +42,6 @@ export function CreateGlobalInviteForm({
   const [selectedDateTime, setSelectedDateTime] = useState<string | undefined>(
     undefined
   );
-
-  // Memoize the role options to prevent re-computation on each render
-  const roleOptions = useMemo(() => {
-    return Object.entries(roleDetails)
-      .filter(
-        ([role, detail]) =>
-          detail.scope === RoleScope.GLOBAL && role !== Role.GENERAL_ADMIN
-      )
-      .map(([value, {name: label, description}]) => ({
-        label,
-        value,
-        description,
-      }));
-  }, []);
 
   const fields: Field[] = [
     {

--- a/web/src/components/forms/create-global-invite-form.tsx
+++ b/web/src/components/forms/create-global-invite-form.tsx
@@ -1,7 +1,7 @@
 import {ExpirySelector} from '@/components/expiry-selector';
 import {Field, Form} from '@/components/form';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {
   INPUT_LIMITS,
   PostCreateInviteInput,
@@ -10,7 +10,6 @@ import {
   RoleScope,
 } from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
-import {ErrorComponent} from '@tanstack/react-router';
 import {useMemo, useState} from 'react';
 import {z} from 'zod';
 
@@ -25,7 +24,7 @@ export function CreateGlobalInviteForm({
 }: {
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
   const [selectedDateTime, setSelectedDateTime] = useState<string | undefined>(
     undefined
@@ -33,7 +32,6 @@ export function CreateGlobalInviteForm({
 
   // Memoize the role options to prevent re-computation on each render
   const roleOptions = useMemo(() => {
-    if (!user) return [];
     return Object.entries(roleDetails)
       .filter(
         ([role, detail]) =>
@@ -44,11 +42,7 @@ export function CreateGlobalInviteForm({
         value,
         description,
       }));
-  }, [user]);
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated" />;
-  }
+  }, []);
 
   const fields: Field[] = [
     {
@@ -97,8 +91,6 @@ export function CreateGlobalInviteForm({
     uses?: number;
     name: string;
   }) => {
-    if (!user) return {type: 'submit', message: 'Not logged in'};
-
     // Validate expiry selection
     if (!selectedDateTime) {
       return {type: 'submit', message: 'Please select an expiry date'};

--- a/web/src/components/forms/create-project-form.tsx
+++ b/web/src/components/forms/create-project-form.tsx
@@ -1,7 +1,7 @@
 import {Field, Form} from '@/components/form';
 import {config} from '@/constants';
 import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeams, useGetTemplates} from '@/hooks/queries';
 import {Action, TemplateListItem} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
@@ -36,7 +36,8 @@ export function CreateProjectForm({
   defaultValues,
   specifiedTeam = undefined,
 }: CreateProjectFormProps) {
-  const {user, refreshToken} = useAuth();
+  const user = useRequiredUser();
+  const {refreshToken} = useAuth();
   const queryClient = useQueryClient();
 
   // can they create projects outside team?
@@ -115,10 +116,6 @@ export function CreateProjectForm({
     file,
     team,
   }: onSubmitProps) => {
-    if (!user) {
-      return {type: 'submit', message: 'User not authenticated'};
-    }
-
     let response;
     if (template) {
       // Create from selected template

--- a/web/src/components/forms/create-project-from-template.tsx
+++ b/web/src/components/forms/create-project-from-template.tsx
@@ -1,7 +1,7 @@
 import {Field, Form} from '@/components/form';
 import {config} from '@/constants';
 import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeams, useGetTemplate} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/templates/$templateId';
 import {Action, PostCreateNotebookInput} from '@faims3/data-model';
@@ -36,12 +36,13 @@ interface CreateProjectFromTemplateFormProps {
  * create outside any team.
  *
  * @param {CreateProjectFromTemplateFormProps} props - The props for the form.
- * @returns {JSX.Element | null} The rendered form, or null if unauthenticated.
+ * @returns {JSX.Element} The rendered form.
  */
 export function CreateProjectFromTemplateForm({
   setDialogOpen,
 }: CreateProjectFromTemplateFormProps) {
-  const {user, refreshToken} = useAuth();
+  const user = useRequiredUser();
+  const {refreshToken} = useAuth();
   const {templateId} = Route.useParams();
   const queryClient = useQueryClient();
   const {data: teamsData} = useGetTeams({user});
@@ -52,7 +53,7 @@ export function CreateProjectFromTemplateForm({
     teams: teamsData?.teams,
     canCreateGlobally,
     createInTeamAction: Action.CREATE_PROJECT_IN_TEAM,
-    decodedToken: user?.decodedToken,
+    decodedToken: user.decodedToken,
   });
 
   const {showTeamCallout, showTeamDropdown} = getTeamFieldState({
@@ -107,8 +108,6 @@ export function CreateProjectFromTemplateForm({
     teamDescription,
     teamLabel,
   ]);
-
-  if (!user) return null;
 
   const onSubmit = async ({
     name,

--- a/web/src/components/forms/create-project-invite.tsx
+++ b/web/src/components/forms/create-project-invite.tsx
@@ -1,6 +1,5 @@
 import {Field, Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
-import {userCanDo} from '@/hooks/auth-hooks';
+import {userCanDo, useRequiredUser} from '@/hooks/auth-hooks';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {
   INPUT_LIMITS,
@@ -12,7 +11,6 @@ import {
   RoleScope,
 } from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
-import {ErrorComponent} from '@tanstack/react-router';
 import {useMemo, useState} from 'react';
 import {z} from 'zod';
 import {ExpirySelector} from '@/components/expiry-selector';
@@ -31,7 +29,7 @@ interface UpdateTemplateFormProps {
 export function CreateProjectInviteForm({
   setDialogOpen,
 }: UpdateTemplateFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {projectId} = Route.useParams();
   const QueryClient = useQueryClient();
   const [selectedDateTime, setSelectedDateTime] = useState<string | undefined>(
@@ -39,7 +37,6 @@ export function CreateProjectInviteForm({
   );
 
   const roleOptions = useMemo(() => {
-    if (!user) return [];
     return Object.entries(roleDetails)
       .filter(
         ([role, {scope, resource}]) =>
@@ -65,10 +62,6 @@ export function CreateProjectInviteForm({
         description: brandNotebook(description),
       }));
   }, [user, projectId]);
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated" />;
-  }
 
   const fields: Field[] = [
     {
@@ -118,8 +111,6 @@ export function CreateProjectInviteForm({
     uses?: number;
     name: string;
   }) => {
-    if (!user) return {type: 'submit', message: 'Not logged in'};
-
     // Validate expiry selection
     if (!selectedDateTime) {
       return {type: 'submit', message: 'Please select an expiry date'};

--- a/web/src/components/forms/create-template-form.tsx
+++ b/web/src/components/forms/create-template-form.tsx
@@ -6,7 +6,11 @@ import {INPUT_LIMITS} from '@faims3/data-model';
 import {z} from 'zod';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetTeams} from '@/hooks/queries';
-import {useIsAuthorisedTo, useCanCreateTemplate} from '@/hooks/auth-hooks';
+import {
+  useIsAuthorisedTo,
+  useCanCreateTemplate,
+  useRequiredUser,
+} from '@/hooks/auth-hooks';
 import {
   Action,
   prepareNotebookUiSpecificationInputForApi,
@@ -47,7 +51,8 @@ export function CreateTemplateForm({
   defaultValues,
   specifiedTeam = undefined,
 }: CreateTemplateFormProps) {
-  const {user, refreshToken} = useAuth();
+  const user = useRequiredUser();
+  const {refreshToken} = useAuth();
   const queryClient = useQueryClient();
   const {data: teams} = useGetTeams({user});
 
@@ -66,7 +71,7 @@ export function CreateTemplateForm({
     teams: teams?.teams,
     canCreateGlobally,
     createInTeamAction: Action.CREATE_TEMPLATE_IN_TEAM,
-    decodedToken: user?.decodedToken,
+    decodedToken: user.decodedToken,
   });
 
   const {showTeamCallout, showTeamDropdown} = getTemplateTeamFieldState({
@@ -128,8 +133,6 @@ export function CreateTemplateForm({
     team?: string;
     visibility?: 'private' | 'public';
   }) => {
-    if (!user) return {type: 'submit', message: 'Not authenticated'};
-
     const {name, description, file, team, visibility} = values;
     const isPublic = canCreatePublicTemplate && visibility === 'public';
     let uiSpecification: unknown = blankNotebook;

--- a/web/src/components/forms/create-template-from-project.tsx
+++ b/web/src/components/forms/create-template-from-project.tsx
@@ -4,7 +4,11 @@ import {resourceNameSchema} from '@/lib/input-limits';
 import {INPUT_LIMITS} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
 import {useGetProject, useGetTeams} from '@/hooks/queries';
-import {useIsAuthorisedTo, useCanCreateTemplate} from '@/hooks/auth-hooks';
+import {
+  useIsAuthorisedTo,
+  useCanCreateTemplate,
+  useRequiredUser,
+} from '@/hooks/auth-hooks';
 import {Action} from '@faims3/data-model';
 import {
   optionalRootDescriptionField,
@@ -41,7 +45,8 @@ export function CreateTemplateFromProjectForm({
   projectId,
   specifiedTeam = undefined,
 }: CreateTemplateFromProjectForm) {
-  const {user, refreshToken} = useAuth();
+  const user = useRequiredUser();
+  const {refreshToken} = useAuth();
   const queryClient = useQueryClient();
   const {data: teams} = useGetTeams({user});
   const {data: projectData} = useGetProject({user, projectId});
@@ -57,7 +62,7 @@ export function CreateTemplateFromProjectForm({
     teams: teams?.teams,
     canCreateGlobally,
     createInTeamAction: Action.CREATE_TEMPLATE_IN_TEAM,
-    decodedToken: user?.decodedToken,
+    decodedToken: user.decodedToken,
   });
 
   const {showTeamCallout, showTeamDropdown} = getTemplateTeamFieldState({
@@ -88,8 +93,6 @@ export function CreateTemplateFromProjectForm({
     description?: string;
     team?: string;
   }) => {
-    if (!user) return {type: 'submit', message: 'Not authenticated'};
-
     const {name, description, team} = values;
 
     if (!projectData?.uiSpecification) {

--- a/web/src/components/forms/edit-project-details-form.tsx
+++ b/web/src/components/forms/edit-project-details-form.tsx
@@ -1,5 +1,5 @@
 import {Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {
   errorMessageFromNotebookJsonBody,
   updateNotebookMetadataRequest,
@@ -25,7 +25,7 @@ export function EditProjectDetailsForm({
   name,
   description,
 }: EditProjectDetailsFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   const fields = [
@@ -45,8 +45,6 @@ export function EditProjectDetailsForm({
     name: string;
     description: string;
   }) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await updateNotebookMetadataRequest({
       user,
       projectId,

--- a/web/src/components/forms/edit-template-details-form.tsx
+++ b/web/src/components/forms/edit-template-details-form.tsx
@@ -1,5 +1,5 @@
 import {Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {
   errorMessageFromTemplateJsonBody,
   updateTemplateRequest,
@@ -25,7 +25,7 @@ export function EditTemplateDetailsForm({
   name,
   description,
 }: EditTemplateDetailsFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   const fields = [
@@ -45,8 +45,6 @@ export function EditTemplateDetailsForm({
     name: string;
     description: string;
   }) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await updateTemplateRequest({
       user,
       templateId,

--- a/web/src/components/forms/export-full-form.tsx
+++ b/web/src/components/forms/export-full-form.tsx
@@ -1,6 +1,6 @@
 import {Checkbox} from '@/components/ui/checkbox';
 import {Label} from '@/components/ui/label';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetProject} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {
@@ -33,7 +33,7 @@ const DEFAULT_OPTIONS: ExportOptions = {
  * It allows users to configure which components to include in the export ZIP.
  */
 const ExportFullForm = () => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {projectId} = Route.useParams();
   const {data} = useGetProject({user, projectId});
   const [options, setOptions] = useState<ExportOptions>(DEFAULT_OPTIONS);
@@ -56,8 +56,6 @@ const ExportFullForm = () => {
   };
 
   const handleSubmit = async () => {
-    if (!user) return;
-
     setIsSubmitting(true);
     setSubmitError(null);
 

--- a/web/src/components/forms/generate-test-records-form.tsx
+++ b/web/src/components/forms/generate-test-records-form.tsx
@@ -1,6 +1,6 @@
 import {Field, Form} from '@/components/form';
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {generateTestRecordsForProject} from '@/hooks/project-hooks';
 import {AlertTriangle} from 'lucide-react';
 import {toast} from 'sonner';
@@ -18,7 +18,7 @@ export function GenerateTestRecordsForm({
   setDialogOpen,
   projectId,
 }: GenerateTestRecordsFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const fields: Field[] = [
     {
@@ -68,10 +68,6 @@ export function GenerateTestRecordsForm({
     parallelism: number;
     includeAttachments: boolean;
   }) => {
-    if (!user) {
-      return {type: 'submit', message: 'User not authenticated'};
-    }
-
     try {
       const result = await generateTestRecordsForProject({
         projectId,

--- a/web/src/components/forms/long-lived-tokens/create-long-lived-token-form.tsx
+++ b/web/src/components/forms/long-lived-tokens/create-long-lived-token-form.tsx
@@ -1,5 +1,5 @@
 import {Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {createLongLivedToken} from '@/hooks/queries';
 import {useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
@@ -22,7 +22,7 @@ export function CreateLongLivedTokenForm({
   setDialogOpen,
   onInterceptClose,
 }: CreateLongLivedTokenFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
   const [createdToken, setCreatedToken] = useState<string | undefined>(
     undefined
@@ -101,8 +101,6 @@ export function CreateLongLivedTokenForm({
    * Handles the form submission
    */
   const onSubmit = async ({title, description}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     // Validate expiry selection
     if (!selectedDateTime) {
       return {type: 'submit', message: 'Please select an expiry date'};

--- a/web/src/components/forms/long-lived-tokens/update-long-lived-token-form.tsx
+++ b/web/src/components/forms/long-lived-tokens/update-long-lived-token-form.tsx
@@ -1,5 +1,5 @@
 import {Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {updateLongLivedToken} from '@/hooks/queries';
 import {useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
@@ -17,7 +17,7 @@ export function UpdateLongLivedTokenForm({
   setDialogOpen,
   token,
 }: UpdateLongLivedTokenFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   const fields = [
@@ -58,8 +58,6 @@ export function UpdateLongLivedTokenForm({
    * Handles the form submission
    */
   const onSubmit = async ({title, description}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     try {
       await updateLongLivedToken({
         tokenId: token.id,

--- a/web/src/components/forms/teams/add-user-to-team-form.tsx
+++ b/web/src/components/forms/teams/add-user-to-team-form.tsx
@@ -1,7 +1,6 @@
 import {Field, Form} from '@/components/form';
 import {config, brandNotebook} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {modifyMemberForTeam} from '@/hooks/teams-hooks';
 import {Action, INPUT_LIMITS, Role, roleDetails} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
@@ -18,7 +17,7 @@ export function AddUserToTeamForm({
   setDialogOpen,
   teamId,
 }: AddUserToTeamFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
 
   // can we add a user to the team?
@@ -90,8 +89,6 @@ export function AddUserToTeamForm({
    * Handles the form submission
    */
   const onSubmit = async ({email, role}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await modifyMemberForTeam({
       action: 'ADD_ROLE',
       email,

--- a/web/src/components/forms/teams/create-team-form.tsx
+++ b/web/src/components/forms/teams/create-team-form.tsx
@@ -1,5 +1,5 @@
 import {Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {createTeam} from '@/hooks/teams-hooks';
 import {resourceNameSchema} from '@/lib/input-limits';
 import {INPUT_LIMITS} from '@faims3/data-model';
@@ -18,7 +18,7 @@ interface CreateTeamFormProps {
  * @returns {JSX.Element} The rendered CreateProjectForm component.
  */
 export function CreateTeamForm({setDialogOpen}: CreateTeamFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
 
   const fields = [
@@ -52,8 +52,6 @@ export function CreateTeamForm({setDialogOpen}: CreateTeamFormProps) {
    * Handles the form submission
    */
   const onSubmit = async ({name, description}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await createTeam({description, name, user});
 
     if (!response.ok) return {type: 'submit', message: 'Error creating team'};

--- a/web/src/components/forms/teams/create-team-invite-form.tsx
+++ b/web/src/components/forms/teams/create-team-invite-form.tsx
@@ -1,8 +1,7 @@
 import {ExpirySelector} from '@/components/expiry-selector';
 import {Field, Form} from '@/components/form';
 import {config, brandNotebook} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {userCanDo} from '@/hooks/auth-hooks';
+import {userCanDo, useRequiredUser} from '@/hooks/auth-hooks';
 import {
   INPUT_LIMITS,
   PostCreateInviteInput,
@@ -13,7 +12,6 @@ import {
   teamInviteToAction,
 } from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
-import {ErrorComponent} from '@tanstack/react-router';
 import {useMemo, useState} from 'react';
 import {z} from 'zod';
 
@@ -32,7 +30,7 @@ export function CreateTeamInviteForm({
   setDialogOpen,
   teamId,
 }: UpdateTemplateFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
   const [selectedDateTime, setSelectedDateTime] = useState<string | undefined>(
     undefined
@@ -42,7 +40,6 @@ export function CreateTeamInviteForm({
   // Hides brand-excluded roles (e.g. DASS hides TEAM_MEMBER_CREATOR) and
   // passes the description so the dropdown shows the new role copy.
   const roleOptions = useMemo(() => {
-    if (!user) return [];
     return Object.entries(roleDetails)
       .filter(
         ([role, {scope, resource}]) =>
@@ -64,10 +61,6 @@ export function CreateTeamInviteForm({
         description: brandNotebook(description),
       }));
   }, [user, teamId]);
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated" />;
-  }
 
   const fields: Field[] = [
     {
@@ -116,8 +109,6 @@ export function CreateTeamInviteForm({
     uses?: number;
     name: string;
   }) => {
-    if (!user) return {type: 'submit', message: 'Not logged in'};
-
     // Validate expiry selection
     if (!selectedDateTime) {
       return {type: 'submit', message: 'Please select an expiry date'};

--- a/web/src/components/forms/teams/update-team-form.tsx
+++ b/web/src/components/forms/teams/update-team-form.tsx
@@ -1,5 +1,5 @@
 import {Form} from '@/components/form';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {updateTeam} from '@/hooks/teams-hooks';
 import {resourceNameSchema} from '@/lib/input-limits';
 import {INPUT_LIMITS} from '@faims3/data-model';
@@ -26,7 +26,7 @@ export function UpdateTeamForm({
   teamId,
   description,
 }: UpdateTeamFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const QueryClient = useQueryClient();
 
   const fields = [
@@ -60,8 +60,6 @@ export function UpdateTeamForm({
    * Handles the form submission
    */
   const onSubmit = async ({name, description}: onSubmitProps) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const response = await updateTeam({description, name, user, teamId});
 
     if (!response.ok) return {type: 'submit', message: 'Error updating team'};

--- a/web/src/components/forms/update-project-form.tsx
+++ b/web/src/components/forms/update-project-form.tsx
@@ -1,4 +1,4 @@
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {Form} from '@/components/form';
 import {readFileAsText} from '@/lib/utils';
 import {designFileSchema} from '@/lib/input-limits';
@@ -30,12 +30,10 @@ export function UpdateProjectForm({
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onSuccess: () => void;
 }) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {projectId} = Route.useParams();
 
   const onSubmit = async ({file}: {file: File}) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const jsonString = await readFileAsText(file);
 
     if (!jsonString) return {type: 'submit', message: 'Error reading file'};

--- a/web/src/components/forms/update-template-form.tsx
+++ b/web/src/components/forms/update-template-form.tsx
@@ -1,4 +1,4 @@
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {Form} from '@/components/form';
 import {readFileAsText} from '@/lib/utils';
 import {designFileSchema} from '@/lib/input-limits';
@@ -32,12 +32,10 @@ export function UpdateTemplateForm({
   setDialogOpen,
   onSuccess,
 }: UpdateTemplateFormProps) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {templateId} = Route.useParams();
 
   const onSubmit = async ({file}: {file: File}) => {
-    if (!user) return {type: 'submit', message: 'User not authenticated'};
-
     const jsonString = await readFileAsText(file);
 
     if (!jsonString) return {type: 'submit', message: 'Error reading file'};

--- a/web/src/components/popovers/add-role-popover.tsx
+++ b/web/src/components/popovers/add-role-popover.tsx
@@ -1,5 +1,5 @@
 import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {RoleCard} from '@/components/ui/role-card';
 import {useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
@@ -30,7 +30,7 @@ export const AddRolePopover = ({
   roles: RoleDetailWithId[];
   userId: string;
 }) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
 
@@ -74,7 +74,7 @@ export const AddRolePopover = ({
                     method: 'POST',
                     headers: {
                       'Content-Type': 'application/json',
-                      Authorization: `Bearer ${user?.token}`,
+                      Authorization: `Bearer ${user.token}`,
                     },
                     body: JSON.stringify({
                       addrole: true,

--- a/web/src/components/popovers/add-team-role-popover.tsx
+++ b/web/src/components/popovers/add-team-role-popover.tsx
@@ -1,5 +1,5 @@
 import {Popover, PopoverContent, PopoverTrigger} from '../ui/popover';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {RoleCard} from '../ui/role-card';
 import {useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
@@ -26,13 +26,9 @@ export const AddTeamRolePopover = ({
   userId: string;
   teamId: string;
 }) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
-
-  if (!user) {
-    return <p>Unauthenticated</p>;
-  }
 
   if (roles.length === 0) {
     return (

--- a/web/src/components/side-bar/app-sidebar.tsx
+++ b/web/src/components/side-bar/app-sidebar.tsx
@@ -12,8 +12,7 @@ import {
   SidebarRail,
 } from '@/components/ui/sidebar';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetProjects, useGetTeams, useGetTemplates} from '@/hooks/queries';
 import {Action, GetListTemplatesResponse} from '@faims3/data-model';
 import {Link, useLocation} from '@tanstack/react-router';
@@ -32,10 +31,10 @@ import Logo from '../logo';
  * based on the authenticated user's data, including projects and templates.
  *
  * @param {React.ComponentProps<typeof Sidebar>} props - The properties to pass to the Sidebar component.
- * @returns {JSX.Element} The rendered sidebar component, or an empty fragment if no user is authenticated.
+ * @returns {JSX.Element} The rendered sidebar component.
  */
 export function AppSidebar({...props}: React.ComponentProps<typeof Sidebar>) {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {pathname} = useLocation();
 
@@ -50,8 +49,6 @@ export function AppSidebar({...props}: React.ComponentProps<typeof Sidebar>) {
   const {data: projects} = useGetProjects({user, enabled: canSeeProjects});
   const {data: templates} = useGetTemplates({user, enabled: canSeeTemplates});
   const {data: teams} = useGetTeams({user, enabled: canSeeTeams});
-
-  if (!user) return <></>;
 
   const topSectionNavItems: NavItem[] = [];
   const bottomSectionNavItems: NavItem[] = [];

--- a/web/src/components/tables/cells/team-cell.tsx
+++ b/web/src/components/tables/cells/team-cell.tsx
@@ -1,5 +1,5 @@
 import {Skeleton} from '@/components/ui/skeleton';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeam} from '@/hooks/queries';
 import {Link} from '@tanstack/react-router';
 
@@ -20,7 +20,7 @@ export const TeamCellComponent = ({
   teamId,
   teamDisplayName,
 }: TeamCellComponentProps) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const hasInjectedName =
     teamDisplayName !== undefined && teamDisplayName.length > 0;
 
@@ -33,10 +33,6 @@ export const TeamCellComponent = ({
     teamId,
     enabled: !hasInjectedName,
   });
-
-  if (!user) {
-    return <p>Unauthenticated</p>;
-  }
 
   const displayLabel = hasInjectedName
     ? teamDisplayName

--- a/web/src/components/tables/cells/template-cell.tsx
+++ b/web/src/components/tables/cells/template-cell.tsx
@@ -1,5 +1,5 @@
 import {Skeleton} from '@/components/ui/skeleton';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTemplate} from '@/hooks/queries';
 import {Link} from '@tanstack/react-router';
 
@@ -14,17 +14,13 @@ interface TemplateCellComponentProps {
 export const TemplateCellComponent = ({
   templateId,
 }: TemplateCellComponentProps) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {
     data: template,
     isLoading,
     isError,
   } = useGetTemplate({user, templateId});
-
-  if (!user) {
-    return <p>Unauthenticated</p>;
-  }
 
   return isLoading ? (
     <Skeleton className="h-5 w-24" />

--- a/web/src/components/tables/global-invites.tsx
+++ b/web/src/components/tables/global-invites.tsx
@@ -9,7 +9,6 @@ import {
   roleDetails,
 } from '@faims3/data-model';
 import {displayDateTime} from '@/lib/time';
-import {useAuth} from '@/context/auth-provider';
 import {useQueryClient} from '@tanstack/react-query';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {Trash} from 'lucide-react';
@@ -29,16 +28,11 @@ export const useGetGlobalInviteColumns = ({
 }): ColumnDef<
   GetGlobalInvitesResponse[number] & {url: string; qrCode: string}
 >[] => {
-  const {user} = useAuth();
   const queryClient = useQueryClient();
 
   const canRemoveSomeInvite = useIsAuthorisedTo({
     action: Action.DELETE_GLOBAL_INVITE,
   });
-
-  if (!user) {
-    return [];
-  }
 
   const baseColumns: ColumnDef<
     GetGlobalInvitesResponse[number] & {url: string; qrCode: string}

--- a/web/src/components/tables/long-lived-tokens.tsx
+++ b/web/src/components/tables/long-lived-tokens.tsx
@@ -1,5 +1,4 @@
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {displayDateTime, nowMs} from '@/lib/time';
 import {Action, GetLongLivedTokensResponse} from '@faims3/data-model';
 import {ColumnDef} from '@tanstack/react-table';
@@ -22,7 +21,7 @@ export const useGetLongLivedTokensColumns = ({
   revokeTokenHandler?: (tokenId: string) => Promise<void>;
   editTokenHandler?: (tokenId: string) => void;
 }): ColumnDef<GetLongLivedTokensResponse['tokens'][number]>[] => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   // Check permissions
   const canEditMyTokens = useIsAuthorisedTo({
@@ -37,10 +36,6 @@ export const useGetLongLivedTokensColumns = ({
   const canRevokeAnyTokens = useIsAuthorisedTo({
     action: Action.REVOKE_ANY_LONG_LIVED_TOKEN,
   });
-
-  if (!user) {
-    return [];
-  }
 
   const canEditToken = (tokenUserId: string) =>
     tokenUserId === user.user.id ? canEditMyTokens : canEditAnyTokens;

--- a/web/src/components/tables/project-invites.tsx
+++ b/web/src/components/tables/project-invites.tsx
@@ -11,9 +11,12 @@ import {
   projectInviteToAction,
 } from '@faims3/data-model';
 import {displayDateTime} from '@/lib/time';
-import {useAuth} from '@/context/auth-provider';
 import {useQueryClient} from '@tanstack/react-query';
-import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
+import {
+  useIsAuthorisedTo,
+  userCanDo,
+  useRequiredUser,
+} from '@/hooks/auth-hooks';
 import {Trash} from 'lucide-react';
 import {
   Tooltip,
@@ -34,7 +37,7 @@ export const useGetInviteColumns = ({
 }): ColumnDef<
   GetProjectInvitesResponse[number] & {url: string; qrCode: string}
 >[] => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   const canDeleteAdminInvite = useIsAuthorisedTo({
@@ -53,10 +56,6 @@ export const useGetInviteColumns = ({
     action: Action.DELETE_GUEST_PROJECT_INVITE,
     resourceId: projectId,
   });
-
-  if (!user) {
-    return [];
-  }
 
   const canRemoveSomeInvite =
     canDeleteAdminInvite ||

--- a/web/src/components/tables/team-invites.tsx
+++ b/web/src/components/tables/team-invites.tsx
@@ -11,9 +11,12 @@ import {
   teamInviteToAction,
 } from '@faims3/data-model';
 import {displayDateTime} from '@/lib/time';
-import {useAuth} from '@/context/auth-provider';
 import {useQueryClient} from '@tanstack/react-query';
-import {useIsAuthorisedTo, userCanDo} from '@/hooks/auth-hooks';
+import {
+  useIsAuthorisedTo,
+  userCanDo,
+  useRequiredUser,
+} from '@/hooks/auth-hooks';
 import {Trash} from 'lucide-react';
 import {
   Tooltip,
@@ -33,7 +36,7 @@ export const useGetTeamInviteColumns = ({
 }): ColumnDef<
   GetTeamInvitesResponse[number] & {url: string; qrCode: string}
 >[] => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   const canDeleteAdminInvite = useIsAuthorisedTo({
@@ -48,10 +51,6 @@ export const useGetTeamInviteColumns = ({
     action: Action.DELETE_MEMBER_TEAM_INVITE,
     resourceId: teamId,
   });
-
-  if (!user) {
-    return [];
-  }
 
   const canRemoveSomeInvite =
     canDeleteAdminInvite || canDeleteManagerInvite || canDeleteMemberInvite;

--- a/web/src/components/tables/team-users.tsx
+++ b/web/src/components/tables/team-users.tsx
@@ -1,4 +1,3 @@
-import {useAuth} from '@/context/auth-provider';
 import {modifyMemberForTeam} from '@/hooks/teams-hooks';
 import {
   Action,
@@ -20,14 +19,14 @@ import {DataTableColumnHeader} from '../data-table/column-header';
 import {AddTeamRolePopover} from '../popovers/add-team-role-popover';
 import {Button} from '../ui/button';
 import {RoleCard} from '../ui/role-card';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 
 export const useGetColumns = ({
   teamId,
 }: {
   teamId: string;
 }): ColumnDef<GetTeamMembersResponse['members'][number]>[] => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   const canRemoveAdmin = useIsAuthorisedTo({
@@ -54,10 +53,6 @@ export const useGetColumns = ({
     action: Action.ADD_ADMIN_TO_TEAM,
     resourceId: teamId,
   });
-
-  if (!user) {
-    return [];
-  }
 
   const rolesAvailable: Role[] = [];
   if (canAddMemberToTeam) {

--- a/web/src/components/tables/users.tsx
+++ b/web/src/components/tables/users.tsx
@@ -1,4 +1,4 @@
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {
   GetListAllUsersItem,
   Role,
@@ -29,7 +29,7 @@ export const useUsersColumns = ({
 }: {
   onReset: (id: string) => void;
 }): ColumnDef<GetListAllUsersItem>[] => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
 
   return [
@@ -59,7 +59,7 @@ export const useUsersColumns = ({
         },
       }) => (
         <div className="flex flex-wrap gap-1 items-center">
-          {userId !== user?.user.id && (
+          {userId !== user.user.id && (
             <AddRolePopover
               roles={Object.entries(roleDetails)
                 .filter(([, {scope}]) => scope === RoleScope.GLOBAL)
@@ -71,7 +71,7 @@ export const useUsersColumns = ({
             <RoleCard
               key={role}
               onRemove={
-                userId === user?.user.id
+                userId === user.user.id
                   ? undefined
                   : async () => {
                       try {
@@ -81,7 +81,7 @@ export const useUsersColumns = ({
                             method: 'POST',
                             headers: {
                               'Content-Type': 'application/json',
-                              Authorization: `Bearer ${user?.token}`,
+                              Authorization: `Bearer ${user.token}`,
                             },
                             body: JSON.stringify({
                               addrole: false,

--- a/web/src/components/tabs/admin/global-invites.tsx
+++ b/web/src/components/tabs/admin/global-invites.tsx
@@ -2,12 +2,10 @@ import {DataTable} from '@/components/data-table/data-table';
 import {CreateGlobalInvite} from '@/components/dialogs/create-global-invite';
 import {useGetGlobalInviteColumns} from '@/components/tables/global-invites';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetGlobalInvites} from '@/hooks/queries';
 import {removeGlobalInvite} from '@/hooks/global-hooks';
 import {Action} from '@faims3/data-model';
-import {ErrorComponent} from '@tanstack/react-router';
 
 /**
  * GlobalInvites component renders a table of global invites.
@@ -16,7 +14,7 @@ import {ErrorComponent} from '@tanstack/react-router';
  * @returns {JSX.Element} The rendered GlobalInvites component.
  */
 const GlobalInvites = () => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {data, isLoading} = useGetGlobalInvites({
     user,
@@ -25,7 +23,6 @@ const GlobalInvites = () => {
 
   const columns = useGetGlobalInviteColumns({
     deleteInviteHandler: async (inviteId: string) => {
-      if (!user) throw new Error('Not authenticated');
       return await removeGlobalInvite({inviteId, user});
     },
   });
@@ -33,10 +30,6 @@ const GlobalInvites = () => {
   const canCreateGlobalInvite = useIsAuthorisedTo({
     action: Action.CREATE_GLOBAL_INVITE,
   });
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated" />;
-  }
 
   return (
     <DataTable

--- a/web/src/components/tabs/project/actions.tsx
+++ b/web/src/components/tabs/project/actions.tsx
@@ -10,13 +10,16 @@ import {Button} from '@/components/ui/button';
 import {Card} from '@/components/ui/card';
 import {List, ListDescription, ListItem, ListLabel} from '@/components/ui/list';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
 import {
   toDesignerNotebookWithHistory,
   useDesignerSaveMutation,
 } from '@/designer/integration';
 import type {NotebookWithHistory} from '@/designer/state/initial';
-import {useCanCreateTemplate, useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {
+  useCanCreateTemplate,
+  useIsAuthorisedTo,
+  useRequiredUser,
+} from '@/hooks/auth-hooks';
 import {useGetProject} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/projects/$projectId';
 import {Action, ProjectStatus} from '@faims3/data-model';
@@ -33,7 +36,7 @@ import {useMemo, useState} from 'react';
  * @returns {JSX.Element} The rendered ProjectActions component.
  */
 const ProjectActions = (): JSX.Element => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {projectId} = Route.useParams();
   const {data, isLoading} = useGetProject({user, projectId});
   const queryClient = useQueryClient();
@@ -50,7 +53,7 @@ const ProjectActions = (): JSX.Element => {
     resourceType: 'projects',
     apiResourceType: 'notebooks',
     resourceId: projectId,
-    token: user?.token,
+    token: user.token,
   });
 
   // need to invalidate the project query after upload

--- a/web/src/components/tabs/project/invites.tsx
+++ b/web/src/components/tabs/project/invites.tsx
@@ -2,12 +2,10 @@ import {DataTable} from '@/components/data-table/data-table';
 import {CreateProjectInvite} from '@/components/dialogs/create-project-invite';
 import {useGetInviteColumns} from '@/components/tables/project-invites';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {removeInviteForProject} from '@/hooks/project-hooks';
 import {useGetProjectInvites} from '@/hooks/queries';
 import {Action} from '@faims3/data-model';
-import {ErrorComponent} from '@tanstack/react-router';
 
 /**
  * ProjectInvites component renders a table of invites for a project.
@@ -17,7 +15,7 @@ import {ErrorComponent} from '@tanstack/react-router';
  * @returns {JSX.Element} The rendered ProjectInvites component.
  */
 const ProjectInvites = ({projectId}: {projectId: string}) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {data, isLoading} = useGetProjectInvites({
     user,
@@ -30,7 +28,6 @@ const ProjectInvites = ({projectId}: {projectId: string}) => {
   const columns = useGetInviteColumns({
     projectId,
     deleteInviteHandler: async inviteId => {
-      if (!user) throw new Error('Not authenticated');
       return await removeInviteForProject({inviteId, projectId, user});
     },
   });
@@ -51,10 +48,6 @@ const ProjectInvites = ({projectId}: {projectId: string}) => {
     action: Action.CREATE_ADMIN_PROJECT_INVITE,
     resourceId: projectId,
   });
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated" />;
-  }
 
   const canInviteSomeUser =
     canInviteAdminToTeam ||

--- a/web/src/components/tabs/project/offline-map.tsx
+++ b/web/src/components/tabs/project/offline-map.tsx
@@ -15,8 +15,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {updateNotebookOfflineMapRegionRequest} from '@/hooks/project-hooks';
 import {useGetProject} from '@/hooks/queries';
 import {LARGE_OFFLINE_MAP_AREA_MB} from '@/lib/offline-map-size';
@@ -151,7 +150,7 @@ function OfflineMapStatusBox({
 export default function ProjectOfflineMap({
   projectId,
 }: ProjectOfflineMapProps): JSX.Element {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const queryClient = useQueryClient();
   const {data: project, isLoading} = useGetProject({user, projectId});
   const canSetOfflineMapRegion = useIsAuthorisedTo({
@@ -206,9 +205,6 @@ export default function ProjectOfflineMap({
 
   const saveMutation = useMutation({
     mutationFn: async (region: OfflineMapRegion | null) => {
-      if (!user) {
-        throw new Error('Not signed in');
-      }
       const response = await updateNotebookOfflineMapRegionRequest({
         user,
         projectId,
@@ -231,9 +227,6 @@ export default function ProjectOfflineMap({
 
   const clearMutation = useMutation({
     mutationFn: async () => {
-      if (!user) {
-        throw new Error('Not signed in');
-      }
       const response = await updateNotebookOfflineMapRegionRequest({
         user,
         projectId,

--- a/web/src/components/tabs/teams/team-invites.tsx
+++ b/web/src/components/tabs/teams/team-invites.tsx
@@ -2,12 +2,10 @@ import {DataTable} from '@/components/data-table/data-table';
 import {CreateTeamInvite} from '@/components/dialogs/teams/create-team-invite';
 import {useGetTeamInviteColumns} from '@/components/tables/team-invites';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTeamInvites} from '@/hooks/queries';
 import {removeInviteForTeam} from '@/hooks/teams-hooks';
 import {Action} from '@faims3/data-model';
-import {ErrorComponent} from '@tanstack/react-router';
 
 /**
  * ProjectInvites component renders a table of invites for a project.
@@ -17,7 +15,7 @@ import {ErrorComponent} from '@tanstack/react-router';
  * @returns {JSX.Element} The rendered ProjectInvites component.
  */
 const TeamInvites = ({teamId}: {teamId: string}) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {data, isLoading} = useGetTeamInvites({
     user,
@@ -28,7 +26,6 @@ const TeamInvites = ({teamId}: {teamId: string}) => {
   const columns = useGetTeamInviteColumns({
     teamId,
     deleteInviteHandler: async inviteId => {
-      if (!user) throw new Error('Not authenticated');
       return await removeInviteForTeam({teamId, inviteId, user});
     },
   });
@@ -45,10 +42,6 @@ const TeamInvites = ({teamId}: {teamId: string}) => {
     action: Action.CREATE_ADMIN_TEAM_INVITE,
     resourceId: teamId,
   });
-
-  if (!user) {
-    return <ErrorComponent error="Not authenticated" />;
-  }
 
   const canAddSomeUser =
     canInviteAdminToTeam || canInviteManagerToTeam || canInviteMemberToTeam;

--- a/web/src/components/tabs/teams/team-templates.tsx
+++ b/web/src/components/tabs/teams/team-templates.tsx
@@ -2,8 +2,7 @@ import {DataTable} from '@/components/data-table/data-table';
 import type {ColumnDef} from '@tanstack/react-table';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
 import {getTemplatesTableColumns} from '@/components/tables/templates';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTemplatesForTeam} from '@/hooks/queries';
 import {
   Action,
@@ -22,7 +21,7 @@ import {
 type TemplateListRow = GetListTemplatesResponse['templates'][number];
 
 const TeamTemplates = ({teamId}: {teamId: string}) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {isPending, data} = useGetTemplatesForTeam({user, teamId});
   const [visibilityFilter, setVisibilityFilter] =
     useState<TemplateVisibilityFilterValue>('all');
@@ -41,14 +40,14 @@ const TeamTemplates = ({teamId}: {teamId: string}) => {
       getTemplatesTableColumns({
         hideTeamColumn: true,
         includeVisibility: globalRolesGrantAction(
-          user?.decodedToken ?? {
+          user.decodedToken ?? {
             globalRoles: [],
             resourceRoles: [],
           },
           Action.CHANGE_TEMPLATE_VISIBILITY
         ),
       }),
-    [user?.decodedToken]
+    [user.decodedToken]
   );
 
   const filteredTemplates = useMemo(

--- a/web/src/components/tabs/teams/team-users.tsx
+++ b/web/src/components/tabs/teams/team-users.tsx
@@ -1,15 +1,13 @@
 import {DataTable} from '@/components/data-table/data-table';
 import {AddTeamUserDialog} from '@/components/dialogs/teams/add-team-user-dialog';
 import {useGetColumns} from '@/components/tables/team-users';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetUsersForTeam} from '@/hooks/queries';
 import {Action} from '@faims3/data-model';
-import {ErrorComponent} from '@tanstack/react-router';
 import {LoaderCircle, Plus} from 'lucide-react';
 
 const TeamUsers = ({teamId}: {teamId: string}) => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {isLoading, data} = useGetUsersForTeam({user, teamId});
 
@@ -27,10 +25,6 @@ const TeamUsers = ({teamId}: {teamId: string}) => {
   });
 
   const columns = useGetColumns({teamId});
-
-  if (!user) {
-    return <ErrorComponent error="Unauthenticated" />;
-  }
 
   const canAddSomeUser =
     canAddAdminToTeam || canAddManagerToTeam || canAddMemberToTeam;

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -6,7 +6,6 @@ import {config} from '@/constants';
 import {ProjectFromTemplateDialog} from '@/components/dialogs/project-from-template';
 import {Button} from '@/components/ui/button';
 import {Card} from '@/components/ui/card';
-import {useAuth} from '@/context/auth-provider';
 import {useGetTemplate} from '@/hooks/queries';
 import {Route} from '@/routes/_protected/templates/$templateId';
 import {useQueryClient} from '@tanstack/react-query';
@@ -15,7 +14,7 @@ import type {NotebookWithHistory} from '@/designer/state/initial';
 import {EditTemplateDialog} from '@/components/dialogs/edit-template';
 import {EditTemplateDetailsDialog} from '@/components/dialogs/edit-template-details-dialog';
 import {Action, getUserResourcesForAction} from '@faims3/data-model';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {AddTemplateToTeamDialog} from '@/components/dialogs/add-template-to-team-dialog';
 import {
   Tooltip,
@@ -36,7 +35,7 @@ import {
  * @returns {JSX.Element} The rendered TemplateActions component.
  */
 const TemplateActions = () => {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {templateId} = Route.useParams();
   const {data, isLoading} = useGetTemplate({user, templateId});
   const queryClient = useQueryClient();
@@ -47,7 +46,7 @@ const TemplateActions = () => {
     resourceType: 'templates',
     apiResourceType: 'templates',
     resourceId: templateId,
-    token: user?.token,
+    token: user.token,
   });
 
   const initialNotebook = useMemo<NotebookWithHistory | undefined>(() => {
@@ -102,7 +101,7 @@ const TemplateActions = () => {
   const canCreateProjectFromTemplate =
     canCreateProject ||
     getUserResourcesForAction({
-      decodedToken: user?.decodedToken,
+      decodedToken: user.decodedToken,
       action: Action.CREATE_PROJECT_IN_TEAM,
     }).length > 0;
 

--- a/web/src/hooks/auth-hooks.ts
+++ b/web/src/hooks/auth-hooks.ts
@@ -8,6 +8,29 @@ import {
 import {useMemo} from 'react';
 
 /**
+ * Returns the authenticated user, asserting it is present.
+ *
+ * Every route under `_protected` renders `SessionExpiredOverlay` instead of
+ * the `<Outlet />` when the user is null or expired, so components below that
+ * layout can never render without a user. This hook exists so those
+ * components can take a non-null `User` directly instead of each hand-rolling
+ * an `if (!user)` guard (dead code that also forces hooks-ordering gymnastics
+ * under `react/rules-of-hooks`).
+ *
+ * @throws If called outside an authenticated route — a programming error, not
+ *   a reachable user state.
+ */
+export const useRequiredUser = (): User => {
+  const {user} = useAuth();
+  if (!user) {
+    throw new Error(
+      'useRequiredUser rendered without an authenticated user. It must only be used under the _protected route layout.'
+    );
+  }
+  return user;
+};
+
+/**
  * helper to map our user to the isAuthorized user
  */
 export const userCanDo = ({

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -542,17 +542,16 @@ export const useGetLongLivedTokens = ({
   user,
   fetchAll,
 }: {
-  user: User | undefined | null;
+  user: User;
   fetchAll: boolean;
 }) =>
   useQuery({
-    queryKey: ['long-lived-tokens', user?.user.id, fetchAll],
+    queryKey: ['long-lived-tokens', user.user.id, fetchAll],
     queryFn: () =>
       get<GetLongLivedTokensResponse>(
         '/api/long-lived-tokens' + (fetchAll ? '?all=true' : ''),
-        user!
+        user
       ),
-    enabled: !!user,
   });
 
 /**

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -239,13 +239,13 @@ export const useGetTemplatesForTeam = ({
   });
 
 /**
- * @param {User | null} user - The user object.
+ * @param {User} user - The user object.
  */
 export const useGetUsersForTeam = ({
   teamId,
   user,
 }: {
-  user: User | null;
+  user: User;
   teamId: string;
 }) =>
   useQuery({
@@ -256,7 +256,6 @@ export const useGetUsersForTeam = ({
         user
       )) as GetTeamMembersResponse;
     },
-    enabled: !!user,
   });
 
 /**

--- a/web/src/routes/_protected/profile/index.tsx
+++ b/web/src/routes/_protected/profile/index.tsx
@@ -2,12 +2,12 @@ import {Button} from '@/components/ui/button';
 import {Card} from '@/components/ui/card';
 import {List, ListDescription, ListItem, ListLabel} from '@/components/ui/list';
 import {config} from '@/constants';
-import {useAuth, User} from '@/context/auth-provider';
+import {User} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
 import {createFileRoute, Link} from '@tanstack/react-router';
 import {CheckCircle, Key, ShieldAlert, XCircle} from 'lucide-react';
 import React, {useMemo} from 'react';
-import {toast} from 'sonner';
 
 export const Route = createFileRoute('/_protected/profile/')({
   component: RouteComponent,
@@ -50,7 +50,7 @@ const userFields: {
  * @returns {JSX.Element} The rendered RouteComponent component.
  */
 function RouteComponent() {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   // breadcrumbs addition
   const paths = useMemo(
@@ -73,12 +73,7 @@ function RouteComponent() {
    */
   const handleChangePassword = () => {
     // Get the username (email) from the user object
-    const username = user?.user.id;
-
-    if (!username) {
-      toast.error('Unable to identify user for password change');
-      return;
-    }
+    const username = user.user.id;
 
     // Create the redirect URL back to the profile page
     const redirectUrl = config.webUrl + '/profile';
@@ -100,7 +95,7 @@ function RouteComponent() {
               <ListItem key={field}>
                 <ListLabel>{label}</ListLabel>
                 <ListDescription>
-                  {render ? render(user?.user[field]) : user?.user[field]}
+                  {render ? render(user.user[field]) : user.user[field]}
                 </ListDescription>
               </ListItem>
             ))}

--- a/web/src/routes/_protected/profile/long-lived-tokens.tsx
+++ b/web/src/routes/_protected/profile/long-lived-tokens.tsx
@@ -14,14 +14,13 @@ import {Label} from '@/components/ui/label';
 import {Separator} from '@/components/ui/separator';
 import {Switch} from '@/components/ui/switch';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {revokeLongLivedToken, useGetLongLivedTokens} from '@/hooks/queries';
 import {nowMs} from '@/lib/time';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
 import {Action, GetLongLivedTokensResponse} from '@faims3/data-model';
 import {useQueryClient} from '@tanstack/react-query';
-import {createFileRoute, ErrorComponent} from '@tanstack/react-router';
+import {createFileRoute} from '@tanstack/react-router';
 import {RefreshCw, AlertTriangle, ExternalLink} from 'lucide-react';
 import {useMemo, useState} from 'react';
 
@@ -36,7 +35,7 @@ export const Route = createFileRoute('/_protected/profile/long-lived-tokens')({
  * @returns {JSX.Element} The rendered RouteComponent component.
  */
 function RouteComponent() {
-  const {user: authUser} = useAuth();
+  const authUser = useRequiredUser();
   const queryClient = useQueryClient();
 
   const paths = useMemo(
@@ -105,15 +104,10 @@ function RouteComponent() {
       }
     },
     revokeTokenHandler: async tokenId => {
-      if (!authUser) return;
       await revokeLongLivedToken({user: authUser, tokenId});
       queryClient.invalidateQueries({queryKey: ['long-lived-tokens']});
     },
   });
-
-  if (!authUser) {
-    return <ErrorComponent error={'Not authorised'} />;
-  }
 
   return (
     <div className="flex flex-col gap-6">

--- a/web/src/routes/_protected/projects/index.tsx
+++ b/web/src/routes/_protected/projects/index.tsx
@@ -2,8 +2,7 @@ import {DataTable} from '@/components/data-table/data-table';
 import {CreateProjectDialog} from '@/components/dialogs/create-project-dialog';
 import {columns} from '@/components/tables/projects';
 import {config} from '@/constants';
-import {useAuth} from '@/context/auth-provider';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetProjects} from '@/hooks/queries';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
 import {Action, getUserResourcesForAction} from '@faims3/data-model';
@@ -21,14 +20,14 @@ export const Route = createFileRoute('/_protected/projects/')({
  * @returns {JSX.Element} The rendered RouteComponent component.
  */
 function ProjectsRouteComponent() {
-  const {user} = useAuth();
+  const user = useRequiredUser();
 
   const {isLoading, data} = useGetProjects({user});
   const pathname = useRouter().state.location.pathname;
   const canCreateGlobally = useIsAuthorisedTo({action: Action.CREATE_PROJECT});
   const canCreateInSomeTeam =
     getUserResourcesForAction({
-      decodedToken: user?.decodedToken,
+      decodedToken: user.decodedToken,
       action: Action.CREATE_PROJECT_IN_TEAM,
     }).length > 0;
 

--- a/web/src/routes/_protected/teams/index.tsx
+++ b/web/src/routes/_protected/teams/index.tsx
@@ -1,11 +1,10 @@
 import {DataTable} from '@/components/data-table/data-table';
 import {columns} from '@/components/tables/teams';
-import {useAuth} from '@/context/auth-provider';
 import {useGetTeams} from '@/hooks/queries';
 import {createFileRoute, useNavigate, useRouter} from '@tanstack/react-router';
 
 import {CreateTeamDialog} from '@/components/dialogs/teams/create-team-dialog';
-import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useIsAuthorisedTo, useRequiredUser} from '@/hooks/auth-hooks';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
 import {Action} from '@faims3/data-model';
 import {useMemo} from 'react';
@@ -21,7 +20,7 @@ export const Route = createFileRoute('/_protected/teams/')({
  * @returns {JSX.Element} The rendered RouteComponent component.
  */
 function RouteComponent() {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const pathname = useRouter().state.location.pathname;
 
   // breadcrumbs addition
@@ -44,10 +43,6 @@ function RouteComponent() {
   const canCreateTeam = useIsAuthorisedTo({action: Action.CREATE_TEAM});
   const {isPending, data} = useGetTeams({user});
   const navigate = useNavigate();
-
-  if (!user) {
-    return <p>No user!</p>;
-  }
 
   return (
     <div className="flex flex-col gap-6">

--- a/web/src/routes/_protected/templates/index.tsx
+++ b/web/src/routes/_protected/templates/index.tsx
@@ -2,7 +2,7 @@ import {createFileRoute, useNavigate} from '@tanstack/react-router';
 import type {ColumnDef} from '@tanstack/react-table';
 import {DataTable} from '@/components/data-table/data-table';
 import {getTemplatesTableColumns} from '@/components/tables/templates';
-import {useAuth} from '@/context/auth-provider';
+import {useRequiredUser} from '@/hooks/auth-hooks';
 import {useGetTemplates} from '@/hooks/queries';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
@@ -32,7 +32,7 @@ export const Route = createFileRoute('/_protected/templates/')({
  * @returns {JSX.Element} The rendered RouteComponent component.
  */
 function RouteComponent() {
-  const {user} = useAuth();
+  const user = useRequiredUser();
   const {isPending, data} = useGetTemplates({user});
   const navigate = useNavigate();
   const [visibilityFilter, setVisibilityFilter] =
@@ -59,14 +59,14 @@ function RouteComponent() {
     () =>
       getTemplatesTableColumns({
         includeVisibility: globalRolesGrantAction(
-          user?.decodedToken ?? {
+          user.decodedToken ?? {
             globalRoles: [],
             resourceRoles: [],
           },
           Action.CHANGE_TEMPLATE_VISIBILITY
         ),
       }),
-    [user?.decodedToken]
+    [user.decodedToken]
   );
 
   const filteredTemplates = useMemo(


### PR DESCRIPTION
# refactor: rule-of-hooks follow-ups — static registry fallback, useRequiredUser

## Ticket

Follow-up to #2187 (targets its `feat/rule-of-hooks` branch).

## Description

Two refactors addressing review findings on #2187. Both keep the rules-of-hooks enforcement intact while removing the ceremony the mechanical fixes introduced.

## Proposed Changes

**1. `refactor(forms): import registry fallback directly instead of late-set mutable state`**

`registryApi.ts` used a mutable module-level `fallbackFieldInfo`, a `setRegistryFallback()` called from `registry.ts` at load time, and a runtime "fallback not initialised" throw in `getFieldInfo`. Any future entry point that loaded `DataView` without the `registry.ts` side-effect module (a unit test, a storybook story, a tree-shaken bundle) would have thrown at first render.

`registryApi.ts` now imports `textFieldSpec` directly as a constant fallback. This is cycle-safe: the text field's transitive imports (form types, fallback renderer types, MUI wrappers) never reach `DataView`, so the RelatedRecord → DataView → registry cycle the registryApi split breaks stays broken. Verified with `madge -c --extensions ts,tsx lib/` (no circular dependencies).

**2. `refactor(web): assert authenticated user once via useRequiredUser`**

Every component under `_protected` is unreachable without a user: `_protected.tsx` returns `<SessionExpiredOverlay />` *instead of* the `<Outlet />` whenever `isAuthenticated` (`!!user && !isExpired()`) is false, and `user` is initialised synchronously from localStorage. So the ~20 `if (!user) return <fallback/>` guards that #2187 had to reorder hooks around are dead code, as are the `if (!user) throw new Error('Not authenticated')` narrowing closures it added to the delete-invite handlers.

This adds a single `useRequiredUser()` hook that asserts the invariant once, converts those components to it, deletes the dead guards/throws/`return []` branches, and reverts the `useGetUsersForTeam` `User | null` + `enabled: !!user` widening (its only caller now passes a non-null user). Net −88 lines, and new components (e.g. plan views) get a non-null `User` without re-litigating where the guard goes.

## How to Test

- `pnpm turbo run build --filter=@faims3/forms` and `pnpm --filter @faims3/forms test` (51 tests pass)
- `library/forms`: `pnpm run lint` (includes the now-fatal `madge` circular-dep check)
- `web`: `pnpm run typecheck` and `pnpm run lint`
- In the web app: browse teams/invites/tokens pages while logged in (unchanged behaviour); log out or let the session expire — the `_protected` layout shows the session-expired overlay before any converted component renders.

## Additional Information

Reviewed pre-push by a multi-model panel (Claude, Codex, Cursor, Antigravity): no findings across circular-dependency, mount-reachability, rules-of-hooks, behavioural-regression, and memo-deps checks.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [ ] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
