### PR TITLE
fix: number field range defaults to blank instead of 0 to 100 (#2149)

### DIFF
--- a/web/src/designer/fields.tsx
+++ b/web/src/designer/fields.tsx
@@ -496,8 +496,6 @@ const fields: {[key: string]: FieldType} = {
       advancedHelperText: '',
       required: false,
       numberType: 'integer',
-      min: 0,
-      max: 100,
       InputProps: {
         type: 'number',
       },


### PR DESCRIPTION
# fix: number field range defaults to blank instead of 0 to 100 (#2149)

## JIRA Ticket

N/A (GitHub issue #2149)

## Description

New Number fields created in the designer defaulted to a range of 0 to 100. Users could easily miss this and then be unable to enter valid values in their forms. New Number fields now default to no limits, and adding a minimum/maximum is an explicit action in the field editor.

## Proposed Changes

- Removed the default `min: 0` and `max: 100` from the `NumberField` template in `web/src/designer/fields.tsx`

No other changes were needed:
- The field editor already treats blank Minimum/Maximum inputs as "no limit" (the params are deleted from the field spec when cleared) and its helper text already reads "Leave empty for no limit"
- The runtime field schema declares `min`/`max` as optional and only applies bound validation when they are defined
- `migrateV4` preserves configured `min`/`max` on existing notebooks, so fields with limits already set are unaffected

## How to Test

1. Log in to the web manager and open a template in the designer
2. Add a Number field — the Minimum and Maximum inputs should be empty
3. In the app, create a record and enter a value outside the old range (e.g. 5000) — no validation error
4. Set an explicit minimum/maximum on the field, re-enter an out-of-range value — validation fires (e.g. "Must be 500 or less")

## Additional Information

Closes #2149

**After — new Number field with blank limits:**

<img width="1763" height="735" alt="notebook" src="https://github.com/user-attachments/assets/9f1ee756-66f0-4a40-884c-c338150b52bd" />

Note: the designer's Preview toggle intentionally runs no validation (`PreviewFormManager` has no validators), so limit validation is only observable in record entry via the app. This is existing behaviour, unchanged by this PR.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.