### PR TITLE
Fix/Update asset generation script

### DIFF
--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -43,20 +43,20 @@ EOT
 
 echo "Generating assets for ${VITE_THEME} theme"
 
-npx capacitor-assets generate --assetPath "./public/base-assets/${VITE_THEME}" \
+pnpx sssf-capacitor-assets generate --assetPath "./public/base-assets/${VITE_THEME}" \
   --pwaManifestPath ./public/manifest.json \
   --iconBackgroundColorDark '#001d34' \
   --splashBackgroundColorDark '#001d34'
 
 ## capacitor-assets can put the pwa icons in the wrong place sometimes
-if test -f icons/icon-48.webp; then
+if test -f icons/icon-192.png; then
   echo "Moving icons into public"
   mkdir -p ./public/assets
   mv icons ./public/assets/icons
 fi
 
 ## copy the icons over to web/ as well (check they exist first)
-if test -f ./public/assets/icons/icon-48.webp; then
+if test -f ./public/assets/icons/icon-192.png; then
   rm -rf ../web/public/assets/icons
   mkdir -p ../web/public/assets/
   cp -r ./public/assets/icons ../web/public/assets/icons

--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -41,9 +41,11 @@ EOT
 
 ## Now run the asset generation script
 
-echo "Generating assets for ${VITE_THEME} theme"
+THEME=${VITE_THEME:-default}
 
-pnpx sssf-capacitor-assets generate --assetPath "./public/base-assets/${VITE_THEME}" \
+echo "Generating assets for ${THEME} theme"
+
+pnpm dlx sssf-capacitor-assets generate --assetPath "./public/base-assets/${THEME}" \
   --pwaManifestPath ./public/manifest.json \
   --iconBackgroundColorDark '#001d34' \
   --splashBackgroundColorDark '#001d34'

--- a/app/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/app/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -5,6 +5,30 @@
       "size": "1024x1024",
       "filename": "AppIcon-512@2x.png",
       "platform": "ios"
+    },
+    {
+      "idiom": "universal",
+      "size": "1024x1024",
+      "filename": "AppIcon-512@2x-dark.png",
+      "platform": "ios",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ]
+    },
+    {
+      "idiom": "universal",
+      "size": "1024x1024",
+      "filename": "AppIcon-512@2x-tinted.png",
+      "platform": "ios",
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "tinted"
+        }
+      ]
     }
   ],
   "info": {

--- a/app/public/manifest.dist.json
+++ b/app/public/manifest.dist.json
@@ -3,46 +3,28 @@
   "name": "APPNAME app",
   "icons": [
     {
-      "src": "assets/icons/icon-48.webp",
-      "type": "image/png",
-      "sizes": "48x48",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "assets/icons/icon-72.webp",
-      "type": "image/png",
-      "sizes": "72x72",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "assets/icons/icon-96.webp",
-      "type": "image/png",
-      "sizes": "96x96",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "assets/icons/icon-128.webp",
-      "type": "image/png",
-      "sizes": "128x128",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "assets/icons/icon-192.webp",
+      "src": "assets/icons/icon-192.png",
       "type": "image/png",
       "sizes": "192x192",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
-      "src": "assets/icons/icon-256.webp",
-      "type": "image/png",
-      "sizes": "256x256",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "assets/icons/icon-512.webp",
+      "src": "assets/icons/icon-512.png",
       "type": "image/png",
       "sizes": "512x512",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "assets/icons/icon-1024.png",
+      "type": "image/png",
+      "sizes": "1024x1024",
+      "purpose": "any"
+    },
+    {
+      "src": "assets/icons/icon-512-maskable.png",
+      "type": "image/png",
+      "sizes": "512x512",
+      "purpose": "maskable"
     }
   ],
   "start_url": ".",

--- a/app/src/gui/components/app-bar/app-bar-heading.tsx
+++ b/app/src/gui/components/app-bar/app-bar-heading.tsx
@@ -25,7 +25,7 @@ export const AppBarHeading = ({link}: AppBarHeadingProps) => (
     }}
   >
     <Box sx={{paddingRight: 0.5}}>
-      <img src="/assets/icons/icon-48.webp" />
+      <img src="/assets/icons/icon-192.png" width={48} height={48} />
     </Box>
     <h2>{config.headingAppName}</h2>
   </NavLink>

--- a/web/src/components/logo.tsx
+++ b/web/src/components/logo.tsx
@@ -21,7 +21,7 @@ export function LogoIcon({size = 24}: {size?: number}) {
   return (
     <img
       className="inline-block"
-      src="/assets/icons/icon-48.webp"
+      src="/assets/icons/icon-192.png"
       width={size}
     />
   );


### PR DESCRIPTION
# Fix/Update asset generation script

## Ticket

None

## Description

Asset generation failed for me on a deployment because npx was missing, I then found that the package we were using, capacitor-assets, is no longer maintained.   

## Proposed Changes

Update package to sssf-capacitor-assets which is a maintained fork of the original.  Use pnpx instead of npx to run it in the script.  

Updated package doesn't generate the same icon sizes so switch to using a larger one, scaled in the app.

## How to Test

Build and run the app, should see no change but now it is using icons/icon-192.png rather than icon-48.webp.   

Have tested Android and IOS builds, see no change.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
