### PR TITLE
refactor: replace axios with native fetch in api (#2050)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -35,7 +35,6 @@
     "@types/passport-openidconnect": "^0.1.3",
     "archiver": "^6.0.1",
     "aws-sdk": "^2.1664.0",
-    "axios": "^1.15.2",
     "body-parser": "1.20.3",
     "cache-manager": "^5.7.3",
     "cookie-session": "2.1.1",

--- a/api/src/auth/keySigning/initJWTKeys.ts
+++ b/api/src/auth/keySigning/initJWTKeys.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import {config, keyService} from '../../buildconfig';
 
 export async function initialiseJWTKey(): Promise<void> {
@@ -9,7 +8,9 @@ export async function initialiseJWTKey(): Promise<void> {
     const signingKey = await keyService.getSigningKey();
 
     // Ensure new lines are encoded properly in the config file
-    const publicKey = signingKey.publicKeyString.replace(/\n/g, '\\n');
+    const publicKey = signingKey.publicKeyString
+      .replace(/\r/g, '')
+      .replace(/\n/g, '\\n');
 
     // _local means referencing the specific node to which this URL references -
     // if in clustering situation would need to be more careful
@@ -18,17 +19,35 @@ export async function initialiseJWTKey(): Promise<void> {
     // rsa:kid format
     const keyName = `rsa:${signingKey.kid}`;
 
+    // basic auth header (fetch has no equivalent of axios' auth option)
+    const {username, password} = config.localCouchdbAuth;
+    const authHeader =
+      'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+
     // use the couch DB config API to put the updated jwt_keys/rsa:kid value
-    await axios.put(
+    const response = await fetch(
       `${couchdbConfigUrl}${encodeURIComponent(keyName)}`,
-      JSON.stringify(publicKey),
       {
-        auth: config.localCouchdbAuth,
-        headers: {'Content-Type': 'application/json'},
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: authHeader,
+        },
+        body: JSON.stringify(publicKey),
       }
     );
+
+    // unlike axios, fetch does not throw on HTTP error status codes
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(
+        `CouchDB responded with status ${response.status}: ${body}`
+      );
+    }
+
     console.log('JWT public key configured in CouchDB');
   } catch (error) {
+    console.error('JWT key configuration error:', error);
     throw new Error('Failed to configure JWT public key in CouchDB');
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
       aws-sdk:
         specifier: ^2.1664.0
         version: 2.1693.0
-      axios:
-        specifier: ^1.15.2
-        version: 1.17.0
       body-parser:
         specifier: 1.20.3
         version: 1.20.3
@@ -545,7 +542,7 @@ importers:
         version: 1.15.40
       '@testing-library/jest-dom':
         specifier: 6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)))(vitest@4.1.8)
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(vitest@4.1.8)
       '@testing-library/react':
         specifier: ^15.0.7
         version: 15.0.7(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -748,7 +745,7 @@ importers:
         version: 5.3.1(typescript@5.9.3)
       jest:
         specifier: ^29.4.3
-        version: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
       madge:
         specifier: ^8.0.0
         version: 8.0.0(supports-color@8.1.1)(typescript@5.9.3)
@@ -760,7 +757,7 @@ importers:
         version: 9.0.0(encoding@0.1.13)
       ts-jest:
         specifier: ^29.0.5
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -854,7 +851,7 @@ importers:
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.14)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)))(vitest@4.1.8)
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.14)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(vitest@4.1.8)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14359,6 +14356,41 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.13.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -16545,7 +16577,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)))(vitest@4.1.8)':
+  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(vitest@4.1.8)':
     dependencies:
       '@adobe/css-tools': 4.5.0
       '@babel/runtime': 7.29.7
@@ -16558,10 +16590,10 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.1
-      jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
       vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.14)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)))(vitest@4.1.8)':
+  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.14)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(vitest@4.1.8)':
     dependencies:
       '@adobe/css-tools': 4.5.0
       '@babel/runtime': 7.29.7
@@ -16574,7 +16606,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.14
-      jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
       vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@testing-library/react@14.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -17328,7 +17360,7 @@ snapshots:
   '@vitest/browser-webdriverio@4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)(webdriverio@9.27.2)':
     dependencies:
       '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       webdriverio: 9.27.2
     transitivePeerDependencies:
       - bufferutil
@@ -17363,7 +17395,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -18983,6 +19015,21 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  create-jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   create-jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)):
     dependencies:
@@ -21305,6 +21352,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3))
@@ -21342,6 +21408,36 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.13.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)):
     dependencies:
@@ -21668,6 +21764,18 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3)):
     dependencies:
@@ -25567,6 +25675,27 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
       jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.2
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 29.7.0
+      '@jest/types': 30.4.1
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      esbuild: 0.25.12
+      jest-util: 30.4.1
+
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6

--- a/web/src/designer/fields.tsx
+++ b/web/src/designer/fields.tsx
@@ -496,8 +496,6 @@ const fields: {[key: string]: FieldType} = {
       advancedHelperText: '',
       required: false,
       numberType: 'integer',
-      min: 0,
-      max: 100,
       InputProps: {
         type: 'number',
       },


### PR DESCRIPTION
# refactor: replace axios with native fetch in api (#2050)
## JIRA Ticket
N/A (GitHub issue #2050)
## Description
The API used axios for a single request: the PUT that pushes the JWT public key into CouchDB's config during database initialisation. Node's built-in fetch handles this, so axios has been removed as a dependency of the API.
## Proposed Changes
- Rewrote `api/src/auth/keySigning/initJWTKeys.ts` to use native fetch instead of axios
- Built the basic auth header manually and added an explicit `response.ok` check, since fetch has no `auth` option and does not throw on HTTP error statuses the way axios does
- Removed `axios` from `api/package.json` and updated the lockfile

Two small additional fixes surfaced during testing:
- Stripped `\r` from the public key before writing to CouchDB config. This fixes a pre-existing bug (reproducible on the original axios code) where PEM key files with Windows (CRLF) line endings cause CouchDB to reject the PUT with `400 Invalid configuration value`. Happy to split this into a separate issue/PR if preferred.
- The catch block now logs the underlying error before rethrowing — the previous behaviour of discarding it made the above failure hard to diagnose.
## How to Test
1. From `api/`, run `pnpm migrate-with-keys` — output should include `JWT public key configured in CouchDB` and the migration should complete successfully
2. Verify the key landed: `curl -u <user>:<password> http://localhost:5984/_node/_local/_config/jwt_keys` should return an `rsa:<kid>` entry containing the public key with `\n` separators and no `\r` characters
3. Start the API and log in to the app — token validation works end to end
4. Negative path: set an incorrect `COUCHDB_PASSWORD`, re-run `pnpm migrate-with-keys` — it fails with a logged error rather than reporting success
## Additional Information
Closes #2050
## Checklist
- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.