### PR TITLE
fix: scope --clear-db volume pruning to this compose project

### DIFF
--- a/localdev.sh
+++ b/localdev.sh
@@ -107,18 +107,15 @@ setup_node_version() {
 manage_docker_volumes() {
   docker_prefix="docker compose"
   echo "Stopping existing Docker containers..."
-  ${docker_prefix} down
 
   if [ "$CLEAR_DB" = true ]; then
+    # Let compose remove its own volumes: couchdb_data is this project's only
+    # named volume, and removing by volume label instead matched every
+    # project's couchdb_data on the host (other checkouts and worktrees).
     echo "Pruning volume containing the couchdb database..."
-    volume_to_remove=$(docker volume ls -q --filter "label=com.docker.compose.volume=couchdb_data")
-    if [ -n "$volume_to_remove" ]; then
-      docker volume rm $volume_to_remove
-      echo "Volume removed: $volume_to_remove"
-    else
-      echo "No volumes found for couchdb_data"
-    fi
+    ${docker_prefix} down --volumes
   else
+    ${docker_prefix} down
     echo "Skipping volume pruning (use --clear-db to clear volumes)"
   fi
 


### PR DESCRIPTION
# fix: scope --clear-db volume pruning to this compose project

## Ticket

n/a

## Description

`--clear-db` pruned every couchdb database on the host, not just this checkout's: the prune filtered only on the compose volume label (`com.docker.compose.volume=couchdb_data`), which every project started from this compose file carries, so running it in one checkout deleted the (stopped) databases of every other checkout and worktree.

The prune is now `docker compose down --volumes`, so compose removes exactly its own project's volumes, resolving the project name the same way `up` does (`COMPOSE_PROJECT_NAME`, `.env`, or the directory name). `couchdb_data` is the project's only named volume and the other mounts are binds, so the flag's effect is unchanged: this checkout's couch data, nothing else.

## Proposed Changes

- `manage_docker_volumes` in `localdev.sh`: with `--clear-db`, run `docker compose down --volumes` and drop the label-filtered `docker volume ls`/`docker volume rm` prune; without it, `down` as before.

## How to Test

On a host with couchdb volumes from several checkouts, run `./localdev.sh --clear-db` in one of them: only that project's `<project>_couchdb_data` is removed and the others survive.

## Additional Information

n/a

## Checklist

- [x] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
