### PR TITLE
feat: ttl cleanup script for expiring DB records + CDK wiring

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -140,6 +140,27 @@ By default skips addresses matching `test` or `demo` (anywhere) or
 `--no-skip`. Disabled accounts are omitted unless `--include-disabled`. Counts
 go to stderr.
 
+## TTL cleanup (ops)
+
+One-shot job that deletes expired ephemeral CouchDB documents in `auth` and
+`invites` (refresh tokens, email codes, verification challenges, expired
+invites; optionally long-lived tokens). Rate-limit retention windows for email
+codes / verification challenges are respected. Survey tombstones and
+people/project/`data-*` docs are never touched.
+
+```bash
+pnpm run ttl-cleanup --dry-run
+pnpm run ttl-cleanup
+pnpm run ttl-cleanup --include-longlived --compact
+```
+
+Exhausted-but-unexpired invites are kept by default (uses may be raised later).
+Pass `--delete-exhausted-invites` only if you intentionally want those removed
+too. Prefer `--dry-run` first against the target Couch.
+
+Retention rules, flags, and AWS scheduling notes:
+[TtlCleanup.md](../docs/developer/docs/source/markdown/TtlCleanup.md).
+
 ## Development
 
 There is an alternate docker compose file for development that mounts the

--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,7 @@
     "migrate-with-keys": "env-cmd tsx src/scripts/migrate.ts --keys",
     "dump-user-emails": "env-cmd tsx src/scripts/dumpUserEmails.ts",
     "delete-metadata-databases": "env-cmd tsx src/scripts/deleteMetadataDatabases.ts",
+    "ttl-cleanup": "env-cmd tsx src/scripts/ttlCleanup.ts",
     "restore-backup": "env-cmd node --expose-gc --max-old-space-size=8000 --import tsx src/scripts/restoreBackup.ts",
     "migrate-test-backups": "tsx src/scripts/migrateBackupJsonl.ts test/backup-short.jsonl test/backup.jsonl",
     "migrate-notebook-json": "tsx src/scripts/migrateNotebookJson.ts",

--- a/api/src/couchdb/index.ts
+++ b/api/src/couchdb/index.ts
@@ -715,6 +715,12 @@ export const destroyCouchDatabase = async (dbName: string): Promise<void> => {
   await nano.db.destroy(dbName);
 };
 
+/** Compacts a CouchDB database by name (reclaims revision bodies). */
+export const compactCouchDatabase = async (dbName: string): Promise<void> => {
+  const nano = await getNanoInstance();
+  await nano.db.compact(dbName);
+};
+
 /**
  * Returns the data DB for a given project using nano-couchdb
  * @param projectID The project ID to use

--- a/api/src/couchdb/ttlCleanup.ts
+++ b/api/src/couchdb/ttlCleanup.ts
@@ -255,7 +255,10 @@ async function* paginateAuthView<T extends {_id?: string}>(
     const result = await authDB.query<T>(viewName, opts);
     let rows = result.rows.filter(r => !!r.doc).map(r => r.doc as T);
 
-    if (skipFirst && rows.length > 0) {
+    // Only drop the startkey row when it is still present. Deletes between
+    // pages remove the previous page's last id from the view, so CouchDB's
+    // next page already starts at the next live key — blind skip would drop it.
+    if (skipFirst && rows.length > 0 && rows[0]._id === startkey) {
       rows = rows.slice(1);
     }
     if (rows.length === 0) {
@@ -313,12 +316,19 @@ async function* paginateInvitesAllDocs(
       const chunk = docs.slice(0, batchSize);
       yield chunk;
       const lastId = chunk[chunk.length - 1]._id;
-      if (!lastId || rawRows.length < fetchLimit) {
+      if (!lastId) {
         return;
       }
-      startkey = lastId;
-      skipFirst = true;
-      continue;
+      // Continue when this page still has unyielded filtered docs (over-fetch
+      // can leave a local tail even on a short CouchDB page), or when CouchDB
+      // may have more rows. Returning on short pages alone permanently skips
+      // the remainder of `docs` after the first batchSize chunk.
+      if (docs.length > batchSize || rawRows.length >= fetchLimit) {
+        startkey = lastId;
+        skipFirst = true;
+        continue;
+      }
+      return;
     }
 
     if (rawRows.length < fetchLimit) {

--- a/api/src/couchdb/ttlCleanup.ts
+++ b/api/src/couchdb/ttlCleanup.ts
@@ -1,0 +1,553 @@
+/**
+ * TTL cleanup for ephemeral auth / invite CouchDB documents.
+ *
+ * Deletes expired refresh tokens, email codes, verification challenges,
+ * invites, and (optionally) long-lived tokens after retention windows that
+ * preserve auth rate-limiting. Never touches people, projects, data-*, or
+ * survey tombstones.
+ *
+ * Pure retention predicates are exported for unit tests; {@link runTtlCleanup}
+ * performs the paginated sweep + bulkDocs deletes.
+ */
+
+import {
+  AUTH_RECORD_ID_PREFIXES,
+  DatabaseInterface,
+  EmailCodeExistingDocument,
+  ExistingInvitesDBDocument,
+  LongLivedTokenExistingDocument,
+  RefreshRecordExistingDocument,
+  VerificationChallengeExistingDocument,
+} from '@faims3/data-model';
+import {compactCouchDatabase, getAuthDB, getInvitesDB} from '.';
+import {
+  EMAIL_CODE_COOLDOWN_MS,
+  EMAIL_CODE_RATE_LIMIT_WINDOW_MS,
+} from './emailReset';
+import {
+  VERIFICATION_COOLDOWN_MS,
+  VERIFICATION_RATE_LIMIT_WINDOW_MS,
+} from './verificationChallenges';
+
+// Defaults
+export const DEFAULT_REFRESH_GRACE_MS = 24 * 60 * 60 * 1000; // 1 day
+export const DEFAULT_RATE_LIMIT_GRACE_MS = 60 * 60 * 1000; // 1 hour
+export const DEFAULT_INVITE_GRACE_MS = 0;
+export const DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+export const DEFAULT_BATCH_SIZE = 100;
+export const DEFAULT_ERROR_THRESHOLD = 0;
+
+export type TtlDocType =
+  | 'refresh'
+  | 'emailcode'
+  | 'verification'
+  | 'invite'
+  | 'longlived';
+
+export type TtlTypeStats = {
+  scanned: number;
+  deleted: number;
+  skipped: number;
+  errors: number;
+};
+
+export type TtlCleanupStats = Record<TtlDocType, TtlTypeStats>;
+
+export type TtlCleanupOptions = {
+  dryRun?: boolean;
+  compact?: boolean;
+  includeLongLived?: boolean;
+  /** Grace after refresh expiry (and override for invite grace when set via CLI). */
+  refreshGraceMs?: number;
+  /** Extra grace on top of email/verification rate-limit retention. */
+  rateLimitGraceMs?: number;
+  inviteGraceMs?: number;
+  /**
+   * Also delete non-expired invites that have exhausted capped uses.
+   * Default false — exhausted invites may still be useful if uses are raised later.
+   */
+  deleteExhaustedInvites?: boolean;
+  longLivedAuditRetentionMs?: number;
+  batchSize?: number;
+  /** Exit non-zero when errors exceed this (default 0 → any error fails). */
+  errorThreshold?: number;
+  nowMs?: number;
+  log?: (message: string) => void;
+};
+
+export type TtlCleanupResult = {
+  dryRun: boolean;
+  durationMs: number;
+  stats: TtlCleanupStats;
+  compacted: string[];
+  success: boolean;
+};
+
+const emptyStats = (): TtlCleanupStats => ({
+  refresh: {scanned: 0, deleted: 0, skipped: 0, errors: 0},
+  emailcode: {scanned: 0, deleted: 0, skipped: 0, errors: 0},
+  verification: {scanned: 0, deleted: 0, skipped: 0, errors: 0},
+  invite: {scanned: 0, deleted: 0, skipped: 0, errors: 0},
+  longlived: {scanned: 0, deleted: 0, skipped: 0, errors: 0},
+});
+
+type DeletableDoc = {_id: string; _rev: string};
+
+const isAuthPrefixMatch = (
+  id: string,
+  documentType: keyof typeof AUTH_RECORD_ID_PREFIXES
+): boolean => id.startsWith(AUTH_RECORD_ID_PREFIXES[documentType]);
+
+/** Retention age for email codes: rate-limit window + cooldown (+ grace). */
+export const emailCodeRetentionMs = (graceMs = DEFAULT_RATE_LIMIT_GRACE_MS) =>
+  EMAIL_CODE_RATE_LIMIT_WINDOW_MS + EMAIL_CODE_COOLDOWN_MS + graceMs;
+
+/** Retention age for verification challenges: window + cooldown (+ grace). */
+export const verificationRetentionMs = (
+  graceMs = DEFAULT_RATE_LIMIT_GRACE_MS
+) => VERIFICATION_RATE_LIMIT_WINDOW_MS + VERIFICATION_COOLDOWN_MS + graceMs;
+
+/**
+ * Refresh tokens: delete when expiry is older than now - grace.
+ * Disabled tokens follow the same expiry+grace rule (no separate disabledAt).
+ */
+export const shouldDeleteRefreshToken = (
+  doc: Pick<
+    RefreshRecordExistingDocument,
+    '_id' | 'documentType' | 'expiryTimestampMs' | 'enabled'
+  >,
+  nowMs: number,
+  graceMs = DEFAULT_REFRESH_GRACE_MS
+): boolean => {
+  if (doc.documentType !== 'refresh') return false;
+  if (!isAuthPrefixMatch(doc._id, 'refresh')) return false;
+  return doc.expiryTimestampMs < nowMs - graceMs;
+};
+
+/**
+ * Email codes: retain through the rate-limit window + cooldown (+ grace),
+ * measured from createdTimestampMs (fallback: expiryTimestampMs). Not deleted
+ * at code expiry alone — used codes are kept until retention elapses.
+ */
+export const shouldDeleteEmailCode = (
+  doc: Pick<
+    EmailCodeExistingDocument,
+    '_id' | 'documentType' | 'createdTimestampMs' | 'expiryTimestampMs' | 'used'
+  >,
+  nowMs: number,
+  graceMs = DEFAULT_RATE_LIMIT_GRACE_MS
+): boolean => {
+  if (doc.documentType !== 'emailcode') return false;
+  if (!isAuthPrefixMatch(doc._id, 'emailcode')) return false;
+  const anchor =
+    typeof doc.createdTimestampMs === 'number'
+      ? doc.createdTimestampMs
+      : doc.expiryTimestampMs;
+  return anchor < nowMs - emailCodeRetentionMs(graceMs);
+};
+
+/**
+ * Verification challenges: same retention model as email codes with
+ * verification window + cooldown constants.
+ */
+export const shouldDeleteVerificationChallenge = (
+  doc: Pick<
+    VerificationChallengeExistingDocument,
+    '_id' | 'documentType' | 'createdTimestampMs' | 'expiryTimestampMs' | 'used'
+  >,
+  nowMs: number,
+  graceMs = DEFAULT_RATE_LIMIT_GRACE_MS
+): boolean => {
+  if (doc.documentType !== 'verification') return false;
+  if (!isAuthPrefixMatch(doc._id, 'verification')) return false;
+  const anchor =
+    typeof doc.createdTimestampMs === 'number'
+      ? doc.createdTimestampMs
+      : doc.expiryTimestampMs;
+  return anchor < nowMs - verificationRetentionMs(graceMs);
+};
+
+/**
+ * Invites: delete when expiry is past (plus optional grace). Optionally also
+ * delete non-expired invites when uses are capped and exhausted (opt-in;
+ * default keeps them so uses can be raised later).
+ */
+export const shouldDeleteInvite = (
+  doc: Pick<
+    ExistingInvitesDBDocument,
+    '_id' | 'expiry' | 'usesOriginal' | 'usesConsumed'
+  >,
+  nowMs: number,
+  {
+    graceMs = DEFAULT_INVITE_GRACE_MS,
+    deleteExhausted = false,
+  }: {graceMs?: number; deleteExhausted?: boolean} = {}
+): boolean => {
+  if (typeof doc.expiry === 'number' && doc.expiry < nowMs - graceMs) {
+    return true;
+  }
+  if (
+    deleteExhausted &&
+    typeof doc.usesOriginal === 'number' &&
+    doc.usesOriginal > 0 &&
+    doc.usesConsumed >= doc.usesOriginal
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Long-lived tokens: never delete non-expired enabled tokens. Delete
+ * revoked (!enabled) or past-expiry tokens only after audit retention.
+ */
+export const shouldDeleteLongLivedToken = (
+  doc: Pick<
+    LongLivedTokenExistingDocument,
+    | '_id'
+    | 'documentType'
+    | 'enabled'
+    | 'expiryTimestampMs'
+    | 'updatedTimestampMs'
+    | 'createdTimestampMs'
+  >,
+  nowMs: number,
+  auditRetentionMs = DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS
+): boolean => {
+  if (doc.documentType !== 'longlived') return false;
+  if (!isAuthPrefixMatch(doc._id, 'longlived')) return false;
+
+  const expired =
+    typeof doc.expiryTimestampMs === 'number' && doc.expiryTimestampMs < nowMs;
+  const revoked = doc.enabled === false;
+
+  // Active, non-expired (including never-expiring) tokens are never deleted.
+  if (doc.enabled && !expired) return false;
+  if (!revoked && !expired) return false;
+
+  const auditAnchor = revoked
+    ? (doc.updatedTimestampMs ?? doc.createdTimestampMs)
+    : (doc.expiryTimestampMs ??
+      doc.updatedTimestampMs ??
+      doc.createdTimestampMs);
+
+  return auditAnchor < nowMs - auditRetentionMs;
+};
+
+async function* paginateAuthView<T extends {_id?: string}>(
+  viewName: string,
+  batchSize: number
+): AsyncGenerator<T[]> {
+  const authDB = getAuthDB();
+  let startkey: string | undefined;
+  let skipFirst = false;
+
+  for (;;) {
+    const fetchLimit = batchSize + (skipFirst ? 1 : 0);
+    const opts: PouchDB.Query.Options<any, any> = {
+      include_docs: true,
+      limit: fetchLimit,
+    };
+    if (startkey !== undefined) {
+      opts.startkey = startkey;
+    }
+
+    const result = await authDB.query<T>(viewName, opts);
+    let rows = result.rows.filter(r => !!r.doc).map(r => r.doc as T);
+
+    if (skipFirst && rows.length > 0) {
+      rows = rows.slice(1);
+    }
+    if (rows.length === 0) {
+      return;
+    }
+
+    yield rows;
+
+    const lastId = rows[rows.length - 1]._id;
+    if (!lastId || rows.length < batchSize) {
+      return;
+    }
+    startkey = lastId;
+    skipFirst = true;
+  }
+}
+
+async function* paginateInvitesAllDocs(
+  batchSize: number
+): AsyncGenerator<ExistingInvitesDBDocument[]> {
+  const invitesDB = getInvitesDB();
+  let startkey: string | undefined;
+  let skipFirst = false;
+
+  for (;;) {
+    // Over-fetch so filtering `_design/*` and skipFirst still yields a full batch.
+    const fetchLimit = batchSize + (skipFirst ? 1 : 0) + 10;
+    const opts: Record<string, unknown> = {
+      include_docs: true,
+      limit: fetchLimit,
+    };
+    if (startkey !== undefined) {
+      opts.startkey = startkey;
+    }
+
+    const result = await invitesDB.allDocs(opts as any);
+    const rawRows = result.rows.filter(r => !!r.doc);
+    if (rawRows.length === 0) {
+      return;
+    }
+
+    let docs = rawRows
+      .filter(r => !r.id.startsWith('_design/'))
+      .map(r => r.doc as ExistingInvitesDBDocument);
+
+    if (skipFirst && docs.length > 0 && docs[0]._id === startkey) {
+      docs = docs.slice(1);
+    }
+
+    // Advance past the last raw row so we do not stall on design-doc-only pages.
+    const lastRawId = rawRows[rawRows.length - 1].id;
+
+    if (docs.length > 0) {
+      // Cap to batchSize for consistent bulk delete chunks.
+      const chunk = docs.slice(0, batchSize);
+      yield chunk;
+      const lastId = chunk[chunk.length - 1]._id;
+      if (!lastId || rawRows.length < fetchLimit) {
+        return;
+      }
+      startkey = lastId;
+      skipFirst = true;
+      continue;
+    }
+
+    if (rawRows.length < fetchLimit) {
+      return;
+    }
+    startkey = lastRawId;
+    skipFirst = true;
+  }
+}
+
+const bulkDelete = async (
+  db: DatabaseInterface,
+  docs: DeletableDoc[],
+  dryRun: boolean
+): Promise<{deleted: number; errors: number}> => {
+  if (docs.length === 0) {
+    return {deleted: 0, errors: 0};
+  }
+  if (dryRun) {
+    return {deleted: docs.length, errors: 0};
+  }
+
+  const payload = docs.map(d => ({_id: d._id, _rev: d._rev, _deleted: true}));
+  const results = await db.bulkDocs(payload);
+
+  let deleted = 0;
+  let errors = 0;
+  for (const r of results) {
+    if ('error' in r && r.error) {
+      // Already gone / conflict: treat as non-fatal skip for idempotency
+      if (r.status === 404 || r.name === 'not_found' || r.status === 409) {
+        continue;
+      }
+      errors += 1;
+    } else {
+      deleted += 1;
+    }
+  }
+  return {deleted, errors};
+};
+
+const sweepAuthType = async <T extends DeletableDoc>({
+  viewName,
+  docType,
+  shouldDelete,
+  stats,
+  batchSize,
+  dryRun,
+}: {
+  viewName: string;
+  docType: TtlDocType;
+  shouldDelete: (doc: T) => boolean;
+  stats: TtlCleanupStats;
+  batchSize: number;
+  dryRun: boolean;
+}): Promise<void> => {
+  const authDB = getAuthDB();
+  const typeStats = stats[docType];
+
+  for await (const batch of paginateAuthView<T>(viewName, batchSize)) {
+    typeStats.scanned += batch.length;
+    const toDelete: DeletableDoc[] = [];
+    for (const doc of batch) {
+      if (shouldDelete(doc)) {
+        toDelete.push({_id: doc._id, _rev: doc._rev});
+      } else {
+        typeStats.skipped += 1;
+      }
+    }
+    const {deleted, errors} = await bulkDelete(authDB, toDelete, dryRun);
+    typeStats.deleted += deleted;
+    typeStats.errors += errors;
+  }
+};
+
+const sweepInvites = async ({
+  stats,
+  batchSize,
+  dryRun,
+  shouldDelete,
+}: {
+  stats: TtlCleanupStats;
+  batchSize: number;
+  dryRun: boolean;
+  shouldDelete: (doc: ExistingInvitesDBDocument) => boolean;
+}): Promise<void> => {
+  const invitesDB = getInvitesDB();
+  const typeStats = stats.invite;
+
+  for await (const batch of paginateInvitesAllDocs(batchSize)) {
+    typeStats.scanned += batch.length;
+    const toDelete: DeletableDoc[] = [];
+    for (const doc of batch) {
+      if (shouldDelete(doc)) {
+        toDelete.push({_id: doc._id, _rev: doc._rev});
+      } else {
+        typeStats.skipped += 1;
+      }
+    }
+    const {deleted, errors} = await bulkDelete(invitesDB, toDelete, dryRun);
+    typeStats.deleted += deleted;
+    typeStats.errors += errors;
+  }
+};
+
+/**
+ * Run the full TTL cleanup sweep against auth + invites DBs.
+ */
+export const runTtlCleanup = async (
+  options: TtlCleanupOptions = {}
+): Promise<TtlCleanupResult> => {
+  const dryRun = options.dryRun ?? false;
+  const compact = options.compact ?? false;
+  const includeLongLived = options.includeLongLived ?? false;
+  const refreshGraceMs = options.refreshGraceMs ?? DEFAULT_REFRESH_GRACE_MS;
+  const rateLimitGraceMs =
+    options.rateLimitGraceMs ?? DEFAULT_RATE_LIMIT_GRACE_MS;
+  const inviteGraceMs = options.inviteGraceMs ?? DEFAULT_INVITE_GRACE_MS;
+  const deleteExhaustedInvites = options.deleteExhaustedInvites ?? false;
+  const longLivedAuditRetentionMs =
+    options.longLivedAuditRetentionMs ?? DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS;
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const errorThreshold = options.errorThreshold ?? DEFAULT_ERROR_THRESHOLD;
+  const nowMs = options.nowMs ?? Date.now();
+  const log = options.log ?? ((msg: string) => console.log(msg));
+
+  const started = Date.now();
+  const stats = emptyStats();
+  const compacted: string[] = [];
+
+  log(
+    `TTL cleanup starting (dryRun=${dryRun}, compact=${compact}, includeLongLived=${includeLongLived}, now=${new Date(nowMs).toISOString()})`
+  );
+
+  // 1. Refresh tokens
+  await sweepAuthType<RefreshRecordExistingDocument>({
+    viewName: 'viewsDocument/refreshTokens',
+    docType: 'refresh',
+    shouldDelete: doc => shouldDeleteRefreshToken(doc, nowMs, refreshGraceMs),
+    stats,
+    batchSize,
+    dryRun,
+  });
+
+  // 2. Email codes (rate-limit retention)
+  await sweepAuthType<EmailCodeExistingDocument>({
+    viewName: 'viewsDocument/emailCodes',
+    docType: 'emailcode',
+    shouldDelete: doc => shouldDeleteEmailCode(doc, nowMs, rateLimitGraceMs),
+    stats,
+    batchSize,
+    dryRun,
+  });
+
+  // 3. Verification challenges (rate-limit retention)
+  await sweepAuthType<VerificationChallengeExistingDocument>({
+    viewName: 'viewsDocument/verificationChallenges',
+    docType: 'verification',
+    shouldDelete: doc =>
+      shouldDeleteVerificationChallenge(doc, nowMs, rateLimitGraceMs),
+    stats,
+    batchSize,
+    dryRun,
+  });
+
+  // 4. Invites
+  await sweepInvites({
+    stats,
+    batchSize,
+    dryRun,
+    shouldDelete: doc =>
+      shouldDeleteInvite(doc, nowMs, {
+        graceMs: inviteGraceMs,
+        deleteExhausted: deleteExhaustedInvites,
+      }),
+  });
+
+  // 5. Long-lived (optional)
+  if (includeLongLived) {
+    await sweepAuthType<LongLivedTokenExistingDocument>({
+      viewName: 'viewsDocument/longLivedTokens',
+      docType: 'longlived',
+      shouldDelete: doc =>
+        shouldDeleteLongLivedToken(doc, nowMs, longLivedAuditRetentionMs),
+      stats,
+      batchSize,
+      dryRun,
+    });
+  }
+
+  // Compaction only after successful deletes (not dry-run)
+  if (compact && !dryRun) {
+    const totalErrors = Object.values(stats).reduce((n, s) => n + s.errors, 0);
+    if (totalErrors === 0) {
+      for (const dbName of ['auth', 'invites'] as const) {
+        try {
+          log(`Compacting ${dbName}...`);
+          await compactCouchDatabase(dbName);
+          compacted.push(dbName);
+        } catch (err) {
+          log(`Compaction failed for ${dbName}: ${(err as Error).message}`);
+          stats.refresh.errors += 1; // attribute to overall error count
+        }
+      }
+    } else {
+      log('Skipping compaction due to delete errors.');
+    }
+  }
+
+  const durationMs = Date.now() - started;
+  const totalErrors = Object.values(stats).reduce((n, s) => n + s.errors, 0);
+  const success = totalErrors <= errorThreshold;
+
+  for (const [type, s] of Object.entries(stats)) {
+    if (
+      type === 'longlived' &&
+      !includeLongLived &&
+      s.scanned === 0 &&
+      s.deleted === 0
+    ) {
+      continue;
+    }
+    log(
+      `  ${type}: scanned=${s.scanned} deleted=${s.deleted} skipped=${s.skipped} errors=${s.errors}`
+    );
+  }
+  log(
+    `TTL cleanup finished in ${durationMs}ms (success=${success}${compacted.length ? `, compacted=${compacted.join(',')}` : ''})`
+  );
+
+  return {dryRun, durationMs, stats, compacted, success};
+};

--- a/api/src/couchdb/ttlCleanup.ts
+++ b/api/src/couchdb/ttlCleanup.ts
@@ -278,7 +278,11 @@ async function* paginateByStartkey<T extends {_id?: string}>(
 
   while (hasMore) {
     const fetchLimit = batchSize + (skipFirst ? 1 : 0) + overFetch;
-    const {docs: fetched, lastRawId, fetchedCount} = await fetchPage({
+    const {
+      docs: fetched,
+      lastRawId,
+      fetchedCount,
+    } = await fetchPage({
       startkey,
       limit: fetchLimit,
     });

--- a/api/src/couchdb/ttlCleanup.ts
+++ b/api/src/couchdb/ttlCleanup.ts
@@ -198,8 +198,16 @@ export const shouldDeleteInvite = (
 };
 
 /**
- * Long-lived tokens: never delete non-expired enabled tokens. Delete
- * revoked (!enabled) or past-expiry tokens only after audit retention.
+ * Long-lived tokens: never delete enabled, non-expired tokens (including
+ * never-expiring ones). Revoked (`enabled === false`) or past-expiry tokens
+ * are kept for `auditRetentionMs` (default 30 days) so revocation/expiry
+ * remains auditable, then deleted.
+ *
+ * The audit clock (`auditAnchor`) starts at:
+ * - revoked: `updatedTimestampMs` (when it was disabled), falling back to
+ *   `createdTimestampMs`
+ * - expired but not revoked: `expiryTimestampMs`, then `updatedTimestampMs`,
+ *   then `createdTimestampMs`
  */
 export const shouldDeleteLongLivedToken = (
   doc: Pick<
@@ -234,109 +242,138 @@ export const shouldDeleteLongLivedToken = (
   return auditAnchor < nowMs - auditRetentionMs;
 };
 
+type StartkeyPage<T> = {
+  /** Docs after source-specific filtering (e.g. drop `_design/*`). */
+  docs: T[];
+  /** Last raw CouchDB row id; used to advance past filtered-only pages. */
+  lastRawId?: string;
+  /** Raw rows returned this fetch (for the page-full check). */
+  fetchedCount: number;
+};
+
+/**
+ * Inclusive-startkey pagination shared by auth views and invites `allDocs`.
+ *
+ * CouchDB `startkey` is inclusive, so after the first page we request
+ * `batchSize + 1` (+ `overFetch`) and drop the previous page's last id — but
+ * only when that id is still the first row. Concurrent deletes can remove
+ * that id from the view between pages; CouchDB then already starts at the
+ * next live key, and a blind skip would drop a live document.
+ *
+ * When the fetch callback filters rows (e.g. `_design/*`), `overFetch` and
+ * `lastRawId` keep us from stalling on filtered-only pages or dropping a
+ * local tail after capping to `batchSize`.
+ */
+async function* paginateByStartkey<T extends {_id?: string}>(
+  batchSize: number,
+  fetchPage: (opts: {
+    startkey?: string;
+    limit: number;
+  }) => Promise<StartkeyPage<T>>,
+  {overFetch = 0}: {overFetch?: number} = {}
+): AsyncGenerator<T[]> {
+  let startkey: string | undefined;
+  let skipFirst = false;
+  let hasMore = true;
+
+  while (hasMore) {
+    const fetchLimit = batchSize + (skipFirst ? 1 : 0) + overFetch;
+    const {docs: fetched, lastRawId, fetchedCount} = await fetchPage({
+      startkey,
+      limit: fetchLimit,
+    });
+    const pageFull = fetchedCount >= fetchLimit;
+
+    let docs = fetched;
+    // Only drop the startkey row when it is still present. Deletes between
+    // pages remove the previous page's last id from the view, so CouchDB's
+    // next page already starts at the next live key — blind skip would drop it.
+    if (skipFirst && docs.length > 0 && docs[0]._id === startkey) {
+      docs = docs.slice(1);
+    }
+
+    if (docs.length === 0) {
+      // Empty after filter (e.g. design-doc-only page): skip past last raw id
+      // when CouchDB may still have rows, otherwise we are done.
+      if (pageFull && lastRawId) {
+        startkey = lastRawId;
+        skipFirst = true;
+      } else {
+        hasMore = false;
+      }
+      continue;
+    }
+
+    const chunk = docs.slice(0, batchSize);
+    yield chunk;
+    const lastId = chunk[chunk.length - 1]._id;
+    // Continue when leftover filtered docs remain locally, or CouchDB may
+    // have more rows. Stopping on short pages alone permanently skips the
+    // remainder of `docs` after the first batchSize chunk.
+    if (lastId && (docs.length > batchSize || pageFull)) {
+      startkey = lastId;
+      skipFirst = true;
+    } else {
+      hasMore = false;
+    }
+  }
+}
+
+/** Page an auth-DB view by `_id` startkey. See {@link paginateByStartkey}. */
 async function* paginateAuthView<T extends {_id?: string}>(
   viewName: string,
   batchSize: number
 ): AsyncGenerator<T[]> {
   const authDB = getAuthDB();
-  let startkey: string | undefined;
-  let skipFirst = false;
-
-  for (;;) {
-    const fetchLimit = batchSize + (skipFirst ? 1 : 0);
+  yield* paginateByStartkey(batchSize, async ({startkey, limit}) => {
     const opts: PouchDB.Query.Options<any, any> = {
       include_docs: true,
-      limit: fetchLimit,
+      limit,
     };
     if (startkey !== undefined) {
       opts.startkey = startkey;
     }
-
     const result = await authDB.query<T>(viewName, opts);
-    let rows = result.rows.filter(r => !!r.doc).map(r => r.doc as T);
-
-    // Only drop the startkey row when it is still present. Deletes between
-    // pages remove the previous page's last id from the view, so CouchDB's
-    // next page already starts at the next live key — blind skip would drop it.
-    if (skipFirst && rows.length > 0 && rows[0]._id === startkey) {
-      rows = rows.slice(1);
-    }
-    if (rows.length === 0) {
-      return;
-    }
-
-    yield rows;
-
-    const lastId = rows[rows.length - 1]._id;
-    if (!lastId || rows.length < batchSize) {
-      return;
-    }
-    startkey = lastId;
-    skipFirst = true;
-  }
+    const docs = result.rows.filter(r => !!r.doc).map(r => r.doc as T);
+    return {
+      docs,
+      lastRawId: result.rows[result.rows.length - 1]?.id,
+      fetchedCount: result.rows.length,
+    };
+  });
 }
 
+/**
+ * Page the invites DB via `allDocs` (no type-specific view). Over-fetches so
+ * filtering `_design/*` still yields a full batch. See {@link paginateByStartkey}.
+ */
 async function* paginateInvitesAllDocs(
   batchSize: number
 ): AsyncGenerator<ExistingInvitesDBDocument[]> {
   const invitesDB = getInvitesDB();
-  let startkey: string | undefined;
-  let skipFirst = false;
-
-  for (;;) {
-    // Over-fetch so filtering `_design/*` and skipFirst still yields a full batch.
-    const fetchLimit = batchSize + (skipFirst ? 1 : 0) + 10;
-    const opts: Record<string, unknown> = {
-      include_docs: true,
-      limit: fetchLimit,
-    };
-    if (startkey !== undefined) {
-      opts.startkey = startkey;
-    }
-
-    const result = await invitesDB.allDocs(opts as any);
-    const rawRows = result.rows.filter(r => !!r.doc);
-    if (rawRows.length === 0) {
-      return;
-    }
-
-    let docs = rawRows
-      .filter(r => !r.id.startsWith('_design/'))
-      .map(r => r.doc as ExistingInvitesDBDocument);
-
-    if (skipFirst && docs.length > 0 && docs[0]._id === startkey) {
-      docs = docs.slice(1);
-    }
-
-    // Advance past the last raw row so we do not stall on design-doc-only pages.
-    const lastRawId = rawRows[rawRows.length - 1].id;
-
-    if (docs.length > 0) {
-      // Cap to batchSize for consistent bulk delete chunks.
-      const chunk = docs.slice(0, batchSize);
-      yield chunk;
-      const lastId = chunk[chunk.length - 1]._id;
-      if (!lastId) {
-        return;
+  yield* paginateByStartkey(
+    batchSize,
+    async ({startkey, limit}) => {
+      const opts: Record<string, unknown> = {
+        include_docs: true,
+        limit,
+      };
+      if (startkey !== undefined) {
+        opts.startkey = startkey;
       }
-      // Continue when this page still has unyielded filtered docs (over-fetch
-      // can leave a local tail even on a short CouchDB page), or when CouchDB
-      // may have more rows. Returning on short pages alone permanently skips
-      // the remainder of `docs` after the first batchSize chunk.
-      if (docs.length > batchSize || rawRows.length >= fetchLimit) {
-        startkey = lastId;
-        skipFirst = true;
-        continue;
-      }
-      return;
-    }
-
-    if (rawRows.length < fetchLimit) {
-      return;
-    }
-    startkey = lastRawId;
-    skipFirst = true;
-  }
+      const result = await invitesDB.allDocs(opts as any);
+      const rawRows = result.rows.filter(r => !!r.doc);
+      const docs = rawRows
+        .filter(r => !r.id.startsWith('_design/'))
+        .map(r => r.doc as ExistingInvitesDBDocument);
+      return {
+        docs,
+        lastRawId: rawRows[rawRows.length - 1]?.id,
+        fetchedCount: rawRows.length,
+      };
+    },
+    {overFetch: 10}
+  );
 }
 
 const bulkDelete = async (

--- a/api/src/couchdb/verificationChallenges.ts
+++ b/api/src/couchdb/verificationChallenges.ts
@@ -23,10 +23,10 @@ import {getCouchUserFromEmailOrUserId} from './users';
 // Expiry time in milliseconds - 24 hours by default
 const VERIFICATION_CHALLENGE_EXPIRY_MS = 24 * 60 * 60 * 1000;
 
-// Rate limiting constants
-const MAX_VERIFICATION_ATTEMPTS = 5; // Maximum number of verification attempts
-const VERIFICATION_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours window for rate limiting
-const VERIFICATION_COOLDOWN_MS = 30 * 60 * 1000; // 30 minute cooldown after max attempts
+// Rate limiting constants (exported for TTL cleanup retention windows)
+export const MAX_VERIFICATION_ATTEMPTS = 5; // Maximum number of verification attempts
+export const VERIFICATION_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours window for rate limiting
+export const VERIFICATION_COOLDOWN_MS = 30 * 60 * 1000; // 30 minute cooldown after max attempts
 
 /**
  * Creates a new email verification challenge for a given user.

--- a/api/src/scripts/ttlCleanup.ts
+++ b/api/src/scripts/ttlCleanup.ts
@@ -1,0 +1,206 @@
+/* eslint-disable n/no-process-exit */
+/**
+ * One-shot TTL cleanup for ephemeral CouchDB documents (auth + invites).
+ *
+ * Deletes expired refresh tokens, email codes, verification challenges,
+ * invites, and optionally long-lived tokens after retention windows that
+ * preserve auth attempt rate-limiting.
+ *
+ * NEVER deletes:
+ *   - people / projects / templates / teams / migrations docs
+ *   - data-* survey record databases
+ *   - survey tombstones (intentional permanent audit markers)
+ *
+ * Usage (from api/ or via filter):
+ *   pnpm run ttl-cleanup --dry-run
+ *   pnpm run ttl-cleanup
+ *   pnpm run ttl-cleanup --include-longlived --compact
+ *   pnpm --filter=@faims3/api ttl-cleanup --dry-run
+ *
+ * Flags:
+ *   --dry-run                    Report candidates only; write nothing
+ *   --compact                    After successful deletes, compact auth + invites
+ *   --grace-ms <n>               Override refresh (and invite) grace in ms (default: 1 day)
+ *   --include-longlived          Also sweep long-lived tokens (audit retention 30d)
+ *   --delete-exhausted-invites   Also delete non-expired invites with exhausted uses
+ *   --batch-size <n>             bulkDocs chunk size (default: 100)
+ *   -h, --help                   Show this help
+ *
+ * Exit codes:
+ *   0  success (including dry-run)
+ *   1  CouchDB connection failure, fatal error, or delete errors above threshold
+ *
+ * Production (Dockerfile.build): override CMD to run the compiled script, e.g.
+ *   node /app/api/build/src/scripts/ttlCleanup.js --dry-run
+ */
+
+import {config} from '../buildconfig';
+import {verifyCouchDBConnection} from '../couchdb';
+import {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_INVITE_GRACE_MS,
+  DEFAULT_REFRESH_GRACE_MS,
+  runTtlCleanup,
+} from '../couchdb/ttlCleanup';
+
+type CliArgs = {
+  dryRun: boolean;
+  compact: boolean;
+  includeLongLived: boolean;
+  deleteExhaustedInvites: boolean;
+  graceMs: number | undefined;
+  batchSize: number;
+  help: boolean;
+};
+
+const showHelp = () => {
+  console.log(`Usage: pnpm run ttl-cleanup [options]
+
+One-shot cleanup of expired ephemeral auth/invite CouchDB documents.
+
+Options:
+  --dry-run                    Count/log candidates only; do not delete
+  --compact                    Compact auth + invites after successful deletes
+  --grace-ms <n>               Grace after refresh/invite expiry in ms (default: ${DEFAULT_REFRESH_GRACE_MS})
+  --include-longlived          Enable long-lived token sweep (audit retention 30d)
+  --delete-exhausted-invites   Also delete non-expired invites with exhausted uses
+  --batch-size <n>             bulkDocs batch size (default: ${DEFAULT_BATCH_SIZE})
+  -h, --help                   Show this help
+
+Never deletes people, projects, data-*, or survey tombstones.
+Email codes / verification challenges are retained for rate-limit window +
+cooldown (+ small grace), not deleted at code expiry alone.
+By default, exhausted-but-unexpired invites are kept (uses may be raised later).
+`);
+};
+
+const parseArgs = (argv: string[]): CliArgs => {
+  const args: CliArgs = {
+    dryRun: false,
+    compact: false,
+    includeLongLived: false,
+    deleteExhaustedInvites: false,
+    graceMs: undefined,
+    batchSize: DEFAULT_BATCH_SIZE,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    // pnpm may forward a bare `--` separator into argv
+    if (arg === '--') {
+      continue;
+    }
+    if (arg === '-h' || arg === '--help') {
+      args.help = true;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (arg === '--compact') {
+      args.compact = true;
+      continue;
+    }
+    if (arg === '--include-longlived') {
+      args.includeLongLived = true;
+      continue;
+    }
+    if (arg === '--delete-exhausted-invites') {
+      args.deleteExhaustedInvites = true;
+      continue;
+    }
+    if (arg === '--grace-ms') {
+      const raw = argv[++i];
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new Error(`Invalid --grace-ms value: ${raw}`);
+      }
+      args.graceMs = n;
+      continue;
+    }
+    if (arg.startsWith('--grace-ms=')) {
+      const n = Number(arg.slice('--grace-ms='.length));
+      if (!Number.isFinite(n) || n < 0) {
+        throw new Error(`Invalid --grace-ms value: ${arg}`);
+      }
+      args.graceMs = n;
+      continue;
+    }
+    if (arg === '--batch-size') {
+      const raw = argv[++i];
+      const n = Number(raw);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`Invalid --batch-size value: ${raw}`);
+      }
+      args.batchSize = n;
+      continue;
+    }
+    if (arg.startsWith('--batch-size=')) {
+      const n = Number(arg.slice('--batch-size='.length));
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`Invalid --batch-size value: ${arg}`);
+      }
+      args.batchSize = n;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+
+  return args;
+};
+
+const main = async () => {
+  let args: CliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error((err as Error).message);
+    showHelp();
+    process.exit(1);
+  }
+
+  if (args.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  console.log(`Couch server: ${config.couchdbInternalUrl}`);
+
+  const connection = await verifyCouchDBConnection();
+  if (!connection.valid) {
+    console.error('Cannot reach CouchDB. Aborting.');
+    console.error(connection.validate_error || connection.server_msg);
+    if (connection.database_errors?.length) {
+      for (const e of connection.database_errors) {
+        console.error(`  ${e}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  const refreshGraceMs = args.graceMs ?? DEFAULT_REFRESH_GRACE_MS;
+  const inviteGraceMs =
+    args.graceMs !== undefined ? args.graceMs : DEFAULT_INVITE_GRACE_MS;
+
+  const result = await runTtlCleanup({
+    dryRun: args.dryRun,
+    compact: args.compact,
+    includeLongLived: args.includeLongLived,
+    deleteExhaustedInvites: args.deleteExhaustedInvites,
+    refreshGraceMs,
+    inviteGraceMs,
+    batchSize: args.batchSize,
+  });
+
+  process.exit(result.success ? 0 : 1);
+};
+
+main().catch(error => {
+  console.error('ttlCleanup failed:', error);
+  process.exit(1);
+});

--- a/api/test/ttlCleanup.test.ts
+++ b/api/test/ttlCleanup.test.ts
@@ -567,6 +567,85 @@ describe('TTL cleanup sweep integration', () => {
     expect(second.stats.longlived.deleted).toBe(0);
   });
 
+  it('scans invite tail when over-fetch exceeds batchSize on a short page', async () => {
+    // paginateInvitesAllDocs over-fetches by +10 then caps to batchSize. With
+    // batchSize=10 a single short page can hold 15 filtered invites; the old
+    // exit condition (rawRows.length < fetchLimit) dropped the last 5 forever.
+    const admin = await getUsersDB().get(adminUserName);
+    const invitesDB = getInvitesDB();
+    const now = Date.now();
+    const batchSize = 10;
+    const total = 15;
+    const ids: string[] = [];
+
+    for (let i = 0; i < total; i++) {
+      const invite = await createResourceInvite({
+        resourceType: Resource.PROJECT,
+        resourceId: 'proj-ttl-page',
+        role: Role.PROJECT_CONTRIBUTOR,
+        name: `expired-page-${i}`,
+        createdBy: admin._id,
+        expiry: now - HOUR_MS,
+      });
+      ids.push(invite._id);
+    }
+
+    const result = await runTtlCleanup({
+      dryRun: false,
+      nowMs: now,
+      batchSize,
+      log: () => {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.stats.invite.scanned).toBe(total);
+    expect(result.stats.invite.deleted).toBe(total);
+
+    for (const id of ids) {
+      await expect(invitesDB.get(id)).rejects.toMatchObject({status: 404});
+    }
+  });
+
+  it('auth pagination does not skip the next live doc after deleting a page anchor', async () => {
+    const authDB = getAuthDB();
+    const local = await getUsersDB().get(localUserName);
+    const now = Date.now();
+    const expiryTimestampMs = now - DEFAULT_REFRESH_GRACE_MS - HOUR_MS;
+
+    // Five consecutive expired refresh docs; batchSize 2 forces page boundaries
+    // on every even id. After page [a,b] deletes b, the next query with
+    // startkey=b must still process c (not slice it away).
+    const ids = ['a', 'b', 'c', 'd', 'e'].map(
+      s => `${AUTH_RECORD_ID_PREFIXES.refresh}ttl-page-${s}`
+    );
+    for (const id of ids) {
+      await authDB.put({
+        _id: id,
+        documentType: 'refresh',
+        userId: local._id,
+        expiryTimestampMs,
+        token: `tok-${id}`,
+        enabled: true,
+        exchangeTokenHash: `hash-${id}`,
+        exchangeTokenUsed: false,
+        exchangeTokenExpiryTimestampMs: now - HOUR_MS,
+      });
+    }
+
+    const result = await runTtlCleanup({
+      dryRun: false,
+      batchSize: 2,
+      nowMs: now,
+      log: () => {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.stats.refresh.deleted).toBe(5);
+    for (const id of ids) {
+      await expect(authDB.get(id)).rejects.toMatchObject({status: 404});
+    }
+  });
+
   it('does not delete long-lived tokens when flag is off', async () => {
     const authDB = getAuthDB();
     const local = await getUsersDB().get(localUserName);

--- a/api/test/ttlCleanup.test.ts
+++ b/api/test/ttlCleanup.test.ts
@@ -1,0 +1,608 @@
+import PouchDB from 'pouchdb';
+import PouchDBFind from 'pouchdb-find';
+PouchDB.plugin(require('pouchdb-adapter-memory'));
+PouchDB.plugin(PouchDBFind);
+
+import {AUTH_RECORD_ID_PREFIXES, Resource, Role} from '@faims3/data-model';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {getAuthDB, getInvitesDB, getUsersDB} from '../src/couchdb';
+import {
+  createNewEmailCode,
+  EMAIL_CODE_COOLDOWN_MS,
+  EMAIL_CODE_RATE_LIMIT_WINDOW_MS,
+} from '../src/couchdb/emailReset';
+import {createResourceInvite} from '../src/couchdb/invites';
+import {createNewLongLivedToken} from '../src/couchdb/longLivedTokens';
+import {createNewRefreshToken} from '../src/couchdb/refreshTokens';
+import {
+  DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS,
+  DEFAULT_RATE_LIMIT_GRACE_MS,
+  DEFAULT_REFRESH_GRACE_MS,
+  emailCodeRetentionMs,
+  runTtlCleanup,
+  shouldDeleteEmailCode,
+  shouldDeleteInvite,
+  shouldDeleteLongLivedToken,
+  shouldDeleteRefreshToken,
+  shouldDeleteVerificationChallenge,
+  verificationRetentionMs,
+} from '../src/couchdb/ttlCleanup';
+import {
+  createVerificationChallenge,
+  VERIFICATION_COOLDOWN_MS,
+  VERIFICATION_RATE_LIMIT_WINDOW_MS,
+} from '../src/couchdb/verificationChallenges';
+import {adminUserName, beforeApiTests, localUserName} from './utils';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+describe('TTL cleanup retention predicates', () => {
+  const now = Date.UTC(2026, 7, 12, 0, 0, 0);
+
+  describe('shouldDeleteRefreshToken', () => {
+    it('deletes refresh tokens expired past grace', () => {
+      expect(
+        shouldDeleteRefreshToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.refresh}a`,
+            documentType: 'refresh',
+            enabled: true,
+            expiryTimestampMs: now - DEFAULT_REFRESH_GRACE_MS - 1,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('keeps not-yet-expired refresh tokens', () => {
+      expect(
+        shouldDeleteRefreshToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.refresh}a`,
+            documentType: 'refresh',
+            enabled: true,
+            expiryTimestampMs: now + HOUR_MS,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('keeps tokens inside the grace window after expiry', () => {
+      expect(
+        shouldDeleteRefreshToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.refresh}a`,
+            documentType: 'refresh',
+            enabled: true,
+            expiryTimestampMs: now - DEFAULT_REFRESH_GRACE_MS + HOUR_MS,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('deletes disabled tokens once expiry is past grace', () => {
+      expect(
+        shouldDeleteRefreshToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.refresh}a`,
+            documentType: 'refresh',
+            enabled: false,
+            expiryTimestampMs: now - DEFAULT_REFRESH_GRACE_MS - 1,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('rejects wrong documentType / id prefix', () => {
+      expect(
+        shouldDeleteRefreshToken(
+          {
+            _id: 'people_someone',
+            documentType: 'refresh',
+            enabled: true,
+            expiryTimestampMs: now - DAY_MS * 10,
+          },
+          now
+        )
+      ).toBe(false);
+      expect(
+        shouldDeleteRefreshToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.refresh}a`,
+            documentType: 'emailcode' as any,
+            enabled: true,
+            expiryTimestampMs: now - DAY_MS * 10,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('shouldDeleteEmailCode', () => {
+    const retention = emailCodeRetentionMs();
+
+    it('keeps codes still inside rate-limit retention (even if code expired/used)', () => {
+      const created = now - EMAIL_CODE_RATE_LIMIT_WINDOW_MS;
+      expect(
+        shouldDeleteEmailCode(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.emailcode}a`,
+            documentType: 'emailcode',
+            createdTimestampMs: created,
+            expiryTimestampMs: created + 30 * 60 * 1000,
+            used: true,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('deletes codes older than window + cooldown + grace', () => {
+      expect(
+        shouldDeleteEmailCode(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.emailcode}a`,
+            documentType: 'emailcode',
+            createdTimestampMs: now - retention - 1,
+            expiryTimestampMs: now - retention,
+            used: false,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('falls back to expiryTimestampMs when created is missing', () => {
+      expect(
+        shouldDeleteEmailCode(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.emailcode}a`,
+            documentType: 'emailcode',
+            createdTimestampMs: undefined as any,
+            expiryTimestampMs: now - retention - 1,
+            used: false,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('retention equals window + cooldown + default grace', () => {
+      expect(emailCodeRetentionMs()).toBe(
+        EMAIL_CODE_RATE_LIMIT_WINDOW_MS +
+          EMAIL_CODE_COOLDOWN_MS +
+          DEFAULT_RATE_LIMIT_GRACE_MS
+      );
+    });
+  });
+
+  describe('shouldDeleteVerificationChallenge', () => {
+    const retention = verificationRetentionMs();
+
+    it('keeps challenges inside verification retention window', () => {
+      expect(
+        shouldDeleteVerificationChallenge(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.verification}a`,
+            documentType: 'verification',
+            createdTimestampMs: now - VERIFICATION_RATE_LIMIT_WINDOW_MS,
+            expiryTimestampMs: now - HOUR_MS,
+            used: true,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('deletes challenges older than window + cooldown + grace', () => {
+      expect(
+        shouldDeleteVerificationChallenge(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.verification}a`,
+            documentType: 'verification',
+            createdTimestampMs: now - retention - 1,
+            expiryTimestampMs: now - retention,
+            used: false,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('retention equals verification window + cooldown + grace', () => {
+      expect(verificationRetentionMs()).toBe(
+        VERIFICATION_RATE_LIMIT_WINDOW_MS +
+          VERIFICATION_COOLDOWN_MS +
+          DEFAULT_RATE_LIMIT_GRACE_MS
+      );
+    });
+  });
+
+  describe('shouldDeleteInvite', () => {
+    it('deletes when expiry is in the past', () => {
+      expect(
+        shouldDeleteInvite({_id: 'inv1', expiry: now - 1, usesConsumed: 0}, now)
+      ).toBe(true);
+    });
+
+    it('keeps future expiry', () => {
+      expect(
+        shouldDeleteInvite(
+          {_id: 'inv1', expiry: now + DAY_MS, usesConsumed: 0},
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('keeps exhausted non-expired invites by default (uses may be raised later)', () => {
+      expect(
+        shouldDeleteInvite(
+          {
+            _id: 'inv1',
+            expiry: now + DAY_MS,
+            usesOriginal: 2,
+            usesConsumed: 2,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('deletes exhausted capped uses when deleteExhausted is enabled', () => {
+      expect(
+        shouldDeleteInvite(
+          {
+            _id: 'inv1',
+            expiry: now + DAY_MS,
+            usesOriginal: 2,
+            usesConsumed: 2,
+          },
+          now,
+          {deleteExhausted: true}
+        )
+      ).toBe(true);
+    });
+
+    it('still deletes expired invites even when exhausted-delete is off', () => {
+      expect(
+        shouldDeleteInvite(
+          {
+            _id: 'inv1',
+            expiry: now - 1,
+            usesOriginal: 1,
+            usesConsumed: 1,
+          },
+          now,
+          {deleteExhausted: false}
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('shouldDeleteLongLivedToken', () => {
+    it('keeps active non-expired tokens', () => {
+      expect(
+        shouldDeleteLongLivedToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.longlived}a`,
+            documentType: 'longlived',
+            enabled: true,
+            expiryTimestampMs: now + DAY_MS,
+            updatedTimestampMs: now - DAY_MS * 60,
+            createdTimestampMs: now - DAY_MS * 60,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('keeps never-expiring enabled tokens', () => {
+      expect(
+        shouldDeleteLongLivedToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.longlived}a`,
+            documentType: 'longlived',
+            enabled: true,
+            expiryTimestampMs: undefined,
+            updatedTimestampMs: now - DAY_MS * 60,
+            createdTimestampMs: now - DAY_MS * 60,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+
+    it('deletes expired tokens past audit retention', () => {
+      const expiredAt = now - DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS - 1;
+      expect(
+        shouldDeleteLongLivedToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.longlived}a`,
+            documentType: 'longlived',
+            enabled: true,
+            expiryTimestampMs: expiredAt,
+            updatedTimestampMs: expiredAt,
+            createdTimestampMs: expiredAt - DAY_MS,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('deletes revoked tokens past audit retention', () => {
+      const revokedAt = now - DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS - 1;
+      expect(
+        shouldDeleteLongLivedToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.longlived}a`,
+            documentType: 'longlived',
+            enabled: false,
+            expiryTimestampMs: now + DAY_MS,
+            updatedTimestampMs: revokedAt,
+            createdTimestampMs: revokedAt - DAY_MS,
+          },
+          now
+        )
+      ).toBe(true);
+    });
+
+    it('keeps recently revoked tokens inside audit window', () => {
+      expect(
+        shouldDeleteLongLivedToken(
+          {
+            _id: `${AUTH_RECORD_ID_PREFIXES.longlived}a`,
+            documentType: 'longlived',
+            enabled: false,
+            expiryTimestampMs: now + DAY_MS,
+            updatedTimestampMs: now - DAY_MS,
+            createdTimestampMs: now - DAY_MS * 2,
+          },
+          now
+        )
+      ).toBe(false);
+    });
+  });
+});
+
+describe('TTL cleanup sweep integration', () => {
+  beforeEach(beforeApiTests);
+
+  it('deletes eligible docs, respects retention, dry-run mutates nothing, second run is idempotent', async () => {
+    const authDB = getAuthDB();
+    const invitesDB = getInvitesDB();
+    const usersDB = getUsersDB();
+    const admin = await usersDB.get(adminUserName);
+    const local = await usersDB.get(localUserName);
+    const now = Date.now();
+
+    // --- Refresh: one deletable (expired past grace), one keep ---
+    const {refresh: expiredRefresh} = await createNewRefreshToken({
+      userId: local._id,
+      refreshExpiryMs: 60_000,
+    });
+    await authDB.put({
+      ...expiredRefresh,
+      expiryTimestampMs: now - DEFAULT_REFRESH_GRACE_MS - HOUR_MS,
+    });
+
+    const {refresh: liveRefresh} = await createNewRefreshToken({
+      userId: local._id,
+      refreshExpiryMs: 60_000,
+    });
+    await authDB.put({
+      ...liveRefresh,
+      expiryTimestampMs: now + DAY_MS,
+    });
+
+    // --- Email code: inside retention (keep), outside (delete), used+old (delete) ---
+    const {record: recentEmail} = await createNewEmailCode({
+      userId: local._id,
+    });
+    // leave timestamps as-is → inside retention → keep
+
+    const {record: oldEmail} = await createNewEmailCode({
+      userId: admin._id,
+    });
+    const oldEmailAnchor = now - emailCodeRetentionMs() - HOUR_MS;
+    await authDB.put({
+      ...oldEmail,
+      createdTimestampMs: oldEmailAnchor,
+      expiryTimestampMs: oldEmailAnchor + 30 * 60 * 1000,
+      used: true,
+    });
+
+    // --- Verification: recent keep, old delete ---
+    const {record: recentVerify} = await createVerificationChallenge({
+      userId: local._id,
+      email: 'local@example.com',
+    });
+
+    const {record: oldVerify} = await createVerificationChallenge({
+      userId: admin._id,
+      email: 'admin@example.com',
+    });
+    const oldVerifyAnchor = now - verificationRetentionMs() - HOUR_MS;
+    await authDB.put({
+      ...oldVerify,
+      createdTimestampMs: oldVerifyAnchor,
+      expiryTimestampMs: oldVerifyAnchor + DAY_MS,
+    });
+
+    // --- Invites: expired delete; future + exhausted-but-unexpired keep ---
+    const expiredInvite = await createResourceInvite({
+      resourceType: Resource.PROJECT,
+      resourceId: 'proj-ttl-1',
+      role: Role.PROJECT_CONTRIBUTOR,
+      name: 'expired',
+      createdBy: admin._id,
+      expiry: now - HOUR_MS,
+    });
+    const futureInvite = await createResourceInvite({
+      resourceType: Resource.PROJECT,
+      resourceId: 'proj-ttl-1',
+      role: Role.PROJECT_ADMIN,
+      name: 'future',
+      createdBy: admin._id,
+      expiry: now + DAY_MS * 10,
+    });
+    const exhaustedInvite = await createResourceInvite({
+      resourceType: Resource.PROJECT,
+      resourceId: 'proj-ttl-2',
+      role: Role.PROJECT_CONTRIBUTOR,
+      name: 'exhausted',
+      createdBy: admin._id,
+      expiry: now + DAY_MS * 10,
+      usesOriginal: 1,
+    });
+    await invitesDB.put({
+      ...exhaustedInvite,
+      usesConsumed: 1,
+    });
+
+    // --- Long-lived: active keep; revoked+old delete when included ---
+    const {record: activeLongLived} = await createNewLongLivedToken({
+      userId: local._id,
+      title: 'active',
+      description: 'keep me',
+      expiryTimestampMs: now + DAY_MS * 30,
+    });
+    const {record: revokedLongLived} = await createNewLongLivedToken({
+      userId: local._id,
+      title: 'revoked',
+      description: 'delete me',
+      expiryTimestampMs: now + DAY_MS * 30,
+    });
+    await authDB.put({
+      ...revokedLongLived,
+      enabled: false,
+      updatedTimestampMs: now - DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS - HOUR_MS,
+    });
+
+    // People doc must never be touched
+    const peopleBefore = await usersDB.get(local._id);
+
+    // Dry-run: no mutations
+    const dry = await runTtlCleanup({
+      dryRun: true,
+      includeLongLived: true,
+      nowMs: now,
+      log: () => {},
+    });
+    expect(dry.success).toBe(true);
+    expect(dry.stats.refresh.deleted).toBeGreaterThanOrEqual(1);
+    expect(dry.stats.emailcode.deleted).toBeGreaterThanOrEqual(1);
+    expect(dry.stats.verification.deleted).toBeGreaterThanOrEqual(1);
+    expect(dry.stats.invite.deleted).toBeGreaterThanOrEqual(1);
+    expect(dry.stats.longlived.deleted).toBeGreaterThanOrEqual(1);
+
+    expect(await authDB.get(expiredRefresh._id)).toBeTruthy();
+    expect(await authDB.get(oldEmail._id)).toBeTruthy();
+    expect(await authDB.get(oldVerify._id)).toBeTruthy();
+    expect(await invitesDB.get(expiredInvite._id)).toBeTruthy();
+    expect(await authDB.get(revokedLongLived._id)).toBeTruthy();
+
+    // Destructive run
+    const first = await runTtlCleanup({
+      dryRun: false,
+      includeLongLived: true,
+      nowMs: now,
+      log: () => {},
+    });
+    expect(first.success).toBe(true);
+    expect(first.stats.refresh.deleted).toBeGreaterThanOrEqual(1);
+    expect(first.stats.emailcode.deleted).toBeGreaterThanOrEqual(1);
+    expect(first.stats.verification.deleted).toBeGreaterThanOrEqual(1);
+    expect(first.stats.invite.deleted).toBeGreaterThanOrEqual(1);
+    expect(first.stats.longlived.deleted).toBeGreaterThanOrEqual(1);
+
+    await expect(authDB.get(expiredRefresh._id)).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(authDB.get(oldEmail._id)).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(authDB.get(oldVerify._id)).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(invitesDB.get(expiredInvite._id)).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(authDB.get(revokedLongLived._id)).rejects.toMatchObject({
+      status: 404,
+    });
+
+    // Kept docs (including exhausted-but-unexpired invites)
+    expect((await authDB.get(liveRefresh._id))._id).toBe(liveRefresh._id);
+    expect((await authDB.get(recentEmail._id))._id).toBe(recentEmail._id);
+    expect((await authDB.get(recentVerify._id))._id).toBe(recentVerify._id);
+    expect((await invitesDB.get(futureInvite._id))._id).toBe(futureInvite._id);
+    expect((await invitesDB.get(exhaustedInvite._id))._id).toBe(
+      exhaustedInvite._id
+    );
+    expect((await authDB.get(activeLongLived._id))._id).toBe(
+      activeLongLived._id
+    );
+
+    // People untouched
+    const peopleAfter = await usersDB.get(local._id);
+    expect(peopleAfter._rev).toBe(peopleBefore._rev);
+
+    // Idempotent second run: no further deletes of remaining candidates
+    const second = await runTtlCleanup({
+      dryRun: false,
+      includeLongLived: true,
+      nowMs: now,
+      log: () => {},
+    });
+    expect(second.success).toBe(true);
+    expect(second.stats.refresh.deleted).toBe(0);
+    expect(second.stats.emailcode.deleted).toBe(0);
+    expect(second.stats.verification.deleted).toBe(0);
+    expect(second.stats.invite.deleted).toBe(0);
+    expect(second.stats.longlived.deleted).toBe(0);
+  });
+
+  it('does not delete long-lived tokens when flag is off', async () => {
+    const authDB = getAuthDB();
+    const local = await getUsersDB().get(localUserName);
+    const now = Date.now();
+
+    const {record} = await createNewLongLivedToken({
+      userId: local._id,
+      title: 'revoked',
+      description: 'should remain when flag off',
+      expiryTimestampMs: now + DAY_MS * 30,
+    });
+    await authDB.put({
+      ...record,
+      enabled: false,
+      updatedTimestampMs: now - DEFAULT_LONG_LIVED_AUDIT_RETENTION_MS - HOUR_MS,
+    });
+
+    const result = await runTtlCleanup({
+      dryRun: false,
+      includeLongLived: false,
+      nowMs: now,
+      log: () => {},
+    });
+    expect(result.stats.longlived.scanned).toBe(0);
+    expect(result.stats.longlived.deleted).toBe(0);
+    expect((await authDB.get(record._id))._id).toBe(record._id);
+  });
+
+  it('negative: never selects people docs via auth predicates', () => {
+    const now = Date.now();
+    const peopleShaped = {
+      _id: 'admin',
+      documentType: 'refresh' as const,
+      enabled: true,
+      expiryTimestampMs: now - DAY_MS * 100,
+    };
+    expect(shouldDeleteRefreshToken(peopleShaped, now)).toBe(false);
+  });
+});

--- a/docs/developer/docs/source/index.rst
+++ b/docs/developer/docs/source/index.rst
@@ -17,6 +17,7 @@ FAIMS3 Developer Documentation
    markdown/GeospatialExport.md
    markdown/Long-lived-tokens.md
    markdown/TokenManagement.md
+   markdown/TtlCleanup.md
    markdown/TestDatasetSeeding.md
    markdown/Configuration.md
    markdown/Android-Deployment.md

--- a/docs/developer/docs/source/markdown/TtlCleanup.md
+++ b/docs/developer/docs/source/markdown/TtlCleanup.md
@@ -1,0 +1,95 @@
+# TTL cleanup of ephemeral CouchDB documents
+
+Ephemeral auth and invite documents expire in application logic, but CouchDB
+does not purge them automatically. Conductor provides a **one-shot CLI** that
+deletes eligible docs after retention windows that preserve auth rate-limiting.
+
+We don't currently utilise the CouchDB \_purge mechanism. Compacting deleted
+records will leave very minimal data, and it is not currently seen as
+worthwhile purging documents.
+
+## What is cleaned
+
+| Doc type       | DB        | When deleted                                                                                                               |
+| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `refresh`      | `auth`    | `expiryTimestampMs` older than now + grace (default 1 day)                                                                 |
+| `emailcode`    | `auth`    | Anchor (`createdTimestampMs`, else expiry) older than rate-limit window + cooldown + grace (not at code expiry alone)      |
+| `verification` | `auth`    | Same model with verification window (24h) + cooldown (30m) + grace                                                         |
+| invite         | `invites` | `expiry` in the past (+ optional grace). Exhausted-but-unexpired invites are **kept** by default                           |
+| `longlived`    | `auth`    | Opt-in (`--include-longlived`): revoked or past expiry, after 30d audit retention. Never deletes active non-expired tokens |
+
+Never touches `people`, `projects`, templates, teams, `data-*` survey DBs, or tombstones.
+
+## Local usage
+
+From the `api` package (requires Conductor `.env` / Couch connectivity):
+
+```bash
+pnpm run ttl-cleanup --dry-run
+pnpm run ttl-cleanup
+pnpm run ttl-cleanup --include-longlived --compact
+pnpm --filter=@faims3/api ttl-cleanup --dry-run
+```
+
+Useful flags:
+
+| Flag                         | Default                                            | Purpose                                                          |
+| ---------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
+| `--dry-run`                  | off                                                | Count/log candidates only                                        |
+| `--compact`                  | off                                                | `POST /{db}/_compact` on auth + invites after successful deletes |
+| `--grace-ms <n>`             | 1d (refresh); also overrides invite grace when set | Extra retention after expiry                                     |
+| `--include-longlived`        | off                                                | Enable long-lived sweep                                          |
+| `--delete-exhausted-invites` | off                                                | Also delete non-expired invites with exhausted capped uses       |
+| `--batch-size <n>`           | 100                                                | `bulkDocs` chunk size                                            |
+
+Exit `0` on success (including dry-run); non-zero on Couch connection failure or delete errors above threshold.
+
+Implementation: `api/src/couchdb/ttlCleanup.ts` (retention + sweep) and
+`api/src/scripts/ttlCleanup.ts` (CLI). Unit tests: `api/test/ttlCleanup.test.ts`.
+
+## Production image
+
+The API image (`Dockerfile.build`) defaults to `node index.js`. Override the
+container command to run the compiled script, e.g.:
+
+```text
+node /app/api/build/src/scripts/ttlCleanup.js --dry-run
+```
+
+(WORKDIR under `NODE_RUN_DIR` may already be `/app/api/build/src`, in which case
+`node scripts/ttlCleanup.js` is enough — match the CDK task definition.)
+
+## AWS schedule
+
+On AWS, cleanup runs as a **separate one-shot Fargate task** scheduled by
+EventBridge Scheduler (`taskCount: 1`), not as in-process cron on the Conductor
+service (which would race across scaled tasks). See
+[infrastructure/aws-cdk/README.md](../../../../../infrastructure/aws-cdk/README.md)
+(`ttlCleanup` config) and the `FaimsTtlCleanup` construct.
+
+### Cron timezone
+
+`scheduleExpression` hours are interpreted in `scheduleExpressionTimezone`
+(EventBridge `ScheduleExpressionTimezone`), **not** UTC by default:
+
+| Config key                   | Default             | Meaning                                |
+| ---------------------------- | ------------------- | -------------------------------------- |
+| `scheduleExpression`         | `cron(0 2 * * ? *)` | Minute / hour / … for EventBridge cron |
+| `scheduleExpressionTimezone` | `Australia/Sydney`  | IANA zone for that cron                |
+
+So the sample daily run is **02:00 Australia/Sydney** and stays on local 02:00
+through AEST (UTC+10) and AEDT (UTC+11). To target a fixed UTC hour instead, set
+`scheduleExpressionTimezone` to `UTC` and adjust the cron hour accordingly.
+
+Config flags map to CLI argv via `buildTtlCleanupCommand`:
+
+| Config key               | CLI flag                     | Default |
+| ------------------------ | ---------------------------- | ------- |
+| `dryRun`                 | `--dry-run`                  | `false` |
+| `compact`                | `--compact`                  | `false` |
+| `includeLongLived`       | `--include-longlived`        | `false` |
+| `deleteExhaustedInvites` | `--delete-exhausted-invites` | `false` |
+
+Suggested ops order: ship an API image that includes the script → enable the
+schedule with `dryRun: true` in staging → enable deletes → keep `compact: false`
+on the daily schedule (compact manually or on a rarer cadence).

--- a/docs/developer/docs/source/markdown/TtlCleanup.md
+++ b/docs/developer/docs/source/markdown/TtlCleanup.md
@@ -13,12 +13,12 @@ worthwhile purging documents.
 Docs are not deleted the instant they expire. Each type is kept for a short
 extra window so in-flight auth and rate-limiting still work, then removed.
 
-| Doc type       | DB        | When deleted                                                                                                                                     |
-| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `refresh`      | `auth`    | Kept for **1 day after expiry** (override with `--grace-ms`), then deleted                                                                       |
-| `emailcode`    | `auth`    | Kept for **rate-limit window + cooldown + 1h** from creation (fallback: expiry). Not deleted when the code itself expires                        |
-| `verification` | `auth`    | Same idea: kept for **24h window + 30m cooldown + 1h** from creation (fallback: expiry)                                                          |
-| invite         | `invites` | Deleted once `expiry` has passed (no extra wait by default; `--grace-ms` can add one). Exhausted-but-unexpired invites are **kept** by default |
+| Doc type       | DB        | When deleted                                                                                                                                    |
+| -------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `refresh`      | `auth`    | Kept for **1 day after expiry** (override with `--grace-ms`), then deleted                                                                      |
+| `emailcode`    | `auth`    | Kept for **rate-limit window + cooldown + 1h** from creation (fallback: expiry). Not deleted when the code itself expires                       |
+| `verification` | `auth`    | Same idea: kept for **24h window + 30m cooldown + 1h** from creation (fallback: expiry)                                                         |
+| invite         | `invites` | Deleted once `expiry` has passed (no extra wait by default; `--grace-ms` can add one). Exhausted-but-unexpired invites are **kept** by default  |
 | `longlived`    | `auth`    | Opt-in (`--include-longlived`): revoked or expired tokens kept **30 days** for audit, then deleted. Active non-expired tokens are never deleted |
 
 Never touches `people`, `projects`, templates, teams, `data-*` survey DBs, or tombstones.
@@ -36,14 +36,14 @@ pnpm --filter=@faims3/api ttl-cleanup --dry-run
 
 Useful flags:
 
-| Flag                         | Default                                            | Purpose                                                          |
-| ---------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
-| `--dry-run`                  | off                                                | Count/log candidates only                                        |
-| `--compact`                  | off                                                | `POST /{db}/_compact` on auth + invites after successful deletes |
-| `--grace-ms <n>`             | 1d for refresh; 0 for invites unless set           | How long to keep refresh/invite docs after they expire           |
-| `--include-longlived`        | off                                                | Enable long-lived sweep                                          |
-| `--delete-exhausted-invites` | off                                                | Also delete non-expired invites with exhausted capped uses       |
-| `--batch-size <n>`           | 100                                                | `bulkDocs` chunk size                                            |
+| Flag                         | Default                                  | Purpose                                                          |
+| ---------------------------- | ---------------------------------------- | ---------------------------------------------------------------- |
+| `--dry-run`                  | off                                      | Count/log candidates only                                        |
+| `--compact`                  | off                                      | `POST /{db}/_compact` on auth + invites after successful deletes |
+| `--grace-ms <n>`             | 1d for refresh; 0 for invites unless set | How long to keep refresh/invite docs after they expire           |
+| `--include-longlived`        | off                                      | Enable long-lived sweep                                          |
+| `--delete-exhausted-invites` | off                                      | Also delete non-expired invites with exhausted capped uses       |
+| `--batch-size <n>`           | 100                                      | `bulkDocs` chunk size                                            |
 
 Exit `0` on success (including dry-run); non-zero on Couch connection failure or delete errors above threshold.
 

--- a/docs/developer/docs/source/markdown/TtlCleanup.md
+++ b/docs/developer/docs/source/markdown/TtlCleanup.md
@@ -10,13 +10,16 @@ worthwhile purging documents.
 
 ## What is cleaned
 
-| Doc type       | DB        | When deleted                                                                                                               |
-| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `refresh`      | `auth`    | `expiryTimestampMs` older than now + grace (default 1 day)                                                                 |
-| `emailcode`    | `auth`    | Anchor (`createdTimestampMs`, else expiry) older than rate-limit window + cooldown + grace (not at code expiry alone)      |
-| `verification` | `auth`    | Same model with verification window (24h) + cooldown (30m) + grace                                                         |
-| invite         | `invites` | `expiry` in the past (+ optional grace). Exhausted-but-unexpired invites are **kept** by default                           |
-| `longlived`    | `auth`    | Opt-in (`--include-longlived`): revoked or past expiry, after 30d audit retention. Never deletes active non-expired tokens |
+Docs are not deleted the instant they expire. Each type is kept for a short
+extra window so in-flight auth and rate-limiting still work, then removed.
+
+| Doc type       | DB        | When deleted                                                                                                                                     |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `refresh`      | `auth`    | Kept for **1 day after expiry** (override with `--grace-ms`), then deleted                                                                       |
+| `emailcode`    | `auth`    | Kept for **rate-limit window + cooldown + 1h** from creation (fallback: expiry). Not deleted when the code itself expires                        |
+| `verification` | `auth`    | Same idea: kept for **24h window + 30m cooldown + 1h** from creation (fallback: expiry)                                                          |
+| invite         | `invites` | Deleted once `expiry` has passed (no extra wait by default; `--grace-ms` can add one). Exhausted-but-unexpired invites are **kept** by default |
+| `longlived`    | `auth`    | Opt-in (`--include-longlived`): revoked or expired tokens kept **30 days** for audit, then deleted. Active non-expired tokens are never deleted |
 
 Never touches `people`, `projects`, templates, teams, `data-*` survey DBs, or tombstones.
 
@@ -37,7 +40,7 @@ Useful flags:
 | ---------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
 | `--dry-run`                  | off                                                | Count/log candidates only                                        |
 | `--compact`                  | off                                                | `POST /{db}/_compact` on auth + invites after successful deletes |
-| `--grace-ms <n>`             | 1d (refresh); also overrides invite grace when set | Extra retention after expiry                                     |
+| `--grace-ms <n>`             | 1d for refresh; 0 for invites unless set           | How long to keep refresh/invite docs after they expire           |
 | `--include-longlived`        | off                                                | Enable long-lived sweep                                          |
 | `--delete-exhausted-invites` | off                                                | Also delete non-expired invites with exhausted capped uses       |
 | `--batch-size <n>`           | 100                                                | `bulkDocs` chunk size                                            |

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -61,6 +61,19 @@ The `FaimsFrontEnd` construct manages the web applications:
 - **Build**: Uses CDK Docker bundling with the image built from `docs/Dockerfile` (Sphinx + themes). The `docs/user` tree is built with `sphinx-build -b html` and deployed to the bucket.
 - **Domain**: Served at the `docs` subdomain (e.g. `docs.your-domain.com`). Configure via `domains.docs`; pass `docsDomainName` and mobile app URLs in the frontend props.
 
+### TTL cleanup (scheduled one-shot)
+
+The `FaimsTtlCleanup` construct (gated by `ttlCleanup.enabled`) runs expired ephemeral CouchDB auth/invite document cleanup as a **separate Fargate task**, not as in-process cron on the Conductor service:
+
+- **Same image** as Conductor (`conductorDockerImage` / tag), with container **command override** to `node scripts/ttlCleanup.js` (WORKDIR `/app/api/build/src` from `Dockerfile.build` / `NODE_RUN_DIR`).
+- **EventBridge Scheduler → ECS RunTask** (`taskCount: 1`) so Conductor auto-scaling does not multiply cleanup runs.
+- **Schedule timezone:** cron hours use `ttlCleanup.scheduleExpressionTimezone` (default `Australia/Sydney`), so the default `cron(0 2 * * ? *)` is **02:00 Sydney local** (AEST/AEDT), not UTC.
+- Shares Conductor cluster, security group, env, and Couch/KEY_SOURCE secrets; logs under CloudWatch prefix `faims-ttl-cleanup`.
+- **Failure alerts:** an EventBridge rule watches ECS Task State Change for this task family; if the cleanup container exits non-zero, a clear message is published to the CouchDB ops SNS topic (`couch.monitoring.alarmTopic.emailAddress` subscribers).
+- Design notes and retention rules: [TtlCleanup.md](../../docs/developer/docs/source/markdown/TtlCleanup.md).
+
+Ship an API image that includes the script **before** setting `ttlCleanup.enabled: true`. Prefer `dryRun: true` first in non-prod; keep `compact: false` on the daily schedule. Ensure Couch monitoring alarm email is configured if you want email delivery of TTL cleanup failures.
+
 ### Auxiliary Components
 
 - **Lambda Function**: A Node.js function to deregister EC2 instances from CloudMap during termination.
@@ -315,6 +328,16 @@ Note that this validation is at a schema level, it might not catch improperly fo
   - `vaultArn`: (Optional) The ARN of an existing backup vault to use. If provided, a new vault will not be created
   - `retentionDays`: The number of days to retain backups (default: 30)
   - `scheduleExpression`: The cron schedule for running backups (default: daily at 3 AM)
+- `ttlCleanup`: (Optional) Scheduled Conductor TTL cleanup of ephemeral CouchDB auth/invite docs. Defaults to disabled when omitted.
+  - `enabled`: When `false`, no schedule or cleanup task definition is created (default: `false`)
+  - `scheduleExpression`: EventBridge Scheduler cron/rate (default: `cron(0 2 * * ? *)` — 02:00 in `scheduleExpressionTimezone`)
+  - `scheduleExpressionTimezone`: IANA timezone for the cron (default: `Australia/Sydney`). Hours in `scheduleExpression` are local to this zone, so daily runs stay at 02:00 through AEST/AEDT. Set to `UTC` if you need a fixed UTC hour instead.
+  - `dryRun`: Pass `--dry-run` (report only; default: `false`)
+  - `compact`: Pass `--compact` after successful deletes (default: `false`; keep off on frequent schedules)
+  - `includeLongLived`: Pass `--include-longlived` for optional long-lived token sweep (default: `false`)
+  - `deleteExhaustedInvites`: Pass `--delete-exhausted-invites` for non-expired invites with exhausted uses (default: `false`; keep off so uses can be raised later)
+  - `cpu` / `memory`: Fargate size for the one-shot task (defaults: `256` / `512`)
+  - Failure alerts use the CouchDB monitoring SNS topic (`couch.monitoring.alarmTopic.emailAddress`)
 - `uiConfiguration`: UI and app build-time settings for the main FAIMS frontend.
   - `uiTheme`: The UI theme: `bubble`, `default`, `fieldmark` or `bssTheme`
   - `notebookListType`: Notebook list display mode: `tabs` or `headings`

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -91,6 +91,17 @@
     "retentionDays": 30,
     "scheduleExpression": "cron(0 3 * * ? *)"
   },
+  "ttlCleanup": {
+    "enabled": false,
+    "scheduleExpression": "cron(0 2 * * ? *)",
+    "scheduleExpressionTimezone": "Australia/Sydney",
+    "dryRun": false,
+    "compact": false,
+    "includeLongLived": false,
+    "deleteExhaustedInvites": false,
+    "cpu": 256,
+    "memory": 512
+  },
   "conductor": {
     "name": "FAIMS Server",
     "enhancedObservability": true,

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -137,6 +137,16 @@ export class FaimsConductor extends Construct {
   public readonly conductorEndpoint: string;
   /** The Fargate Service */
   public readonly fargateService: ecs.FargateService;
+  /** ECS cluster hosting the Conductor service (and scheduled one-shot tasks). */
+  public readonly cluster: ecs.Cluster;
+  /** Security group attached to Conductor tasks (Couch egress equivalent). */
+  public readonly serviceSecurityGroup: ec2.SecurityGroup;
+  /** Conductor container image (shared with scheduled jobs such as TTL cleanup). */
+  public readonly containerImage: ecs.ContainerImage;
+  /** Non-secret environment variables applied to the Conductor container. */
+  public readonly environment: Record<string, string>;
+  /** Secrets Manager-backed secrets applied to the Conductor container. */
+  public readonly secrets: Record<string, ecs.Secret>;
 
   constructor(scope: Construct, id: string, props: FaimsConductorProps) {
     super(scope, id);
@@ -152,16 +162,15 @@ export class FaimsConductor extends Construct {
 
     // If you want to use a local build for debugging (not recommended for production, set this to false)
     const useDockerHub = true;
-    let conductorContainerImage: ecs.ContainerImage;
 
     if (useDockerHub) {
       // Setup container image from DockerHub image
-      conductorContainerImage = ecs.ContainerImage.fromRegistry(
+      this.containerImage = ecs.ContainerImage.fromRegistry(
         `${props.config.conductorDockerImage}:${props.config.conductorDockerImageTag}`
       );
     } else {
       // Build and bundle with cdk and ECR
-      conductorContainerImage = ecs.ContainerImage.fromAsset(getPathToRoot(), {
+      this.containerImage = ecs.ContainerImage.fromAsset(getPathToRoot(), {
         file: 'Dockerfile.build',
         exclude: ['infrastructure'],
       });
@@ -244,8 +253,102 @@ export class FaimsConductor extends Construct {
       });
     }
 
+    // Expose env/secrets so sibling one-shot tasks (e.g. TTL cleanup) can reuse
+    // the same Couch + KEY_SOURCE bootstrapping without duplicating the block.
+    this.environment = {
+      PROFILE_NAME: 'default',
+      CONDUCTOR_INSTANCE_NAME: props.config.name,
+      CONDUCTOR_DESCRIPTION: props.config.description,
+      COUCHDB_EXTERNAL_PORT: `${props.couchDBPort}`,
+      COUCHDB_PUBLIC_URL: props.couchDBEndpoint,
+      COUCHDB_INTERNAL_URL: props.couchDBEndpoint,
+      CONDUCTOR_SHORT_CODE_PREFIX: props.config.shortCodePrefix,
+      // Conductor API URLs
+      CONDUCTOR_PUBLIC_URL: this.conductorEndpoint,
+      CONDUCTOR_URL: this.conductorEndpoint,
+      WEB_APP_PUBLIC_URL: props.webAppPublicUrl,
+      ANDROID_APP_PUBLIC_URL: props.androidAppPublicUrl,
+      IOS_APP_PUBLIC_URL: props.iosAppPublicUrl,
+      KEY_SOURCE: 'AWS_SM',
+      AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
+      NEW_CONDUCTOR_URL: props.webUrl,
+      PROVISION_SSO_USERS_POLICY: props.config.provisionSSOUsersPolicy,
+      MIGRATE_NOTEBOOKS_ON_STARTUP: props.config.migrateNotebooksOnStartup
+        ? 'true'
+        : 'false',
+
+      // Bugsnag (optional)
+      ...(props.bugsnagApiKey ? {BUGSNAG_API_KEY: props.bugsnagApiKey} : {}),
+
+      // add any auth environment variables
+      ...authEnvironment,
+
+      // disable local login if specified in config (for SSO only deployments)
+      // defaults to false if not provided in config
+      DISABLE_LOCAL_LOGIN: props.authProviders
+        ? props.authProviders.disableLocalLogin
+          ? 'true'
+          : 'false'
+        : 'false',
+
+      // Security configurations
+      MAXIMUM_LONG_LIVED_DURATION_DAYS: props.maximumLongLivedDurationDays
+        ? props.maximumLongLivedDurationDays.toString()
+        : 'infinite',
+      RATE_LIMITER_ENABLED:
+        props.rateLimiterEnabled === false ? 'false' : 'true',
+      AUTH_ATTEMPT_LIMITER_ENABLED:
+        props.authAttemptLimiterEnabled === false ? 'false' : 'true',
+
+      // Email Service Configuration
+      EMAIL_SERVICE_TYPE: props.smtpConfig.emailServiceType,
+      EMAIL_FROM_ADDRESS: props.smtpConfig.fromEmail,
+      EMAIL_FROM_NAME: props.smtpConfig.fromName,
+      EMAIL_REPLY_TO: props.smtpConfig.replyTo || props.smtpConfig.fromEmail,
+      TEST_EMAIL_ADDRESS: props.smtpConfig.testEmailAddress,
+      SMTP_CACHE_EXPIRY_SECONDS: `${props.smtpConfig.cacheExpirySeconds || DEFAULT_SMTP_CACHE_EXPIRY}`,
+
+      // Whitelisting for redirects - should include API, APP, WEB and APP_ID://
+      REDIRECT_WHITELIST: [
+        this.conductorEndpoint,
+        props.webAppPublicUrl,
+        props.webUrl,
+        `${props.appId}://`,
+        ...(props.localhostWhitelist
+          ? [
+              'http://localhost:3000',
+              'http://localhost:3001',
+              'http://localhost:8080',
+              'http://localhost:8000',
+            ]
+          : []),
+      ].join(','),
+    };
+
+    this.secrets = {
+      COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(
+        props.couchDbAdminSecret,
+        'password'
+      ),
+      COUCHDB_USER: ecs.Secret.fromSecretsManager(
+        props.couchDbAdminSecret,
+        'username'
+      ),
+      FAIMS_COOKIE_SECRET: ecs.Secret.fromSecretsManager(props.cookieSecret),
+
+      // SMTP Credentials from Secret
+      SMTP_HOST: ecs.Secret.fromSecretsManager(smtpSecret, 'host'),
+      SMTP_PORT: ecs.Secret.fromSecretsManager(smtpSecret, 'port'),
+      SMTP_SECURE: ecs.Secret.fromSecretsManager(smtpSecret, 'secure'),
+      SMTP_USER: ecs.Secret.fromSecretsManager(smtpSecret, 'user'),
+      SMTP_PASSWORD: ecs.Secret.fromSecretsManager(smtpSecret, 'pass'),
+
+      // Include any auth config secrets
+      ...authSecrets,
+    };
+
     conductorTaskDfn.addContainer('conductor-container-dfn', {
-      image: conductorContainerImage,
+      image: this.containerImage,
       portMappings: [
         {
           containerPort: this.internalPort,
@@ -253,96 +356,8 @@ export class FaimsConductor extends Construct {
           name: 'conductor-port',
         },
       ],
-      environment: {
-        PROFILE_NAME: 'default',
-        CONDUCTOR_INSTANCE_NAME: props.config.name,
-        CONDUCTOR_DESCRIPTION: props.config.description,
-        COUCHDB_EXTERNAL_PORT: `${props.couchDBPort}`,
-        COUCHDB_PUBLIC_URL: props.couchDBEndpoint,
-        COUCHDB_INTERNAL_URL: props.couchDBEndpoint,
-        CONDUCTOR_SHORT_CODE_PREFIX: props.config.shortCodePrefix,
-        // Conductor API URLs
-        CONDUCTOR_PUBLIC_URL: this.conductorEndpoint,
-        CONDUCTOR_URL: this.conductorEndpoint,
-        WEB_APP_PUBLIC_URL: props.webAppPublicUrl,
-        ANDROID_APP_PUBLIC_URL: props.androidAppPublicUrl,
-        IOS_APP_PUBLIC_URL: props.iosAppPublicUrl,
-        KEY_SOURCE: 'AWS_SM',
-        AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
-        NEW_CONDUCTOR_URL: props.webUrl,
-        PROVISION_SSO_USERS_POLICY: props.config.provisionSSOUsersPolicy,
-        MIGRATE_NOTEBOOKS_ON_STARTUP: props.config.migrateNotebooksOnStartup
-          ? 'true'
-          : 'false',
-
-        // Bugsnag (optional)
-        ...(props.bugsnagApiKey ? {BUGSNAG_API_KEY: props.bugsnagApiKey} : {}),
-
-        // add any auth environment variables
-        ...authEnvironment,
-
-        // disable local login if specified in config (for SSO only deployments)
-        // defaults to false if not provided in config
-        DISABLE_LOCAL_LOGIN: props.authProviders
-          ? props.authProviders.disableLocalLogin
-            ? 'true'
-            : 'false'
-          : 'false',
-
-        // Security configurations
-        MAXIMUM_LONG_LIVED_DURATION_DAYS: props.maximumLongLivedDurationDays
-          ? props.maximumLongLivedDurationDays.toString()
-          : 'infinite',
-        RATE_LIMITER_ENABLED:
-          props.rateLimiterEnabled === false ? 'false' : 'true',
-        AUTH_ATTEMPT_LIMITER_ENABLED:
-          props.authAttemptLimiterEnabled === false ? 'false' : 'true',
-
-        // Email Service Configuration
-        EMAIL_SERVICE_TYPE: props.smtpConfig.emailServiceType,
-        EMAIL_FROM_ADDRESS: props.smtpConfig.fromEmail,
-        EMAIL_FROM_NAME: props.smtpConfig.fromName,
-        EMAIL_REPLY_TO: props.smtpConfig.replyTo || props.smtpConfig.fromEmail,
-        TEST_EMAIL_ADDRESS: props.smtpConfig.testEmailAddress,
-        SMTP_CACHE_EXPIRY_SECONDS: `${props.smtpConfig.cacheExpirySeconds || DEFAULT_SMTP_CACHE_EXPIRY}`,
-
-        // Whitelisting for redirects - should include API, APP, WEB and APP_ID://
-        REDIRECT_WHITELIST: [
-          this.conductorEndpoint,
-          props.webAppPublicUrl,
-          props.webUrl,
-          `${props.appId}://`,
-          ...(props.localhostWhitelist
-            ? [
-                'http://localhost:3000',
-                'http://localhost:3001',
-                'http://localhost:8080',
-                'http://localhost:8000',
-              ]
-            : []),
-        ].join(','),
-      },
-      secrets: {
-        COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(
-          props.couchDbAdminSecret,
-          'password'
-        ),
-        COUCHDB_USER: ecs.Secret.fromSecretsManager(
-          props.couchDbAdminSecret,
-          'username'
-        ),
-        FAIMS_COOKIE_SECRET: ecs.Secret.fromSecretsManager(props.cookieSecret),
-
-        // SMTP Credentials from Secret
-        SMTP_HOST: ecs.Secret.fromSecretsManager(smtpSecret, 'host'),
-        SMTP_PORT: ecs.Secret.fromSecretsManager(smtpSecret, 'port'),
-        SMTP_SECURE: ecs.Secret.fromSecretsManager(smtpSecret, 'secure'),
-        SMTP_USER: ecs.Secret.fromSecretsManager(smtpSecret, 'user'),
-        SMTP_PASSWORD: ecs.Secret.fromSecretsManager(smtpSecret, 'pass'),
-
-        // Include any auth config secrets
-        ...authSecrets,
-      },
+      environment: this.environment,
+      secrets: this.secrets,
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'faims-conductor',
         logRetention: logs.RetentionDays.ONE_MONTH,
@@ -353,7 +368,7 @@ export class FaimsConductor extends Construct {
     // =========================
 
     // Create the ECS Cluster
-    const cluster = new ecs.Cluster(this, 'ConductorCluster', {
+    this.cluster = new ecs.Cluster(this, 'ConductorCluster', {
       vpc: props.vpc,
       // Enable enhanced metrics - this gives container/task level insights and
       // more metrics
@@ -365,7 +380,7 @@ export class FaimsConductor extends Construct {
     });
 
     // Create Security Group for the Fargate service
-    const serviceSecurityGroup = new ec2.SecurityGroup(
+    this.serviceSecurityGroup = new ec2.SecurityGroup(
       this,
       'ConductorServiceSG',
       {
@@ -377,11 +392,11 @@ export class FaimsConductor extends Construct {
 
     // Create Fargate Service
     this.fargateService = new ecs.FargateService(this, 'conductor-service', {
-      cluster: cluster,
+      cluster: this.cluster,
       taskDefinition: conductorTaskDfn,
       // Target number of tasks to run
       desiredCount: props.config.autoScaling.desiredCapacity,
-      securityGroups: [serviceSecurityGroup],
+      securityGroups: [this.serviceSecurityGroup],
       assignPublicIp: true, // TODO Change this if using private subnets with NAT
     });
 
@@ -477,7 +492,7 @@ export class FaimsConductor extends Construct {
     // ================
 
     // Allow inbound traffic from the ALB
-    serviceSecurityGroup.connections.allowFrom(
+    this.serviceSecurityGroup.connections.allowFrom(
       props.sharedBalancer.alb,
       ec2.Port.tcp(this.internalPort),
       'Allow traffic from ALB to Conductor Fargate Service'

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -85,8 +85,8 @@ export class EC2CouchDB extends Construct {
   private readonly ebsDeviceName: string = '/dev/xvdf';
   /** The device name for the EBS data volume */
   public readonly dataVolume: ec2.Volume;
-  /** The Alarm SNS topic being published to */
-  private readonly alarmSNSTopic: sns.Topic;
+  /** Ops alarm SNS topic (email when monitoring.alarmTopic.emailAddress is set). */
+  public readonly alarmSNSTopic: sns.Topic;
   /** The monitoring config */
   private readonly monitoringConfig?: MonitoringConfig;
   /** Path to AWS cloud watch agent config - be sure to prefix with file:*/

--- a/infrastructure/aws-cdk/lib/components/ttl-cleanup.ts
+++ b/infrastructure/aws-cdk/lib/components/ttl-cleanup.ts
@@ -1,0 +1,226 @@
+/**
+ * Scheduled one-shot Fargate task for Conductor TTL cleanup of ephemeral
+ * CouchDB auth/invite documents.
+ *
+ * Uses EventBridge Scheduler → ecs:RunTask (taskCount: 1) so Conductor
+ * service scaling does not multiply cleanup executions. Reuses the Conductor
+ * image with a command override (not the API server CMD).
+ *
+ * See docs/developer/docs/source/markdown/TtlCleanup.md.
+ */
+
+import {ArnFormat, Stack, TimeZone} from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as scheduler from 'aws-cdk-lib/aws-scheduler';
+import * as schedulerTargets from 'aws-cdk-lib/aws-scheduler-targets';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import {Construct} from 'constructs';
+import {TtlCleanupConfig} from '../config';
+
+/** Container name used in the task definition and failure event filter. */
+export const TTL_CLEANUP_CONTAINER_NAME = 'ttl-cleanup-container';
+
+/**
+ * Properties for the FaimsTtlCleanup construct
+ */
+export interface FaimsTtlCleanupProps {
+  /** VPC used by Conductor / Couch networking */
+  vpc: ec2.IVpc;
+  /** Conductor ECS cluster to RunTask into */
+  cluster: ecs.ICluster;
+  /** Security groups with Couch egress equivalent to Conductor */
+  securityGroups: ec2.ISecurityGroup[];
+  /** Same Docker image as Conductor */
+  containerImage: ecs.ContainerImage;
+  /** Non-secret env required to boot buildconfig + open Couch */
+  environment: Record<string, string>;
+  /** Secrets Manager-backed secrets (Couch + KEY_SOURCE dependencies) */
+  secrets: Record<string, ecs.Secret>;
+  /** ARN of the JWT private key secret (task role grantRead) */
+  privateKeySecretArn: string;
+  /** ttlCleanup block from stack config */
+  config: TtlCleanupConfig;
+  /**
+   * Ops SNS topic for non-zero exit alerts (typically the CouchDB alarm topic
+   * that already has an email subscription).
+   */
+  alarmTopic: sns.ITopic;
+}
+
+/**
+ * Builds the container command for the compiled TTL cleanup script.
+ *
+ * Production image WORKDIR is `/app/api/build/src` (NODE_RUN_DIR), so the
+ * entry is `scripts/ttlCleanup.js` relative to that directory — not the
+ * default `node index.js` API server CMD.
+ */
+export const buildTtlCleanupCommand = (
+  config: Partial<
+    Pick<
+      TtlCleanupConfig,
+      'dryRun' | 'compact' | 'includeLongLived' | 'deleteExhaustedInvites'
+    >
+  >
+): string[] => {
+  const command = ['node', 'scripts/ttlCleanup.js'];
+  if (config.dryRun) {
+    command.push('--dry-run');
+  }
+  if (config.compact) {
+    command.push('--compact');
+  }
+  if (config.includeLongLived) {
+    command.push('--include-longlived');
+  }
+  if (config.deleteExhaustedInvites) {
+    command.push('--delete-exhausted-invites');
+  }
+  return command;
+};
+
+/**
+ * Plain-text SNS body for a failed TTL cleanup task (EventBridge fields filled
+ * at invoke time). Exported for unit tests.
+ */
+export const buildTtlCleanupFailureMessage = (): events.RuleTargetInput => {
+  const clusterArn = events.EventField.fromPath('$.detail.clusterArn');
+  const taskArn = events.EventField.fromPath('$.detail.taskArn');
+  const taskDefinitionArn = events.EventField.fromPath(
+    '$.detail.taskDefinitionArn'
+  );
+  const stopCode = events.EventField.fromPath('$.detail.stopCode');
+  const stoppedReason = events.EventField.fromPath('$.detail.stoppedReason');
+  const startedAt = events.EventField.fromPath('$.detail.startedAt');
+  const stoppedAt = events.EventField.fromPath('$.detail.stoppedAt');
+
+  return events.RuleTargetInput.fromText(
+    [
+      'ALERT: FAIMS TTL cleanup failed (non-zero exit)',
+      '',
+      'The scheduled one-shot ECS task that purges expired ephemeral CouchDB',
+      'auth/invite documents exited with a non-zero exit code.',
+      '',
+      'Action: inspect CloudWatch Logs (stream prefix faims-ttl-cleanup),',
+      'confirm CouchDB connectivity/credentials, then re-run the task or wait',
+      'for the next schedule.',
+      '',
+      `Cluster: ${clusterArn}`,
+      `Task: ${taskArn}`,
+      `Task definition: ${taskDefinitionArn}`,
+      `Stop code: ${stopCode}`,
+      `Stopped reason: ${stoppedReason}`,
+      `Started at: ${startedAt}`,
+      `Stopped at: ${stoppedAt}`,
+    ].join('\n')
+  );
+};
+
+/**
+ * EventBridge Scheduler + Fargate task definition for TTL cleanup.
+ */
+export class FaimsTtlCleanup extends Construct {
+  /** Task definition used by the schedule (and manual ecs run-task). */
+  public readonly taskDefinition: ecs.FargateTaskDefinition;
+  /** EventBridge Scheduler schedule. */
+  public readonly schedule: scheduler.Schedule;
+  /** Rule that notifies SNS when the cleanup container exits non-zero. */
+  public readonly failureRule: events.Rule;
+
+  constructor(scope: Construct, id: string, props: FaimsTtlCleanupProps) {
+    super(scope, id);
+
+    if (!props.config.enabled) {
+      throw new Error(
+        'FaimsTtlCleanup should only be instantiated when ttlCleanup.enabled is true'
+      );
+    }
+
+    this.taskDefinition = new ecs.FargateTaskDefinition(
+      this,
+      'ttl-cleanup-task-dfn',
+      {
+        cpu: props.config.cpu,
+        memoryLimitMiB: props.config.memory,
+        ephemeralStorageGiB: 21,
+      }
+    );
+
+    const command = buildTtlCleanupCommand(props.config);
+
+    this.taskDefinition.addContainer(TTL_CLEANUP_CONTAINER_NAME, {
+      image: props.containerImage,
+      command,
+      environment: props.environment,
+      secrets: props.secrets,
+      logging: ecs.LogDriver.awsLogs({
+        streamPrefix: 'faims-ttl-cleanup',
+        logRetention: logs.RetentionDays.ONE_MONTH,
+      }),
+    });
+
+    // Signing keys via AWS Secrets Manager (KEY_SOURCE=AWS_SM)
+    sm.Secret.fromSecretCompleteArn(
+      this,
+      'ttlCleanupPrivateKeySecret',
+      props.privateKeySecretArn
+    ).grantRead(this.taskDefinition.taskRole);
+
+    this.schedule = new scheduler.Schedule(this, 'ttl-cleanup-schedule', {
+      description:
+        'Daily one-shot FAIMS TTL cleanup of expired ephemeral CouchDB docs',
+      // Cron hours are local to scheduleExpressionTimezone (default Australia/Sydney).
+      schedule: scheduler.ScheduleExpression.expression(
+        props.config.scheduleExpression,
+        TimeZone.of(props.config.scheduleExpressionTimezone)
+      ),
+      // Default TimeWindow.off() — avoid drifting overlaps with daily cadence.
+      timeWindow: scheduler.TimeWindow.off(),
+      target: new schedulerTargets.EcsRunFargateTask(props.cluster, {
+        taskDefinition: this.taskDefinition,
+        taskCount: 1,
+        securityGroups: props.securityGroups,
+        vpcSubnets: {subnetType: ec2.SubnetType.PUBLIC},
+        assignPublicIp: true,
+      }),
+    });
+
+    // Non-zero exit → ops SNS (same topic as CouchDB alarms when wired).
+    const stack = Stack.of(this);
+    // Prefix matches all revisions: ...:task-definition/<family>:<rev>
+    const taskDefinitionArnPrefix = stack.formatArn({
+      service: 'ecs',
+      resource: 'task-definition',
+      resourceName: this.taskDefinition.family,
+      arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+    });
+
+    this.failureRule = new events.Rule(this, 'ttl-cleanup-failure-rule', {
+      description:
+        'Notify SNS when the FAIMS TTL cleanup ECS task exits with a non-zero code',
+      eventPattern: {
+        source: ['aws.ecs'],
+        detailType: ['ECS Task State Change'],
+        detail: {
+          lastStatus: ['STOPPED'],
+          clusterArn: [props.cluster.clusterArn],
+          taskDefinitionArn: [{prefix: taskDefinitionArnPrefix}],
+          containers: {
+            name: [TTL_CLEANUP_CONTAINER_NAME],
+            exitCode: [events.Match.anythingBut(0)],
+          },
+        },
+      },
+    });
+
+    this.failureRule.addTarget(
+      new eventsTargets.SnsTopic(props.alarmTopic, {
+        message: buildTtlCleanupFailureMessage(),
+      })
+    );
+  }
+}

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -476,6 +476,42 @@ const BackupConfigSchema = z
     }
   );
 
+/**
+ * Scheduled one-shot ECS task that runs Conductor TTL cleanup against CouchDB.
+ * Independent of Conductor service scaling (EventBridge Scheduler → RunTask).
+ * See docs/developer/docs/source/markdown/TtlCleanup.md.
+ */
+const TtlCleanupConfigSchema = z.object({
+  /** When false, no schedule / task definition is created. */
+  enabled: z.boolean().default(false),
+  /**
+   * EventBridge Scheduler cron/rate expression. Hours/minutes are interpreted in
+   * `scheduleExpressionTimezone` (default Australia/Sydney), not UTC.
+   */
+  scheduleExpression: z.string().default('cron(0 2 * * ? *)'),
+  /**
+   * IANA timezone for `scheduleExpression` (EventBridge Scheduler
+   * ScheduleExpressionTimezone). Default Australia/Sydney so daily runs stay at
+   * local 02:00 through AEST/AEDT.
+   */
+  scheduleExpressionTimezone: z.string().default('Australia/Sydney'),
+  /** Pass --dry-run to the cleanup script (report only). */
+  dryRun: z.boolean().default(false),
+  /** Pass --compact after successful deletes (prefer rarer cadence). */
+  compact: z.boolean().default(false),
+  /** Pass --include-longlived for optional long-lived token sweep. */
+  includeLongLived: z.boolean().default(false),
+  /**
+   * Pass --delete-exhausted-invites for non-expired invites with exhausted uses.
+   * Default false — exhausted invites may still be useful if uses are raised later.
+   */
+  deleteExhaustedInvites: z.boolean().default(false),
+  /** Fargate CPU units for the cleanup task. */
+  cpu: z.number().int().positive().default(256),
+  /** Fargate memory (MiB) for the cleanup task. */
+  memory: z.number().int().positive().default(512),
+});
+
 const AppSupportLinksSchema = z.object({
   /** The support email address */
   supportEmail: z.string().default('support@fieldmark.au'),
@@ -600,6 +636,21 @@ export const ConfigSchema = z.object({
   couch: CouchConfigSchema,
   /** Backup configuration */
   backup: BackupConfigSchema,
+  /**
+   * Scheduled TTL cleanup of ephemeral auth/invite CouchDB docs.
+   * Disabled by default — enable only after the API image includes ttlCleanup.
+   */
+  ttlCleanup: TtlCleanupConfigSchema.optional().default({
+    enabled: false,
+    scheduleExpression: 'cron(0 2 * * ? *)',
+    scheduleExpressionTimezone: 'Australia/Sydney',
+    dryRun: false,
+    compact: false,
+    includeLongLived: false,
+    deleteExhaustedInvites: false,
+    cpu: 256,
+    memory: 512,
+  }),
   /** Conductor service configuration */
   conductor: ConductorConfigSchema,
   /** Domain configuration for all services */
@@ -638,6 +689,7 @@ export type BugMonitoringConfiguration = z.infer<
   typeof BugMonitoringConfigurationSchema
 >;
 export type ConductorConfig = z.infer<typeof ConductorConfigSchema>;
+export type TtlCleanupConfig = z.infer<typeof TtlCleanupConfigSchema>;
 export type DomainsConfig = z.infer<typeof DomainsConfigSchema>;
 export type SMTPConfig = z.infer<typeof SMTPConfigSchema>;
 export type OfflineMapsConfig = z.infer<typeof OfflineMapsConfigSchema>;

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -8,6 +8,7 @@ import {FaimsConductor} from './components/conductor';
 import {FaimsFrontEnd} from './components/front-end';
 import {FaimsNetworking} from './components/networking';
 import {EC2CouchDB} from './components/couch-db';
+import {FaimsTtlCleanup} from './components/ttl-cleanup';
 import {Config} from './config';
 
 /**
@@ -150,6 +151,24 @@ export class FaimsInfraStack extends cdk.Stack {
       localhostWhitelist: config.conductor.localhostWhitelist,
       bugsnagApiKey: config.bugMonitoring.bugsnagKey,
     });
+
+    // TTL CLEANUP (scheduled one-shot; not in-process cron)
+    // =====================================================
+    // Deploy API image with ttlCleanup before enabling in an environment.
+    if (config.ttlCleanup.enabled) {
+      new FaimsTtlCleanup(this, 'ttl-cleanup', {
+        vpc: networking.vpc,
+        cluster: conductor.cluster,
+        securityGroups: [conductor.serviceSecurityGroup],
+        containerImage: conductor.containerImage,
+        environment: conductor.environment,
+        secrets: conductor.secrets,
+        privateKeySecretArn: config.secrets.privateKey,
+        config: config.ttlCleanup,
+        // Same ops SNS/email as CouchDB monitoring alarms.
+        alarmTopic: couchDb.alarmSNSTopic,
+      });
+    }
 
     // FRONT-END
     // =========

--- a/infrastructure/aws-cdk/test/ttl-cleanup.test.ts
+++ b/infrastructure/aws-cdk/test/ttl-cleanup.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for TTL cleanup CDK helpers and synthesised resources.
+ */
+import * as cdk from 'aws-cdk-lib';
+import {Match, Template} from 'aws-cdk-lib/assertions';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import {
+  buildTtlCleanupCommand,
+  FaimsTtlCleanup,
+  TTL_CLEANUP_CONTAINER_NAME,
+} from '../lib/components/ttl-cleanup';
+
+describe('buildTtlCleanupCommand', () => {
+  it('uses compiled script path relative to NODE_RUN_DIR (not API server CMD)', () => {
+    expect(buildTtlCleanupCommand({})).toEqual([
+      'node',
+      'scripts/ttlCleanup.js',
+    ]);
+  });
+
+  it('appends dry-run, compact, include-longlived, and delete-exhausted-invites when set', () => {
+    expect(
+      buildTtlCleanupCommand({
+        dryRun: true,
+        compact: true,
+        includeLongLived: true,
+        deleteExhaustedInvites: true,
+      })
+    ).toEqual([
+      'node',
+      'scripts/ttlCleanup.js',
+      '--dry-run',
+      '--compact',
+      '--include-longlived',
+      '--delete-exhausted-invites',
+    ]);
+  });
+
+  it('omits delete-exhausted-invites by default (exhausted unexpired invites kept)', () => {
+    expect(
+      buildTtlCleanupCommand({
+        dryRun: true,
+        deleteExhaustedInvites: false,
+      })
+    ).toEqual(['node', 'scripts/ttlCleanup.js', '--dry-run']);
+  });
+});
+
+describe('FaimsTtlCleanup synth', () => {
+  it('creates Scheduler + task definition with ttlCleanup command override', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TtlCleanupTestStack', {
+      env: {account: '123456789012', region: 'ap-southeast-2'},
+    });
+
+    const vpc = new ec2.Vpc(stack, 'vpc', {maxAzs: 2, natGateways: 0});
+    const cluster = new ecs.Cluster(stack, 'cluster', {vpc});
+    const sg = new ec2.SecurityGroup(stack, 'sg', {vpc});
+    const couchSecret = new sm.Secret(stack, 'couch', {
+      secretObjectValue: {
+        username: cdk.SecretValue.unsafePlainText('admin'),
+        password: cdk.SecretValue.unsafePlainText('password'),
+      },
+    });
+    const privateKeyArn =
+      'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:private-key-AbCdEf';
+    const alarmTopic = new sns.Topic(stack, 'ops-alarms', {
+      displayName: 'CouchDB Alarms',
+    });
+
+    new FaimsTtlCleanup(stack, 'ttl-cleanup', {
+      vpc,
+      cluster,
+      securityGroups: [sg],
+      containerImage: ecs.ContainerImage.fromRegistry(
+        'ghcr.io/faims/faims3-api:latest'
+      ),
+      environment: {
+        COUCHDB_INTERNAL_URL: 'https://couch.example.com',
+        COUCHDB_PUBLIC_URL: 'https://couch.example.com',
+        KEY_SOURCE: 'AWS_SM',
+        AWS_SECRET_KEY_ARN: privateKeyArn,
+        EMAIL_SERVICE_TYPE: 'MOCK',
+        REDIRECT_WHITELIST: 'https://conductor.example.com',
+      },
+      secrets: {
+        COUCHDB_USER: ecs.Secret.fromSecretsManager(couchSecret, 'username'),
+        COUCHDB_PASSWORD: ecs.Secret.fromSecretsManager(
+          couchSecret,
+          'password'
+        ),
+      },
+      privateKeySecretArn: privateKeyArn,
+      alarmTopic,
+      config: {
+        enabled: true,
+        scheduleExpression: 'cron(0 2 * * ? *)',
+        scheduleExpressionTimezone: 'Australia/Sydney',
+        dryRun: true,
+        compact: false,
+        includeLongLived: false,
+        deleteExhaustedInvites: false,
+        cpu: 256,
+        memory: 512,
+      },
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::Scheduler::Schedule', {
+      ScheduleExpression: 'cron(0 2 * * ? *)',
+      ScheduleExpressionTimezone: 'Australia/Sydney',
+      FlexibleTimeWindow: {Mode: 'OFF'},
+      Target: {
+        EcsParameters: Match.objectLike({
+          TaskCount: 1,
+          LaunchType: 'FARGATE',
+        }),
+      },
+    });
+
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      Cpu: '256',
+      Memory: '512',
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: TTL_CLEANUP_CONTAINER_NAME,
+          Command: ['node', 'scripts/ttlCleanup.js', '--dry-run'],
+          Image: 'ghcr.io/faims/faims3-api:latest',
+          LogConfiguration: Match.objectLike({
+            Options: Match.objectLike({
+              'awslogs-stream-prefix': 'faims-ttl-cleanup',
+            }),
+          }),
+        }),
+      ]),
+    });
+
+    // Must not be the API server CMD alone
+    const taskDefs = template.findResources('AWS::ECS::TaskDefinition');
+    for (const resource of Object.values(taskDefs)) {
+      const containers = resource.Properties.ContainerDefinitions as Array<{
+        Command?: string[];
+      }>;
+      for (const c of containers) {
+        expect(c.Command).not.toEqual(['node', 'index.js']);
+      }
+    }
+
+    template.hasResourceProperties('AWS::Events::Rule', {
+      Description:
+        'Notify SNS when the FAIMS TTL cleanup ECS task exits with a non-zero code',
+      EventPattern: {
+        source: ['aws.ecs'],
+        'detail-type': ['ECS Task State Change'],
+        detail: Match.objectLike({
+          lastStatus: ['STOPPED'],
+          containers: {
+            name: [TTL_CLEANUP_CONTAINER_NAME],
+            // CDK wraps numeric anything-but as [[{ "anything-but": [0] }]]
+            exitCode: [[{'anything-but': [0]}]],
+          },
+        }),
+      },
+      Targets: Match.arrayWith([
+        Match.objectLike({
+          InputTransformer: Match.objectLike({
+            InputTemplate: Match.stringLikeRegexp(
+              'ALERT: FAIMS TTL cleanup failed \\(non-zero exit\\)'
+            ),
+          }),
+        }),
+      ]),
+    });
+  });
+});


### PR DESCRIPTION
Implements an API ts script which uses the existing types/infra of the TS API context to write a safe DB TTL cleanup job. It targets expiring ephemeral DB artifacts, especially refresh tokens. These currently hang around forever and in a busy system would eventually exhaust the DB.

Alternatively, we could have done a cron bash job, but this would mean either we have a bash script which would be tricky to maintain given DB types migrate through time, or we need to have the full TS runtime/repo context in the VM which is best avoided. It also leaks a fair bit of FAIMS specific stuff in the DB layer which is not ideal as it makes transferring to other couch hosts harder. 

In the AWS world, running this as a scheduled job on the API node is not ideal as they intentionally should be able to run in a cluster, so you'd need some master. The ideal approach as implemented is to run an ECS 'task' which is ephemeral (exits as a typical task with 0/1 exit code) scheduled on a cron job. It can reuse the whole TaskDfn from the existing API task, and just override the run command. Also implemented alerting against the existing SNS topic. 

Adds CDK config to enable and configure the script including scheduling and options.