### PR TITLE
Use repository name for the api docker image name

### DIFF
--- a/.github/workflows/publish-conductor.yml
+++ b/.github/workflows/publish-conductor.yml
@@ -7,12 +7,10 @@ on:
     types: [published]
   workflow_dispatch:
 
-# Defines two custom environment variables for the workflow. These are
-# used for the Container registry domain, and a name for the Docker
-# image that this workflow builds.
+# Defines a custom environment variable for the workflow: the Container
+# registry domain used for publishing the Docker image.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{github.repository_owner}}/faims3-api
 
 jobs:
   build-and-push:
@@ -30,6 +28,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Derive image name from repository
+        id: image-name
+        shell: bash
+        # use the repo name, converted to lowercase, and append "-api" to the end of it
+        # as the image name. For example, if the repo is "FAIMS3",
+        # the image name will be "faims3-api".
+        run: |
+          repo_name="${GITHUB_REPOSITORY#*/}"
+          repo_name="${repo_name,,}"
+          echo "image_name=${GITHUB_REPOSITORY_OWNER}/${repo_name}-api" >> "$GITHUB_OUTPUT"
+
       # Uses the `docker/login-action` action to log in to the Container registry
       # using the account and password that will publish the packages.
       # Once published, the packages are scoped to the account defined here.
@@ -44,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
           tags: |
             type=sha,prefix=sha-
             type=ref,event=branch

--- a/docs/developer/docs/source/markdown/DeployingAWSStack.md
+++ b/docs/developer/docs/source/markdown/DeployingAWSStack.md
@@ -358,13 +358,13 @@ aws backup delete-backup-vault \
 
 ### Conductor (API) Configuration
 
-The following section configures the API
+The following section configures the API.
 
 ```json
   "conductor": {
     "name": "FAIMS Server",
     "description": "FAIMS Conductor instance deployment.",
-    "conductorDockerImage": "org/faims3-api",
+    "conductorDockerImage": "see-below",
     "conductorDockerImageTag": "latest",
     "shortCodePrefix": "FAIMS",
     "cpu": 1024,
@@ -383,8 +383,17 @@ The following section configures the API
 
 You need to update the following
 
-- `conductorDockerImage`: you can either use `ghcr.io/faims/faims3-api` OR you can fork the repo, and deploy your own container to GHCR, which will allow you more control over the lifecycle. I think by default use a tagged version of the FAIMS upstream container image.
-- `conductorDockerImageTag`: I don't recommend using latest, as you may get out of sync, instead, specify the specific commit e.g. `sha-522bb4b`
+- `conductorDockerImage`: you can either use `ghcr.io/faims/faims3-api` OR you
+  can fork the repo, and deploy your own container to GHCR, which will allow you
+  more control over the lifecycle. I think by default use a tagged version of the
+  FAIMS upstream container image.
+  If you fork the repository, the image name will be `ghcr.io/org/reponame-api`
+  where `org` will be the organisation owning
+  your repository, `reponame` is the lowercase version of the repository name.  
+  You should see the package listed in your repository packages list.
+
+- `conductorDockerImageTag`: I don't recommend using latest, as you may get out
+  of sync, instead, specify the specific commit e.g. `sha-522bb4b`
 
 The remaining options are for your consideration. They are largely performance, the below is a suitable production profile:
 


### PR DESCRIPTION
# Use repository name for the api docker image name

## Ticket

None

## Description

The docker image name was fixed as 'faims3-api' but this means we can't publish different versions from alternate repositories.  

## Proposed Changes

Make the image name be based on the repository name.  For FAIMS3 this will still be faims3-api but for a repository called FAIMS3-Alternate it would be faims3-alternate-api.  

## How to Test

Trigger the publish-conductor.yml workflow

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
