### PR TITLE
Add dco.yml and allow remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,6 @@
+# If a DCO sign-off is missed, we allow a followup commit
+# with the wording "I, A. User <user@example.com>, hereby add my Signed-off-by to this commit: <commit-hash>"
+#
+# A remediation commit can include more than one line in this format if needed
+allowRemediationCommits:
+  individual: true

--- a/README.md
+++ b/README.md
@@ -488,3 +488,20 @@ two options:
 git pull
 ./scripts/release.sh finalize 1.5.0 --push
 ```
+
+## Contributing to FAIMS3 and DCO
+
+Contributions to this Open Source project are welcome in the form of pull requests. If you
+wish to get involved with the project please contact one of the developers.
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/) to
+ensure that contributors certify that they wrote or otherwise have the right to submit
+the code they are contributing to the project. All commits should be signed with the
+`-s` flag on `git commit`.
+
+If you forget to sign an individual commit, you can push a subsequent commit with a remediation
+message of the form:
+
+```text
+I, A. User <user@example.com>, hereby add my Signed-off-by to this commit: <commit-hash>
+```


### PR DESCRIPTION

# Allow DCO remediation commits

## Ticket

None

## Description

Sometimes we forget to add Signed-off-by to commits. 

## Proposed Changes

Adds dco.yml and allows remediation commits of the form:

I, A. User <user@example.com>, hereby add my Signed-off-by to this commit: commit-hash

This allows us to assert DCO without having to go back and change the git history.

## How to Test

Can't test without making a mistake, we'll see if it works.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
