### PR TITLE
build: adds new EBS recovery documentation and improves docs

### DIFF
--- a/api/src/scripts/deleteMetadataDatabases.ts
+++ b/api/src/scripts/deleteMetadataDatabases.ts
@@ -5,7 +5,7 @@
  *
  * Usage (from api/):
  *   pnpm run delete-metadata-databases
- *   pnpm run delete-metadata-databases -- --dry-run
+ *   pnpm run delete-metadata-databases --dry-run
  */
 import * as readline from 'readline';
 import {ProjectDocument} from '@faims3/data-model';

--- a/api/src/scripts/dumpUserEmails.ts
+++ b/api/src/scripts/dumpUserEmails.ts
@@ -4,10 +4,10 @@
  *
  * Usage (from api/, with .env pointing at the target Couch):
  *   pnpm run dump-user-emails
- *   pnpm run dump-user-emails -- --format=csv
- *   pnpm run dump-user-emails -- --format=bcc --include-disabled
- *   pnpm run dump-user-emails -- --skip=test,example\\.com
- *   pnpm run dump-user-emails -- --no-skip
+ *   pnpm run dump-user-emails --format=csv
+ *   pnpm run dump-user-emails --format=bcc --include-disabled
+ *   pnpm run dump-user-emails --skip=test,example\\.com
+ *   pnpm run dump-user-emails --no-skip
  *
  * Formats:
  *   lines  one email per line (default) — paste into BCC / mailing tools
@@ -16,14 +16,71 @@
  *
  * Skip: emails matching any --skip regex are excluded (case-insensitive).
  * Default skip list: test, demo (anywhere), example\.com
+ *
+ * Progress / diagnostics go to stderr so stdout stays paste-ready.
  */
 import {isPeopleUserAccountDisabled} from '@faims3/data-model';
+import {config} from '../buildconfig';
+import {verifyCouchDBConnection} from '../couchdb';
 import {filterPeopleUsersForList, getUsers} from '../couchdb/users';
 
 type Format = 'lines' | 'bcc' | 'csv';
 
 /** Default patterns: "test"/"demo" anywhere in the address; example.com domain. */
 const DEFAULT_SKIP_PATTERNS = ['test', 'demo', String.raw`example\.com`];
+
+/** How long to wait for the initial HTTP probe / full user fetch before failing. */
+const CONNECT_TIMEOUT_MS = 15_000;
+const FETCH_USERS_TIMEOUT_MS = 60_000;
+
+function log(...args: unknown[]): void {
+  console.error('[dump-user-emails]', ...args);
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    const parts = [`${error.name}: ${error.message}`];
+    const anyErr = error as Error & {
+      code?: string;
+      cause?: unknown;
+      status?: number;
+      statusCode?: number;
+    };
+    if (anyErr.code) parts.push(`code=${anyErr.code}`);
+    if (anyErr.status !== undefined) parts.push(`status=${anyErr.status}`);
+    if (anyErr.statusCode !== undefined) {
+      parts.push(`statusCode=${anyErr.statusCode}`);
+    }
+    if (anyErr.cause !== undefined) {
+      parts.push(`cause=${formatError(anyErr.cause)}`);
+    }
+    if (error.stack) parts.push(error.stack);
+    return parts.join('\n');
+  }
+  return String(error);
+}
+
+async function withTimeout<T>(
+  label: string,
+  ms: number,
+  work: Promise<T>
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(
+          `${label} timed out after ${ms}ms. Check COUCHDB_INTERNAL_URL, network/VPN, and that Couch is reachable.`
+        )
+      );
+    }, ms);
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
 
 function parseArgs(argv: string[]): {
   format: Format;
@@ -61,7 +118,7 @@ function parseArgs(argv: string[]): {
       continue;
     }
     if (arg === '-h' || arg === '--help') {
-      console.log(`Usage: pnpm run dump-user-emails -- [options]
+      console.log(`Usage: pnpm run dump-user-emails [options]
 
 Options:
   --format=lines|bcc|csv   Output format (default: lines)
@@ -107,13 +164,122 @@ function csvEscape(value: string): string {
   return value;
 }
 
+function logConfigSummary(): void {
+  const auth = config.localCouchdbAuth;
+  log('Config:');
+  log(`  COUCHDB_INTERNAL_URL=${config.couchdbInternalUrl}`);
+  log(`  COUCHDB_PUBLIC_URL=${config.couchdbPublicUrl}`);
+  log(
+    `  auth=${auth ? `user=${auth.username} password=set` : 'missing (defaults may apply)'}`
+  );
+}
+
+/** Quick HTTP reachability check with AbortSignal (PouchDB has no useful timeout). */
+async function probeCouchHttp(timeoutMs: number): Promise<void> {
+  const url = config.couchdbInternalUrl;
+  const headers: Record<string, string> = {Accept: 'application/json'};
+  const auth = config.localCouchdbAuth;
+  if (auth) {
+    headers.Authorization =
+      'Basic ' +
+      Buffer.from(`${auth.username}:${auth.password}`, 'utf8').toString(
+        'base64'
+      );
+  }
+
+  log(`Probing ${url} (GET /, timeout ${timeoutMs}ms)...`);
+  const started = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+      signal: controller.signal,
+    });
+    const bodyPreview = (await response.text()).slice(0, 200);
+    log(
+      `Probe OK in ${Date.now() - started}ms: HTTP ${response.status}` +
+        (bodyPreview ? ` body=${JSON.stringify(bodyPreview)}` : '')
+    );
+    if (!response.ok && response.status !== 401) {
+      // 401 still proves we reached Couch; other errors are useful to surface.
+      log(`Warning: unexpected HTTP status ${response.status}`);
+    }
+  } catch (error) {
+    const elapsed = Date.now() - started;
+    if (
+      error instanceof Error &&
+      (error.name === 'AbortError' || error.message.includes('aborted'))
+    ) {
+      throw new Error(
+        `Timed out after ${elapsed}ms connecting to ${url}. ` +
+          'Check COUCHDB_INTERNAL_URL, DNS, VPN/firewall, and that the ALB/Couch target is healthy.'
+      );
+    }
+    throw new Error(
+      `Failed to reach CouchDB at ${url} after ${elapsed}ms: ${formatError(error)}`
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 const main = async () => {
   try {
     const {format, includeDisabled, skipPatterns} = parseArgs(
       process.argv.slice(2)
     );
     const skipMatchers = compileSkipMatchers(skipPatterns);
-    const users = filterPeopleUsersForList(await getUsers(), includeDisabled);
+
+    logConfigSummary();
+    log(
+      `Options: format=${format}` +
+        (includeDisabled ? ' includeDisabled' : '') +
+        (skipPatterns.length
+          ? ` skip=${JSON.stringify(skipPatterns)}`
+          : ' no-skip')
+    );
+
+    await probeCouchHttp(CONNECT_TIMEOUT_MS);
+
+    log('Verifying required databases (people, projects, templates, auth)...');
+    const verifyStarted = Date.now();
+    const connection = await withTimeout(
+      'verifyCouchDBConnection',
+      CONNECT_TIMEOUT_MS * 2,
+      verifyCouchDBConnection()
+    );
+    log(`verifyCouchDBConnection finished in ${Date.now() - verifyStarted}ms`);
+    if (!connection.valid) {
+      log('CouchDB validity check failed:');
+      if (connection.server_msg) log(`  server: ${connection.server_msg}`);
+      if (connection.validate_error) {
+        log(`  validate: ${connection.validate_error}`);
+      }
+      for (const dbErr of connection.database_errors ?? []) {
+        log(`  database: ${dbErr}`);
+      }
+      process.exit(1);
+    }
+    log('Required databases reachable.');
+
+    log(`Fetching people docs (timeout ${FETCH_USERS_TIMEOUT_MS}ms)...`);
+    const fetchStarted = Date.now();
+    const allUsers = await withTimeout(
+      'getUsers()',
+      FETCH_USERS_TIMEOUT_MS,
+      getUsers()
+    );
+    log(
+      `Fetched ${allUsers.length} people docs in ${Date.now() - fetchStarted}ms`
+    );
+
+    const users = filterPeopleUsersForList(allUsers, includeDisabled);
+    log(
+      `After disabled filter: ${users.length} users` +
+        (includeDisabled ? ' (including disabled)' : ' (active only)')
+    );
 
     type Row = {
       email: string;
@@ -148,14 +314,8 @@ const main = async () => {
 
     rows.sort((a, b) => a.email.localeCompare(b.email));
 
-    // Counts go to stderr so stdout stays paste-ready for mail clients.
-    console.error(
-      `users=${users.length} emails=${rows.length} skipped=${skipped}` +
-        ` format=${format}` +
-        (includeDisabled ? ' includeDisabled' : '') +
-        (skipPatterns.length
-          ? ` skip=${JSON.stringify(skipPatterns)}`
-          : ' no-skip')
+    log(
+      `users=${users.length} emails=${rows.length} skipped=${skipped} format=${format}`
     );
 
     if (format === 'lines') {
@@ -179,9 +339,11 @@ const main = async () => {
       }
     }
 
+    log('Done.');
     process.exit(0);
   } catch (error) {
-    console.error('Failed to dump user emails:', error);
+    log('Failed:');
+    console.error(formatError(error));
     process.exit(1);
   }
 };

--- a/docs/developer/docs/source/index.rst
+++ b/docs/developer/docs/source/index.rst
@@ -23,6 +23,7 @@ FAIMS3 Developer Documentation
    markdown/Backup.md
    markdown/DeployingAWSStack.md
    markdown/CouchVersionUpgradeGuideAWS.md
+   markdown/CouchBackupRecoveryGuideAWS.md
    markdown/IOS-Deployment.md
    markdown/AppInitialisation.md
    markdown/forms/04-dependency-injection.md

--- a/docs/developer/docs/source/markdown/Backup.md
+++ b/docs/developer/docs/source/markdown/Backup.md
@@ -42,12 +42,12 @@ This would restore records from the backup file to all databases. To limit the
 databases restored to those matching the regular expression `mybackup.*`:
 
 ```shell
-pnpm run restore-backup -- --pattern 'mybackup.*' fieldmark-backup-2025-06-19-1750363850254.jsonl
+pnpm run restore-backup --pattern 'mybackup.*' fieldmark-backup-2025-06-19-1750363850254.jsonl
 ```
 
 By default, existing records will not be overwritten when the backup is restored.
 To overwrite existing records, add the `--force` flag to the command line:
 
 ```shell
-pnpm run restore-backup -- --force fieldmark-backup-2025-06-19-1750363850254.jsonl
+pnpm run restore-backup --force fieldmark-backup-2025-06-19-1750363850254.jsonl
 ```

--- a/docs/developer/docs/source/markdown/CouchBackupRecoveryGuideAWS.md
+++ b/docs/developer/docs/source/markdown/CouchBackupRecoveryGuideAWS.md
@@ -1,0 +1,287 @@
+# CouchDB backup recovery on AWS
+
+Purpose: Restore the CouchDB **data** EBS volume from a known-good snapshot (manual
+`ec2Snapshot.sh` or AWS Backup recovery point) by setting
+`couch.ebsRecoverySnapshotId` and redeploying.
+
+**Status**: Validated on DEV. Proceed carefully. Emergency recovery process. Worth exercising.
+
+Related docs:
+
+- [CouchDB version upgrade on AWS](./CouchVersionUpgradeGuideAWS.md) — similar
+  tooling (`scripts/.env`, prepare-replace, `migrate-with-keys`)
+- [Deploying AWS Stack](./DeployingAWSStack.md) — `backup` config
+- [CDK README](../../../../../infrastructure/aws-cdk/README.md) — config
+  pull/push, validation
+
+## How backups relate to the stack
+
+| Piece | Role |
+| ----- | ---- |
+| Couch EC2 | Boot + Docker + `local.ini`; **not** the durable datastore |
+| Data EBS (`/dev/xvdf` → `/opt/couchdb/data`) | Couch databases; retained across instance replace |
+| AWS Backup (`BackupConstruct`) | Scheduled snapshots of **that EBS volume only** (vault + plan from `backup` in config) |
+| Manual snapshot | `./scripts/ec2Snapshot.sh create` — same volume, ad-hoc `snap-…` |
+| `couch.ebsRecoverySnapshotId` | CDK creates a **new** volume from `snap-…` and attaches it |
+
+AWS Backup EBS recovery-point ARNs look like
+`arn:aws:ec2:<region>::snapshot/snap-…` — the `snap-…` id is what you put in
+config.
+
+Changing `ebsRecoverySnapshotId` replaces the **Volume** (and attachment). CDK
+embeds the snap id in those construct ids (`…FromSnap…`) so CloudFormation
+creates a new volume from the snap — you cannot add `SnapshotId` to an existing
+volume in place. The same snap id keeps those ids stable (no churn). Clearing
+the field drops the suffix and would replace again with an empty `volumeSize`
+volume. The instance may stay; user data does not re-run unless the instance is
+also replaced. This procedure stops/detaches first (same as upgrade) so
+CloudFormation can move the attachment, then starts Couch again and re-runs
+keys/migrate.
+
+## Notes (AWS)
+
+- **Downtime** from prepare-replace until Couch is healthy and
+  `migrate-with-keys` succeeds. Notify users first.
+- Restoring overwrites live on-disk data with the snapshot point-in-time. Newer
+  writes are gone unless you have another copy.
+- Prefer a completed snapshot **before** you destroy or detach anything you
+  might still need (take a “last chance” snapshot of the current volume if it
+  is still readable).
+- After restore, run `pnpm run migrate-with-keys` (JWT public key + design-doc /
+  schema migrations). Fresh `local.ini` from user data / boot is not enough for
+  FAIMS auth.
+- **Leave `ebsRecoverySnapshotId` in config after a successful restore.** Clearing
+  it and redeploying replaces the data volume with a new empty one (`volumeSize`)
+  and loses the recovered disk. Leaving the id only matters if the Volume
+  resource is created/replaced again (it does not re-copy the snap every deploy).
+- Default volume `RemovalPolicy` retains the old volume when CFN replaces it —
+  delete the orphan manually only after you are sure.
+
+## Setup
+
+### CDK config
+
+From `infrastructure/aws-cdk`:
+
+```bash
+./config.sh pull <env> # note you may need --config_repo <git clone string> if first time running on a stage
+export CONFIG_FILE_NAME=<env>.json
+pnpm run validate-config
+```
+
+Keep `CONFIG_FILE_NAME` set for the whole window. `stackName` / region are in
+`configs/<env>.json`.
+
+### Repo revision and build
+
+**Use the same whole-repo revision as the deployed FAIMS stack** (e.g. `main`
+pulled up to date if that is what is deployed, or the git SHA/tag matching the
+deployed Conductor/app image tags). A newer or older local tree can apply schema
+changes early/late, regress the env, or leave design docs / shared packages out
+of sync.
+
+From the repo root:
+
+```bash
+pnpm install
+pnpm build   # or npx turbo build
+```
+
+### API env from the deployed stack
+
+With **AWS credentials active**, build `api/.env` from the Conductor task
+(Secrets Manager values included). Later steps reuse this file.
+
+From `infrastructure/aws-cdk`:
+
+```bash
+./scripts/env-from-cdk-stack.sh <stack-name> -o ../../api/.env --region <region>
+# e.g. ./scripts/env-from-cdk-stack.sh DASS-stage -o ../../api/.env -r ap-southeast-2
+```
+
+Confirm `api/.env` includes the region (needed for Secrets Manager / JWT key
+load). The export script writes this when you pass `--region`; if missing, add:
+
+```bash
+# api/.env
+AWS_DEFAULT_REGION=ap-southeast-2
+```
+
+### Setup scripting env
+
+From `infrastructure/aws-cdk` (separate from `api/.env`):
+
+```bash
+cp scripts/.env.dist scripts/.env
+```
+
+Then use the values from `api/.env` to fill out the first fields (db url,
+username, password) in `scripts/.env`, and set `STACK_NAME` to the CloudFormation
+stack name from `configs/<env>.json` (same as `stackName`).
+
+### Local access to VPC-only Couch (couch auth proxy)
+
+**When** couch-auth-proxy is deployed (Couch no longer on the public ALB;
+[#2211](https://github.com/FAIMS/FAIMS3/pull/2211) — expected on `main` later),
+`env-from-cdk-stack` sets `COUCHDB_INTERNAL_URL` to a **VPC private** address.
+Laptop scripts (`dump-user-emails`, `migrate-with-keys`, baseline) cannot reach
+it directly.
+
+**Fix:** SSM port-forward Couch `:5984` to localhost, then point both
+`api/.env` and `scripts/.env` at the tunnel (leave `COUCHDB_PUBLIC_URL` as the
+public proxy hostname). Ensure `scripts/.env` has `STACK_NAME` (see Baseline
+below).
+
+```bash
+# from infrastructure/aws-cdk — STACK_NAME from scripts/.env; leave running
+./scripts/ssmCouchTunnel.sh
+```
+
+```bash
+# api/.env
+COUCHDB_INTERNAL_URL=http://127.0.0.1:5984
+
+# infrastructure/aws-cdk/scripts/.env (baseline / EC2 helpers)
+COUCH_URL=http://127.0.0.1:5984
+```
+
+Until proxy lands on `main`, skip this if Couch is still reachable via the
+exported public/internal URL.
+
+### Notify users
+
+Dump active user emails (uses `api/.env` above) and send a maintenance notice
+**before** you stop Couch:
+
+```bash
+cd api
+pnpm run dump-user-emails                 # one address per line (stdout)
+pnpm run dump-user-emails --format=bcc # comma-separated for a BCC field
+pnpm run dump-user-emails --format=csv > users.csv
+```
+
+Default skip filters drop addresses matching `test`, `demo`, or `example.com`;
+see `api/README.md` (`--skip` / `--no-skip`).
+
+## 1. Baseline and choose recovery point
+
+From `infrastructure/aws-cdk`, ensuring `scripts/.env` is correct:
+
+```bash
+pnpm run couch-upgrade-baseline --instance-id   # writes EC2_INSTANCE_ID; save JSON
+./scripts/ec2Snapshot.sh list                        # recent snaps for /dev/xvdf
+```
+
+Pick a `snap-…` (table above, EC2 → Snapshots, or AWS Backup → vault recovery
+points — parse `snap-…` from the EBS recovery-point ARN).
+
+Optional last-chance backup of current data (if the volume is still good enough
+to snapshot):
+
+```bash
+./scripts/ec2Snapshot.sh create   # wait until completed; keep this id aside
+```
+
+## 2. Set recovery snapshot in config
+
+In `configs/<env>.json`:
+
+```json
+"couch": {
+  "...": "...",
+  "ebsRecoverySnapshotId": "snap-0123456789abcdef0"
+}
+```
+
+`volumeSize` is ignored while a snapshot id is set (size comes from the snap).
+
+```bash
+./config.sh push <env>   # if you use the private config repo
+pnpm cdk diff            # expect new Volume (+ attachment) ids (…FromSnap…); stop if blast radius is wrong
+```
+
+## 3. Stop, detach, deploy
+
+**Hard downtime starts here.**
+
+### Why we can't just run deploy: `ec2PrepareReplace.sh`
+
+Setting `ebsRecoverySnapshotId` makes CDK/CloudFormation **replace** the Couch
+data `Volume` (new construct id → new volume from `snap-…`) and
+`VolumeAttachment`. That fails while the current data volume is still attached
+to the instance (“already attached” / attachment cannot move).
+
+`./scripts/ec2PrepareReplace.sh` (reads `EC2_INSTANCE_ID` from `scripts/.env`)
+does the minimum AWS-side prep:
+
+1. **Stop** the Couch EC2 instance (Couch down from here).
+2. **Detach** the data volume on `/dev/xvdf` (or `EC2_DATA_DEVICE`).
+3. **Wait** until that volume is `available`.
+
+It does **not** delete the old volume, create the snapshot, or change config —
+those are separate steps. After it finishes, `cdk deploy` can create the
+recovery volume and attach it. (The script was named for instance-replace
+upgrades; recovery reuses the same stop/detach precondition.)
+
+### Run the setup and then deploy
+
+```bash
+./scripts/ec2PrepareReplace.sh
+pnpm cdk deploy
+```
+
+Watch CloudFormation / CDK status until the update succeeds. Prepare-replace left
+the instance **stopped**; after the new volume is attached, start it:
+
+```bash
+./scripts/ec2StartInstance.sh   # start EC2_INSTANCE_ID; wait until running
+```
+
+Then wait for ALB Couch target healthy and refresh the instance id:
+
+```bash
+pnpm run couch-upgrade-baseline --instance-id
+```
+
+If mount/Couch looks wrong on the old instance, force a clean user-data boot by
+also replacing the instance (e.g. bump a harmless user-data-affecting setting or
+follow the upgrade prepare-replace + deploy path) — draft note: confirm the
+lightest reliable path while testing.
+
+## 4. Re-init keys and migrate
+
+AWS credentials active; use Setup’s `api/.env`:
+
+```bash
+cd api
+pnpm run migrate-with-keys
+```
+
+Expect `JWT public key configured in CouchDB` and a successful migration.
+
+## 5. Verify
+
+```bash
+# from infrastructure/aws-cdk — compare markers/version to step 1 / expected snap era
+pnpm run couch-upgrade-baseline --instance-id
+```
+
+Smoke-test Conductor login, Control Centre, collection app. Optionally SSM to the
+instance: `df -h /opt/couchdb/data`, `curl -s http://localhost:5984`.
+
+## 6. After restore — leave the snapshot id
+
+Keep `ebsRecoverySnapshotId` set to the snap you restored from (and push config
+if you use the private config repo). Do **not** remove it and `cdk deploy` —
+that replaces the Volume with a blank `volumeSize` disk.
+
+Leaving the pin is fine for ongoing ops: unchanged deploys leave the existing
+volume alone. The downside is only if the volume resource is later replaced
+(stack recreate / attachment replace / accidental property churn): CFN would
+build again from that same `snap-…`.
+
+Optional later: delete any **previous** orphaned data volume CFN retained when
+the restore replaced the live volume (irreversible — only after you are sure).
+
+**Later task (not documented here):** procedure to copy data onto a “clean”
+volume (no `SnapshotId` in the template) and drop the recovery pin safely.

--- a/docs/developer/docs/source/markdown/CouchBackupRecoveryGuideAWS.md
+++ b/docs/developer/docs/source/markdown/CouchBackupRecoveryGuideAWS.md
@@ -16,13 +16,13 @@ Related docs:
 
 ## How backups relate to the stack
 
-| Piece | Role |
-| ----- | ---- |
-| Couch EC2 | Boot + Docker + `local.ini`; **not** the durable datastore |
-| Data EBS (`/dev/xvdf` → `/opt/couchdb/data`) | Couch databases; retained across instance replace |
-| AWS Backup (`BackupConstruct`) | Scheduled snapshots of **that EBS volume only** (vault + plan from `backup` in config) |
-| Manual snapshot | `./scripts/ec2Snapshot.sh create` — same volume, ad-hoc `snap-…` |
-| `couch.ebsRecoverySnapshotId` | CDK creates a **new** volume from `snap-…` and attaches it |
+| Piece                                        | Role                                                                                   |
+| -------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Couch EC2                                    | Boot + Docker + `local.ini`; **not** the durable datastore                             |
+| Data EBS (`/dev/xvdf` → `/opt/couchdb/data`) | Couch databases; retained across instance replace                                      |
+| AWS Backup (`BackupConstruct`)               | Scheduled snapshots of **that EBS volume only** (vault + plan from `backup` in config) |
+| Manual snapshot                              | `./scripts/ec2Snapshot.sh create` — same volume, ad-hoc `snap-…`                       |
+| `couch.ebsRecoverySnapshotId`                | CDK creates a **new** volume from `snap-…` and attaches it                             |
 
 AWS Backup EBS recovery-point ARNs look like
 `arn:aws:ec2:<region>::snapshot/snap-…` — the `snap-…` id is what you put in

--- a/docs/developer/docs/source/markdown/CouchVersionUpgradeGuideAWS.md
+++ b/docs/developer/docs/source/markdown/CouchVersionUpgradeGuideAWS.md
@@ -7,7 +7,9 @@ Related docs:
 
 - [Deploying AWS Stack](./DeployingAWSStack.md)
 - [CDK README](../../../../../infrastructure/aws-cdk/README.md) — config pull/push,
-  validation, and [EBS snapshot recovery](../../../../../infrastructure/aws-cdk/README.md#recovering-couch-data-volume-from-ebs-snapshot)
+  validation
+- [CouchDB backup recovery on AWS](./CouchBackupRecoveryGuideAWS.md) — restore
+  data volume from `snap-…` / AWS Backup
 - Upstream: <https://docs.couchdb.org/en/stable/install/upgrading.html>
 
 Not covered: notebook JSON migrations.
@@ -90,6 +92,35 @@ load). The export script writes this when you pass `--region`; if missing, add:
 AWS_DEFAULT_REGION=ap-southeast-2
 ```
 
+### Local access to VPC-only Couch (placeholder)
+
+**When** couch-auth-proxy is deployed (Couch no longer on the public ALB;
+[#2211](https://github.com/FAIMS/FAIMS3/pull/2211) — expected on `main` later),
+`env-from-cdk-stack` sets `COUCHDB_INTERNAL_URL` to a **VPC private** address.
+Laptop scripts (`dump-user-emails`, `migrate-with-keys`, baseline) cannot reach
+it directly.
+
+**Fix:** SSM port-forward Couch `:5984` to localhost, then point both
+`api/.env` and `scripts/.env` at the tunnel (leave `COUCHDB_PUBLIC_URL` as the
+public proxy hostname). Ensure `scripts/.env` has `STACK_NAME` (see Baseline
+below).
+
+```bash
+# from infrastructure/aws-cdk — STACK_NAME from scripts/.env; leave running
+./scripts/ssmCouchTunnel.sh
+```
+
+```bash
+# api/.env
+COUCHDB_INTERNAL_URL=http://127.0.0.1:5984
+
+# infrastructure/aws-cdk/scripts/.env (baseline / EC2 helpers)
+COUCH_URL=http://127.0.0.1:5984
+```
+
+Until proxy lands on `main`, skip this if Couch is still reachable via the
+exported public/internal URL.
+
 ### Notify users
 
 Dump active user emails (uses `api/.env` above) and send a maintenance notice
@@ -98,8 +129,8 @@ Dump active user emails (uses `api/.env` above) and send a maintenance notice
 ```bash
 cd api
 pnpm run dump-user-emails                 # one address per line (stdout)
-pnpm run dump-user-emails -- --format=bcc # comma-separated for a BCC field
-pnpm run dump-user-emails -- --format=csv > users.csv
+pnpm run dump-user-emails --format=bcc # comma-separated for a BCC field
+pnpm run dump-user-emails --format=csv > users.csv
 ```
 
 Default skip filters drop addresses matching `test`, `demo`, or `example.com`;
@@ -174,7 +205,7 @@ Watch CloudFormation events and ALB Couch target health until healthy. Refresh
 `EC2_INSTANCE_ID` in `scripts/.env` for the new instance:
 
 ```bash
-pnpm run couch-upgrade-baseline -- --instance-id
+pnpm run couch-upgrade-baseline --instance-id
 ```
 
 ## 4. Re-init keys and migrate
@@ -196,7 +227,7 @@ From `infrastructure/aws-cdk`, refresh the instance id if needed and re-run the
 baseline; compare to the pre-upgrade output (version, markers):
 
 ```bash
-pnpm run couch-upgrade-baseline -- --instance-id
+pnpm run couch-upgrade-baseline --instance-id
 ```
 
 Smoke-test Conductor login, Control Centre, and the collection app.
@@ -208,6 +239,6 @@ Smoke-test Conductor login, Control Centre, and the collection app.
 on-disk state; if auth breaks, use snapshot restore instead.
 
 **Data restore:** follow
-[Recovering couch data volume from EBS Snapshot](../../../../../infrastructure/aws-cdk/README.md#recovering-couch-data-volume-from-ebs-snapshot)
-(`ebsRecoverySnapshotId`). Remove that field from config after a successful
-restore.
+[CouchDB backup recovery on AWS](./CouchBackupRecoveryGuideAWS.md)
+(`ebsRecoverySnapshotId`). Leave that field set after restore — clearing it and
+redeploying replaces the data volume with an empty one.

--- a/docs/developer/docs/source/markdown/DeployingAWSStack.md
+++ b/docs/developer/docs/source/markdown/DeployingAWSStack.md
@@ -342,7 +342,7 @@ I recommend the following configuration for a production level deployment - you 
 
 The prior configuration is valid - consider the combination of retention and schedule which suits your requirements for snapshot retention.
 
-These snapshots retain the **EBS Volume backing couch** - we have tested that you can recover completely from this volume.
+These snapshots retain the **EBS Volume backing couch** - we have tested that you can recover completely from this volume. Recovery procedure (draft): [CouchDB backup recovery on AWS](./CouchBackupRecoveryGuideAWS.md).
 
 The above expression schedules a daily update at 3am - in combination with 30 day retentions, this means 30 concurrent snapshots - if you have a lot of data, this could result in a lot of storage costs - so beware.
 
@@ -785,7 +785,7 @@ From within `api` (again ensuring your have AWS creds active!)
 ```sh
 pnpm i
 npx turbo build
-pnpm run migrate -- --keys
+pnpm run migrate --keys
 ```
 
 This will migrate all the databases, and force push the JWT signing keys. In the future, you do not need to include the `-- --keys` postfix for routine migrations.

--- a/docs/developer/docs/source/markdown/MetadataMigrationGuide.md
+++ b/docs/developer/docs/source/markdown/MetadataMigrationGuide.md
@@ -142,7 +142,7 @@ Inside `uiSpecification`:
 From `api/`:
 
 ```bash
-pnpm run delete-metadata-databases -- --dry-run
+pnpm run delete-metadata-databases --dry-run
 ```
 
 Review output: each `metadata-{projectId}` should show **`hasInlinedUiSpecification: true`** and ideally **`stillReferencedOnProject: false`**. Investigate any project flagged as missing `uiSpecification` before deleting.
@@ -155,7 +155,7 @@ When §3 validation passes:
 
 ```bash
 cd api
-pnpm run delete-metadata-databases -- --dry-run   # review
+pnpm run delete-metadata-databases --dry-run   # review
 pnpm run delete-metadata-databases              # interactive confirmation
 ```
 

--- a/docs/developer/docs/source/markdown/NotebookDefinition.md
+++ b/docs/developer/docs/source/markdown/NotebookDefinition.md
@@ -134,7 +134,7 @@ Optional startup migration: `MIGRATE_NOTEBOOKS_ON_STARTUP` still runs notebook m
 After all projects are on v4 with inlined specs, operators can remove orphaned Couch databases:
 
 ```sh
-cd api && pnpm run delete-metadata-databases -- --dry-run
+cd api && pnpm run delete-metadata-databases --dry-run
 ```
 
 See `api/src/scripts/deleteMetadataDatabases.ts`.

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -186,7 +186,7 @@ We provide a script called `config.sh` to manage configurations. This script can
    or
 
    ```bash
-   pnpm run config -- <push/pull> <environment> [options]
+   pnpm run config <push/pull> <environment> [options]
    ```
 
    - `<push/pull>`: Use `pull` to fetch configurations, `push` to update the repository.
@@ -239,7 +239,7 @@ To switch between different environments:
    or
 
    ```bash
-   pnpm run config -- pull prod
+   pnpm run config pull prod
    ```
 
 2. The script will copy the environment-specific files into your project and tell you to set the `CONFIG_FILE_NAME` environment variable. Set it like this:
@@ -548,101 +548,20 @@ This
 
 This operation is a "no-op" if already setup.
 
-# Recovering couch data volume from EBS Snapshot
+# Recovering couch data volume from EBS snapshot
 
-The couch data volume is handled separately from the OS data in your instance. This allows the data volume to be backed up regularly without needing to be concerned about producing AMIs which associate the boot volume with EBS snapshots (such as in the AWS Backup for EC2 process). The config contains a flag to recover the EBS data volume from an existing EBS snapshot ID. The process to perform this recovery is explained below.
+Couch data lives on a separate EBS volume (`/dev/xvdf`). AWS Backup
+(`BackupConstruct`) snapshots that volume on the `backup` schedule; ad-hoc
+snapshots use `scripts/ec2Snapshot.sh`. Restore is driven by
+`couch.ebsRecoverySnapshotId` (`snap-…`).
 
-TODO: Verify and test these instructions with real data.
+**Operator procedure:** [CouchDB backup recovery on AWS](../../docs/developer/docs/source/markdown/CouchBackupRecoveryGuideAWS.md)
+— prepare-replace → set snap id → `cdk deploy` → `ec2StartInstance.sh` →
+`migrate-with-keys` → **leave the snapshot id set** (removing it and redeploying
+replaces the volume with an empty disk).
 
-If you need to recover your CouchDB data from a previously created EBS snapshot, follow these steps:
-
-1. **Locate your EBS snapshot ID**
-   - Go to the AWS Management Console
-   - Navigate to EC2 > Snapshots
-   - Find the snapshot you want to use for recovery
-   - Copy the Snapshot ID (it should look like `snap-0123456789abcdef0`)
-
-2. **Update your configuration file**
-   - Open your infrastructure configuration file (typically `configs/<stage>.json`)
-   - Locate the `couch` section
-   - Add or update the `ebsRecoverySnapshotId` field with your snapshot ID:
-
-     ```json
-     "couch": {
-       ...
-       "ebsRecoverySnapshotId": "snap-0123456789abcdef0"
-     }
-     ```
-
-   - The `volumeSize` field will be ignored if a snapshot ID is provided
-
-3. **Deploy your updated infrastructure**
-   - Run your deployment command, for example:
-     ```
-     export CONFIG_FILE_NAME=<stage>.json
-     cdk deploy
-     ```
-
-4. **Verify the recovery**
-   - Once deployment is complete, SSM or SSH connect into your EC2 instance
-     - TODO: verify a process to do this in production context - right now permissions would not allow this connection
-   - Check that the CouchDB data volume is mounted correctly:
-     ```
-     df -h /opt/couchdb/data
-     ```
-   - Verify that CouchDB is running and can access the data:
-     ```
-     curl http://localhost:5984
-     ```
-
-5. **After Recovery**
-   - It's probably safe to continue using
-   - Once recovery is successful and you've verified your data, you may want to remove the `ebsRecoverySnapshotId` from your config to prevent accidental reuse in future deployments.
-   - If you need to change the volume size or create a new volume:
-     1. You'll need to manually delete the existing EBS volume through the AWS console or CLI.
-     2. Remove the `ebsRecoverySnapshotId` from your config.
-     3. Add the desired `volumeSize` to your config.
-     4. Run `cdk deploy` to create a new volume with the specified size.
-
-Remember:
-
-- Always use CDK diff to understand the likely ramifications of your CDK update
-- If you want to keep using the recovered data but need more space, consider using AWS EBS volume modification to increase the size of the existing volume instead of creating a new one.
-- Deleting an EBS volume is irreversible. Always ensure you have backups before making such changes.
-
-## Recovery process diagram (proposed)
-
-The below diagram indicates three backup/recovery processes for couch
-
-1. (CouchDB replication - left) Nightly startup of idle couch instance, replicate all databases from live DB, shut down. Run EBS snapshot.
-2. (EBS Snapshots - middle) Nightly snapshots of live db data volume
-3. (Recovery options - right)
-   1. (Realtime rollover) Try recovering but starting up idle instance, adding to target group for load balancer, and removing unhealthy instance. This could be followed by getting the latest snapshot from the live instance and recovering it, depending on recovery priorities.
-   2. (Recover backup DB from EBS snapshot) If prod continues to operate but data has been lost, could use idle database to recover from an EBS snapshot, and then replicate lost data.
-   3. (Recover live DB from EBS snapshot) If both databases are not operational and require recovery, can directly recover the live DB from the latest EBS snapshot.
-
-```mermaid
-graph TD
-    A[Start] --> B[Nightly Backup Process]
-    B --> C[Start idle instance]
-    C --> D[Replicate all databases]
-    D --> E[Shutdown idle instance]
-    E --> F[Take EBS snapshot of backup instance]
-
-    G[Regular Process] --> H[Take regular EBS snapshots of live DB]
-
-    I[Disaster Recovery Situation] --> J{Try immediate recovery}
-    J -->|Yes| K[Start idle instance]
-    K --> L[Point load balancer to idle instance]
-    L --> M{Does it work?}
-    M -->|Yes| N[Recovery complete]
-    M -->|No| O[Use EBS snapshot]
-    J -->|No| O
-    O --> P[Recover data volume of main instance]
-    P --> Q[Restart main instance]
-    Q --> R[Point load balancer to main instance]
-    R --> N
-```
+Related scripts under `scripts/`: `ec2Snapshot.sh`, `ec2PrepareReplace.sh`,
+`ec2StartInstance.sh`, `ssmCouchTunnel.sh` (VPC-only Couch / proxy stacks).
 
 # Email Configuration
 

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -396,10 +396,18 @@ EOL`,
     // grant permission for the instance to read the secret
     props.cookieSecret.grantRead(this.instance);
 
+    // Include recovery snapshot id in Volume/Attachment construct ids so CFN
+    // *replaces* the volume when the snap changes. Adding SnapshotId on an
+    // existing AWS::EC2::Volume is an invalid in-place update. Empty suffix
+    // when unset keeps logical ids stable for stacks not in recovery.
+    const recoveryVolumeIdSuffix = props.dataVolumeSnapshotId
+      ? `FromSnap${props.dataVolumeSnapshotId.replace(/[^a-zA-Z0-9]/g, '')}`
+      : '';
+
     // Create and attach the EBS volume for CouchDB data
     const dataVolume = new ec2.Volume(
       this,
-      'CouchDBDataVolume' + debugIdPostfix,
+      'CouchDBDataVolume' + debugIdPostfix + recoveryVolumeIdSuffix,
       {
         volumeType: ec2.EbsDeviceVolumeType.GP3,
         availabilityZone: this.instance.instanceAvailabilityZone,
@@ -415,7 +423,7 @@ EOL`,
     // Attach the EBS data volume for couch to the correct path
     new ec2.CfnVolumeAttachment(
       this,
-      'CouchDBVolumeAttachment' + debugIdPostfix,
+      'CouchDBVolumeAttachment' + debugIdPostfix + recoveryVolumeIdSuffix,
       {
         volumeId: dataVolume.volumeId,
         instanceId: this.instance.instanceId,

--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -309,6 +309,9 @@ export class FaimsFrontEnd extends Construct {
     // Setup a deployment into this bucket with static files
     new aws_s3_deployment.BucketDeployment(this, 'deploy', {
       destinationBucket: this.faimsBucket,
+      // increase memory limit to 2GB for the lambda s3 sync - increases
+      // performance
+      memoryLimit: 2048,
       // Setup with distribution so that the deployment will invalidate
       // distribution cache when the files are redeployed
       distribution: this.faimsDistribution,
@@ -468,6 +471,9 @@ export class FaimsFrontEnd extends Construct {
     // Setup a deployment into this bucket with static files
     new aws_s3_deployment.BucketDeployment(this, 'web-deploy', {
       destinationBucket: this.webBucket,
+      // increase memory limit to 2GB for the lambda s3 sync - increases
+      // performance
+      memoryLimit: 2048,
       // Setup with distribution so that the deployment will invalidate
       // distribution cache when the files are redeployed
       distribution: this.webDistribution,

--- a/infrastructure/aws-cdk/scripts/.env.dist
+++ b/infrastructure/aws-cdk/scripts/.env.dist
@@ -10,7 +10,8 @@ MARKER_DBS=
 
 # --- EC2 / EBS (snapshot + prepare-replace scripts) ---
 # CloudFormation stack name (configs/<env>.json → stackName). Used by
-# `pnpm run couch-upgrade-baseline -- --instance-id` to resolve EC2_INSTANCE_ID.
+# `pnpm run couch-upgrade-baseline --instance-id`, `./scripts/ssmCouchTunnel.sh`,
+# `./scripts/ec2StartInstance.sh`, and related EC2 helpers.
 STACK_NAME=
 # Filled automatically with --instance-id, or set manually.
 EC2_INSTANCE_ID=i-0123456789abcdef0

--- a/infrastructure/aws-cdk/scripts/couchUpgradeBaseline.ts
+++ b/infrastructure/aws-cdk/scripts/couchUpgradeBaseline.ts
@@ -3,7 +3,7 @@
  *
  *   cp scripts/.env.dist scripts/.env   # fill in values
  *   pnpm run couch-upgrade-baseline
- *   pnpm run couch-upgrade-baseline -- --instance-id
+ *   pnpm run couch-upgrade-baseline --instance-id
  *
  * With --instance-id: look up the Couch EC2 instance from STACK_NAME via
  * CloudFormation and write EC2_INSTANCE_ID into scripts/.env.
@@ -58,7 +58,7 @@ function parseArgs(argv: string[]): {
 }
 
 function printHelp(): void {
-  console.log(`Usage: pnpm run couch-upgrade-baseline [-- --instance-id]
+  console.log(`Usage: pnpm run couch-upgrade-baseline [--instance-id]
 
 Record CouchDB version, DB list, and optional marker stats as JSON.
 

--- a/infrastructure/aws-cdk/scripts/ec2PrepareReplace.sh
+++ b/infrastructure/aws-cdk/scripts/ec2PrepareReplace.sh
@@ -6,7 +6,7 @@
 #
 # Prerequisites: stack idle (e.g. UPDATE_ROLLBACK_COMPLETE), snapshot taken.
 # After this: pnpm cdk deploy, then refresh EC2_INSTANCE_ID via
-#   pnpm run couch-upgrade-baseline -- --instance-id
+#   pnpm run couch-upgrade-baseline --instance-id
 #
 set -euo pipefail
 
@@ -207,13 +207,17 @@ main() {
 
   cat <<EOF
 
-Ready for instance replace. Next:
+Ready for volume/instance replace. Next:
 
   pnpm cdk deploy
 
-Then refresh EC2_INSTANCE_ID:
+# Recovery (volume replace; instance often still stopped):
+  ./scripts/ec2StartInstance.sh
+  pnpm run couch-upgrade-baseline --instance-id
 
-  pnpm run couch-upgrade-baseline -- --instance-id
+# Upgrade (instance replace): refresh id after deploy, then start if needed:
+  pnpm run couch-upgrade-baseline --instance-id
+  ./scripts/ec2StartInstance.sh
 EOF
 }
 

--- a/infrastructure/aws-cdk/scripts/ec2StartInstance.sh
+++ b/infrastructure/aws-cdk/scripts/ec2StartInstance.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Start the Couch EC2 instance (e.g. after ec2PrepareReplace.sh + cdk deploy
+# left it stopped with a new data volume attached).
+#
+#   ./scripts/ec2StartInstance.sh
+#
+# After this: wait for ALB Couch target healthy, then
+#   pnpm run couch-upgrade-baseline --instance-id
+#   cd api && pnpm run migrate-with-keys
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+usage() {
+  cat <<EOF
+Usage: $0
+
+  Start EC2_INSTANCE_ID if stopped and wait until running.
+
+Reads EC2_INSTANCE_ID (and optional AWS_REGION, STACK_NAME) from:
+  ${ENV_FILE}
+
+If EC2_INSTANCE_ID is missing or still the .env.dist placeholder, looks up the
+Couch instance from STACK_NAME via CloudFormation.
+EOF
+  exit 1
+}
+
+load_env() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing ${ENV_FILE}. Copy scripts/.env.dist to scripts/.env and fill in values." >&2
+    exit 1
+  fi
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    [[ "$line" != *=* ]] && continue
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    if [[ "${value}" =~ ^\".*\"$ || "${value}" =~ ^\'.*\'$ ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+    [[ -z "$value" ]] && continue
+    if [[ -z "${!key+x}" ]]; then
+      export "$key=$value"
+    fi
+  done <"$ENV_FILE"
+}
+
+require_aws() {
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "Error: aws CLI is required." >&2
+    exit 1
+  fi
+  local err
+  if ! err="$(aws sts get-caller-identity "${REGION_ARGS[@]}" 2>&1)"; then
+    echo "Error: aws sts get-caller-identity failed." >&2
+    echo "$err" >&2
+    exit 1
+  fi
+}
+
+REGION_ARGS=()
+
+init_region_args() {
+  local region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+  REGION_ARGS=()
+  if [[ -n "$region" ]]; then
+    REGION_ARGS=(--region "$region")
+  fi
+}
+
+instance_state() {
+  local instance_id="$1"
+  aws ec2 describe-instances \
+    --instance-ids "$instance_id" \
+    "${REGION_ARGS[@]}" \
+    --query 'Reservations[0].Instances[0].State.Name' \
+    --output text
+}
+
+resolve_instance_id() {
+  local instance_id="${EC2_INSTANCE_ID:-}"
+  if [[ -n "$instance_id" && "$instance_id" != "i-0123456789abcdef0" ]]; then
+    echo "$instance_id"
+    return
+  fi
+
+  local stack_name="${STACK_NAME:-}"
+  if [[ -z "$stack_name" ]]; then
+    echo "Error: EC2_INSTANCE_ID is missing/placeholder and STACK_NAME is unset in ${ENV_FILE}." >&2
+    exit 1
+  fi
+
+  echo "Looking up CouchDB EC2 instance from STACK_NAME=${stack_name}..." >&2
+  instance_id="$(aws cloudformation describe-stack-resources \
+    --stack-name "$stack_name" \
+    "${REGION_ARGS[@]}" \
+    --query "StackResources[?ResourceType=='AWS::EC2::Instance' && contains(LogicalResourceId, 'CouchDBInstance')].PhysicalResourceId | [0]" \
+    --output text)"
+
+  if [[ -z "$instance_id" || "$instance_id" == "None" ]]; then
+    echo "Error: no CouchDB EC2 instance found in stack ${stack_name}." >&2
+    exit 1
+  fi
+  echo "$instance_id"
+}
+
+main() {
+  if [[ $# -gt 0 ]]; then
+    case "$1" in
+      -h | --help | help) usage ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        usage
+        ;;
+    esac
+  fi
+
+  load_env
+  init_region_args
+  require_aws
+
+  local instance_id
+  instance_id="$(resolve_instance_id)"
+  local istate
+  istate="$(instance_state "$instance_id")"
+
+  echo "Instance:  ${instance_id} (${istate})"
+  echo
+
+  case "$istate" in
+    running)
+      echo "Instance already running."
+      ;;
+    pending)
+      echo "Instance already starting; waiting until running..."
+      aws ec2 wait instance-running \
+        --instance-ids "$instance_id" \
+        "${REGION_ARGS[@]}"
+      echo "Instance:  running"
+      ;;
+    stopped | stopping)
+      if [[ "$istate" == "stopping" ]]; then
+        echo "Waiting for instance to finish stopping..."
+        aws ec2 wait instance-stopped \
+          --instance-ids "$instance_id" \
+          "${REGION_ARGS[@]}"
+      fi
+      echo "Starting instance..."
+      aws ec2 start-instances \
+        --instance-ids "$instance_id" \
+        "${REGION_ARGS[@]}" \
+        --output text >/dev/null
+      aws ec2 wait instance-running \
+        --instance-ids "$instance_id" \
+        "${REGION_ARGS[@]}"
+      echo "Instance:  running"
+      ;;
+    *)
+      echo "Error: instance is in state '${istate}'; expected stopped/running." >&2
+      exit 1
+      ;;
+  esac
+
+  cat <<EOF
+
+Next:
+
+  # Wait for ALB Couch target healthy, then:
+  pnpm run couch-upgrade-baseline --instance-id
+  cd ../../api && pnpm run migrate-with-keys
+EOF
+}
+
+main "$@"

--- a/infrastructure/aws-cdk/scripts/ssmCouchTunnel.sh
+++ b/infrastructure/aws-cdk/scripts/ssmCouchTunnel.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# SSM port-forward CouchDB :5984 from the stack's Couch EC2 instance to localhost.
+#
+#   ./scripts/ssmCouchTunnel.sh [-r|--region <region>] [-l|--local-port <port>]
+#
+# Reads STACK_NAME (and optional AWS_REGION / EC2_INSTANCE_ID) from scripts/.env.
+# Leave running, then point local API scripts at the tunnel:
+#   COUCHDB_INTERNAL_URL=http://127.0.0.1:5984
+#
+# Requires: aws CLI, session-manager-plugin, credentials that can SSM to the instance.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+usage() {
+  cat <<EOF
+Usage: $0 [-r|--region <region>] [-l|--local-port <port>]
+
+  Resolve the CouchDB EC2 instance from STACK_NAME in scripts/.env and start
+  an SSM port-forward of remote :5984 to localhost (default local port 5984).
+
+Reads STACK_NAME (and optional AWS_REGION, EC2_INSTANCE_ID) from:
+  ${ENV_FILE}
+
+Examples:
+  $0
+  $0 -r ap-southeast-2 -l 15984
+EOF
+  exit 1
+}
+
+load_env() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing ${ENV_FILE}. Copy scripts/.env.dist to scripts/.env and set STACK_NAME." >&2
+    exit 1
+  fi
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    [[ "$line" != *=* ]] && continue
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    if [[ "${value}" =~ ^\".*\"$ || "${value}" =~ ^\'.*\'$ ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+    [[ -z "$value" ]] && continue
+    if [[ -z "${!key+x}" ]]; then
+      export "$key=$value"
+    fi
+  done <"$ENV_FILE"
+}
+
+AWS_REGION_ARG=""
+LOCAL_PORT="5984"
+REMOTE_PORT="5984"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help | help) usage ;;
+    -r | --region)
+      [[ $# -ge 2 ]] || usage
+      AWS_REGION_ARG="$2"
+      shift 2
+      ;;
+    -l | --local-port)
+      [[ $# -ge 2 ]] || usage
+      LOCAL_PORT="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage
+      ;;
+    *)
+      echo "Unexpected argument: $1 (stack name comes from scripts/.env STACK_NAME)" >&2
+      usage
+      ;;
+  esac
+done
+
+load_env
+
+STACK_NAME="${STACK_NAME:-}"
+if [[ -z "$STACK_NAME" ]]; then
+  echo "Error: STACK_NAME is required in ${ENV_FILE}" >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "Error: aws CLI is required." >&2
+  exit 1
+fi
+if ! command -v session-manager-plugin >/dev/null 2>&1; then
+  echo "Error: session-manager-plugin is required (AWS SSM Session Manager plugin)." >&2
+  exit 1
+fi
+
+REGION_ARGS=()
+if [[ -n "$AWS_REGION_ARG" ]]; then
+  REGION_ARGS=(--region "$AWS_REGION_ARG")
+elif [[ -n "${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ]]; then
+  REGION_ARGS=(--region "${AWS_REGION:-$AWS_DEFAULT_REGION}")
+fi
+
+if ! err="$(aws sts get-caller-identity "${REGION_ARGS[@]}" 2>&1)"; then
+  echo "Error: aws sts get-caller-identity failed." >&2
+  echo "$err" >&2
+  exit 1
+fi
+
+echo "Stack:       ${STACK_NAME}"
+
+INSTANCE_ID="${EC2_INSTANCE_ID:-}"
+# Ignore placeholder from .env.dist
+if [[ "$INSTANCE_ID" == "i-0123456789abcdef0" ]]; then
+  INSTANCE_ID=""
+fi
+
+if [[ -z "$INSTANCE_ID" ]]; then
+  echo "Looking up CouchDB EC2 instance..."
+  INSTANCE_ID="$(aws cloudformation describe-stack-resources \
+    --stack-name "$STACK_NAME" \
+    "${REGION_ARGS[@]}" \
+    --query "StackResources[?ResourceType=='AWS::EC2::Instance' && contains(LogicalResourceId, 'CouchDBInstance')].PhysicalResourceId | [0]" \
+    --output text)"
+fi
+
+if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
+  echo "Error: no CouchDB EC2 instance found in stack ${STACK_NAME}" >&2
+  echo "(expected AWS::EC2::Instance with LogicalResourceId containing CouchDBInstance)." >&2
+  echo "Set STACK_NAME correctly, or set EC2_INSTANCE_ID in scripts/.env." >&2
+  exit 1
+fi
+
+echo "Instance:    ${INSTANCE_ID}"
+echo "Forward:     localhost:${LOCAL_PORT} -> ${INSTANCE_ID}:${REMOTE_PORT}"
+echo
+echo "Leave this running. Point local env at the tunnel:"
+echo "  # api/.env"
+echo "  COUCHDB_INTERNAL_URL=http://127.0.0.1:${LOCAL_PORT}"
+echo "  # infrastructure/aws-cdk/scripts/.env"
+echo "  COUCH_URL=http://127.0.0.1:${LOCAL_PORT}"
+echo
+
+exec aws ssm start-session \
+  --target "$INSTANCE_ID" \
+  "${REGION_ARGS[@]}" \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters "{\"portNumber\":[\"${REMOTE_PORT}\"],\"localPortNumber\":[\"${LOCAL_PORT}\"]}"


### PR DESCRIPTION
Mostly just a new guide, but also exercises it and fixes a couple of issues. 

This included some missing lambda memory size limit bumps (causing very slow deploys), unnecessary `--` pass through flag in pnpm scripts, and other small touch ups.