### PR TITLE
Add TEMPLATE_MANAGER role and give it to TEAM_MANAGER

### DIFF
--- a/api/src/scripts/seedTestDataset.ts
+++ b/api/src/scripts/seedTestDataset.ts
@@ -160,15 +160,39 @@ const USER_SPECS: UserSpec[] = [
     },
   },
 
-  // ── seed-manager-cross ────────────────────────────────────────────────────
+  // ── seed-manager-blue ────────────────────────────────────────────────────
   // TEAM_MANAGER on Blue
-  // Exercises visibility differences across teams for the same user.
+  // Manager for the blue team
   {
     email: 'seed-manager-blue@faims.test',
     tag: 'MANAGER_BLUE',
     name: 'Blue Team Manager',
     assignResourceRoles(user, ctx) {
       addTeamRole({user, role: Role.TEAM_MANAGER, teamId: ctx.blueTeamId});
+    },
+  },
+
+  // ── seed-manager-red ────────────────────────────────────────────────────
+  // TEAM_MANAGER on Red
+  // Manager for the red team
+  {
+    email: 'seed-manager-red@faims.test',
+    tag: 'MANAGER_RED',
+    name: 'Red Team Manager',
+    assignResourceRoles(user, ctx) {
+      addTeamRole({user, role: Role.TEAM_MANAGER, teamId: ctx.redTeamId});
+    },
+  },
+
+  // ── seed-admin-red ────────────────────────────────────────────────────
+  // TEAM_ADMIN on Red
+  // Admin for the red team
+  {
+    email: 'seed-admin-red@faims.test',
+    tag: 'ADMIN_RED',
+    name: 'Red Team Admin',
+    assignResourceRoles(user, ctx) {
+      addTeamRole({user, role: Role.TEAM_ADMIN, teamId: ctx.redTeamId});
     },
   },
 

--- a/api/test/teamIntegration.test.ts
+++ b/api/test/teamIntegration.test.ts
@@ -58,7 +58,11 @@ import {
   getTemplate,
   getTemplateIdsByTeamId,
 } from '../src/couchdb/templates';
-import {createUser, saveCouchUser} from '../src/couchdb/users';
+import {
+  createUser,
+  getExpressUserFromEmailOrUserId,
+  saveCouchUser,
+} from '../src/couchdb/users';
 import {userCanDo} from '../src/middleware';
 import {app} from '../src/expressSetup';
 import {callbackObject} from './mocks';
@@ -226,7 +230,7 @@ describe('Team integration with templates and projects', () => {
     expect(projectDocWithoutTeam.ownedByTeamId).to.be.undefined;
   });
 
-  it('allows team members to create resources in their team', async () => {
+  it('allows team members to create and retrieve resources in their team', async () => {
     // Create a team
     const team = await createTeam(app, {
       teamName: 'Permission Team',
@@ -334,7 +338,29 @@ describe('Team integration with templates and projects', () => {
         teamId: team._id,
       }),
       managerToken
-    ).expect(200);
+    )
+      .expect(200)
+      .then(async res => {
+        // And if we can create them, we should be able to fetch them as well
+        const projectId = res.body.notebook;
+
+        // need to update the token to get any new permissions
+        const updatedUser = await getExpressUserFromEmailOrUserId(user._id);
+        const updatedToken = await generateJwtFromUser({
+          user: updatedUser!,
+          signingKey,
+        });
+
+        await requestAuthAndType(
+          request(app).get(`${NOTEBOOKS_API_BASE}/${projectId}`),
+          updatedToken
+        )
+          .expect(200)
+          .expect(res => {
+            const project = res.body;
+            expect(project).to.not.be.null;
+          });
+      });
     // Try to create a template in the team using the API
     await requestAuthAndType(
       request(app)
@@ -345,6 +371,114 @@ describe('Team integration with templates and projects', () => {
           teamId: team._id,
         }),
       managerToken
+    )
+      .expect(200)
+      .then(async res => {
+        const template_id = res.body._id;
+        // need to update the token to get any new permissions
+        const updatedUser = await getExpressUserFromEmailOrUserId(user._id);
+        const updatedToken = await generateJwtFromUser({
+          user: updatedUser!,
+          signingKey,
+        });
+
+        await requestAuthAndType(
+          request(app).get(`${TEMPLATE_API_BASE}/${template_id}`),
+          updatedToken
+        )
+          .expect(200)
+          .expect(res => {
+            const templates = res.body;
+            expect(templates).to.not.be.null;
+          });
+      });
+  });
+
+  it('gives team managers template-manager access and team admins the extra delete permission', async () => {
+    const team = await createTeam(app, {
+      teamName: 'Template Permission Team',
+      description: 'A team for template permission tests',
+    });
+
+    const template = await requestAuthAndType(
+      request(app)
+        .post(`${TEMPLATE_API_BASE}`)
+        .send({
+          ...sampleCreateTemplatePayload('team-owned template'),
+          name: 'team-owned template',
+          teamId: team._id,
+        } satisfies PostCreateTemplateInput),
+      adminToken
+    )
+      .expect(200)
+      .then(res => res.body);
+
+    const [user, err] = await createUser({
+      username: 'templatepermmanager',
+      name: 'Template Permission Manager',
+    });
+
+    expect(err).to.equal('');
+    expect(user).to.not.be.null;
+
+    if (!user) {
+      throw new Error('User creation failed ' + err);
+    }
+
+    addTeamRole({
+      user,
+      teamId: team._id,
+      role: Role.TEAM_MANAGER,
+    });
+    await saveCouchUser(user);
+
+    const signingKey = await keyService.getSigningKey();
+    const refreshedManagerUser = await getExpressUserFromEmailOrUserId(
+      user._id
+    );
+    const managerToken = await generateJwtFromUser({
+      user: refreshedManagerUser!,
+      signingKey,
+    });
+
+    await requestAuthAndType(
+      request(app).get(`${TEMPLATE_API_BASE}/${template._id}`),
+      managerToken
+    ).expect(200);
+
+    await requestAuthAndType(
+      request(app).put(`${TEMPLATE_API_BASE}/${template._id}/archive`).send({
+        archive: true,
+      }),
+      managerToken
+    ).expect(200);
+
+    await requestAuthAndType(
+      request(app).post(`${TEMPLATE_API_BASE}/${template._id}/delete`),
+      managerToken
+    ).expect(401);
+
+    removeTeamRole({
+      user,
+      teamId: team._id,
+      role: Role.TEAM_MANAGER,
+    });
+    addTeamRole({
+      user,
+      teamId: team._id,
+      role: Role.TEAM_ADMIN,
+    });
+    await saveCouchUser(user);
+
+    const refreshedAdminUser = await getExpressUserFromEmailOrUserId(user._id);
+    const adminTokenForTemplate = await generateJwtFromUser({
+      user: refreshedAdminUser!,
+      signingKey,
+    });
+
+    await requestAuthAndType(
+      request(app).post(`${TEMPLATE_API_BASE}/${template._id}/delete`),
+      adminTokenForTemplate
     ).expect(200);
   });
 
@@ -671,6 +805,14 @@ describe('Team integration with templates and projects', () => {
     );
 
     expect(hasProjectManagerVirtual).to.be.true;
+
+    // Check that virtual roles include template manager role
+    const hasTemplateManagerVirtual = virtualRolesManager.some(
+      role =>
+        role.resourceId === template._id && role.role === Role.TEMPLATE_MANAGER
+    );
+
+    expect(hasTemplateManagerVirtual).to.be.true;
 
     // Test with team admin role (should grant PROJECT_ADMIN and TEMPLATE_ADMIN virtually)
     removeTeamRole({

--- a/docs/user/core/permissions.md
+++ b/docs/user/core/permissions.md
@@ -50,21 +50,27 @@ and {{notebooks}} in the team.
 | Act as {{notebook}} manager for any {{notebook}} owned by the team       |   ❌   |        ❌        |   ✅    |      ✅       |
 | Add or remove managers to the team                                       |   ❌   |        ❌        |   ❌    |      ✅       |
 | Act as {{notebook}} administrator for any {{notebook}} owned by the team |   ❌   |        ❌        |   ❌    |      ✅       |
+| Act as template manager for any template owned by the team               |   ❌   |        ❌        |   ✅    |      ✅       |
 | Act as template administrator for any template owned by the team         |   ❌   |        ❌        |   ❌    |      ✅       |
 
-> ⚠️ **Note**: _Team Member (Creator)_ can create {{notebooks}} but does NOT automatically get access to existing team {{notebooks}}. This is by design for teaching environments where students create isolated {{notebooks}}. They would become _{{Notebook}} Administrator_ for any {{notebooks}} that they create.
+> ⚠️ **Note**: _Team Member (Creator)_ can create {{notebooks}} but does NOT
+> automatically get access to existing team {{notebooks}}. This is by design for
+> teaching environments where students create isolated {{notebooks}}. They would
+> become _{{Notebook}} Administrator_ for any {{notebooks}} that they create.
 
 ### Template Roles
 
 Template roles give a user permission to work on a particular template.
 
-| Permission                                      | Guest | Administrator |
-| :---------------------------------------------- | :---: | :-----------: |
-| View the template                               |  ✅   |      ✅       |
-| update all details of a template                |  ❌   |      ✅       |
-| archive a template so it is no longer available |  ❌   |      ✅       |
+| Permission                                      | Guest | Manager | Administrator |
+| :---------------------------------------------- | :---: | :-----: | :-----------: |
+| View the template                               |  ✅   |   ✅    |      ✅       |
+| update all details of a template                |  ❌   |   ✅    |      ✅       |
+| archive a template so it is no longer available |  ❌   |   ✅    |      ✅       |
+| delete the template after archiving             |  ❌   |   ❌    |      ✅       |
 
-> 💡 **Note**: Template roles are primarily managed through team membership. Team Administrators act as template administrators for team templates.
+> 💡 **Note**: Template roles are primarily managed through team membership.
+> E.g. Team Administrators act as template administrators for team templates.
 
 ### {{Notebook}} Roles
 
@@ -82,4 +88,9 @@ Template roles give a user permission to work on a particular template.
 | can export data from the {{notebook}} in various formats                                        |  ❌   |     ❌      |   ✅    |      ✅       |
 | can create invites for the {{notebook}} and add or remove new guests, contributors and managers |  ❌   |     ❌      |   ✅    |      ✅       |
 | add or remove other administrators to the {{notebook}}                                          |  ❌   |     ❌      |   ❌    |      ✅       |
-| delete the notebook (operation not currently supported)                                         |  ❌   |     ❌      |   ❌    |      ✅       |
+| close the the {{notebook}} (prevents further contributions)                                     |  ❌   |     ❌      |   ✅    |      ✅       |
+| archive the {{notebook}} (makes it not visible to users)                                        |  ❌   |     ❌      |   ✅    |      ✅       |
+| delete the {{notebook}} after archiving (removes all data)                                      |  ❌   |     ❌      |   ❌    |      ✅       |
+
+> 💡 **Note**: {{Notebook}} roles are primarily managed through team membership.
+> E.g. Team Administrators act as {{notebook}} administrators for team templates.

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -971,6 +971,7 @@ export enum Role {
   // TEMPLATE ROLES
   // ================
   TEMPLATE_ADMIN = 'TEMPLATE_ADMIN',
+  TEMPLATE_MANAGER = 'TEMPLATE_MANAGER',
   TEMPLATE_GUEST = 'TEMPLATE_GUEST',
 
   // TEAM ROLES
@@ -1072,8 +1073,14 @@ export const roleDetails: Record<Role, RoleDetails> = {
     scope: RoleScope.RESOURCE_SPECIFIC,
     resource: Resource.TEMPLATE,
   },
-  [Role.TEMPLATE_GUEST]: {
+  [Role.TEMPLATE_MANAGER]: {
     name: 'Template Manager',
+    description: 'View, update and archive a template.',
+    scope: RoleScope.RESOURCE_SPECIFIC,
+    resource: Resource.TEMPLATE,
+  },
+  [Role.TEMPLATE_GUEST]: {
+    name: 'Template Guest',
     description: 'Guest access to a template.',
     scope: RoleScope.RESOURCE_SPECIFIC,
     resource: Resource.TEMPLATE,
@@ -1207,15 +1214,18 @@ export const roleActions: Record<
   [Role.TEMPLATE_GUEST]: {
     actions: [Action.READ_TEMPLATE_DETAILS],
   },
-  [Role.TEMPLATE_ADMIN]: {
+  [Role.TEMPLATE_MANAGER]: {
     actions: [
       Action.UPDATE_TEMPLATE_DETAILS,
       Action.CHANGE_TEMPLATE_TEAM,
       Action.UPDATE_TEMPLATE_UISPEC,
       Action.CHANGE_TEMPLATE_STATUS,
-      Action.DELETE_TEMPLATE,
     ],
     inheritedRoles: [Role.TEMPLATE_GUEST],
+  },
+  [Role.TEMPLATE_ADMIN]: {
+    actions: [Action.DELETE_TEMPLATE],
+    inheritedRoles: [Role.TEMPLATE_MANAGER],
   },
 
   // GLOBAL ROLES
@@ -1370,7 +1380,12 @@ export const roleActions: Record<
     // NOTE this is a bit of a permission leak here re: general creator
     inheritedRoles: [Role.TEAM_MEMBER],
     // Projects owned by team -> manager
-    virtualRoles: new Map([[Resource.PROJECT, [Role.PROJECT_MANAGER]]]),
+    virtualRoles: new Map([
+      // Projects owned by team -> manager
+      [Resource.PROJECT, [Role.PROJECT_MANAGER]],
+      // Template owned by team -> manager
+      [Resource.TEMPLATE, [Role.TEMPLATE_MANAGER]],
+    ]),
   },
 
   [Role.TEAM_ADMIN]: {
@@ -1386,7 +1401,7 @@ export const roleActions: Record<
     ],
     inheritedRoles: [Role.TEAM_MANAGER],
     virtualRoles: new Map([
-      // Projects owned by team -> manager
+      // Projects owned by team -> admin
       [Resource.PROJECT, [Role.PROJECT_ADMIN]],
       // Template owned by team -> admin
       [Resource.TEMPLATE, [Role.TEMPLATE_ADMIN]],


### PR DESCRIPTION
# Add TEMPLATE_MANAGER role and give it to TEAM_MANAGER for all team templates

## Ticket

None

## Description

TEAM_MANAGER was able to create templates within a team but could not see existing templates. 

## Proposed Changes

Added a new TEMPLATE_MANAGER role that has what used to be the permissions of TEMPLATE_ADMIN without template deletion.  Made this a virtual role for TEAM_MANAGER so that team managers can see and manage templates within the team but can't delete them.   TEAM_ADMIN is required to delete templates via TEMPLATE_ADMIN. 

Adds tests around this new distinction and new users in the seed data with the admin and manager roles within teams.

## How to Test

After running the seed-test-dataset script, as user seed-manager-red you should be able to see the sample template in the red team.  You should not be able to delete it.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
