### PR TITLE
fix: double wrap of CDK exit code condition

### DIFF
--- a/infrastructure/aws-cdk/lib/components/ttl-cleanup.ts
+++ b/infrastructure/aws-cdk/lib/components/ttl-cleanup.ts
@@ -211,7 +211,10 @@ export class FaimsTtlCleanup extends Construct {
           taskDefinitionArn: [{prefix: taskDefinitionArnPrefix}],
           containers: {
             name: [TTL_CLEANUP_CONTAINER_NAME],
-            exitCode: [events.Match.anythingBut(0)],
+            // Match.anythingBut already serialises as [{ "anything-but": [0] }].
+            // An extra array wrap becomes [[{ ... }]], which EventBridge rejects
+            // ("Match value must be String, number, true, false, or null").
+            exitCode: events.Match.anythingBut(0),
           },
         },
       },

--- a/infrastructure/aws-cdk/test/ttl-cleanup.test.ts
+++ b/infrastructure/aws-cdk/test/ttl-cleanup.test.ts
@@ -160,8 +160,7 @@ describe('FaimsTtlCleanup synth', () => {
           lastStatus: ['STOPPED'],
           containers: {
             name: [TTL_CLEANUP_CONTAINER_NAME],
-            // CDK wraps numeric anything-but as [[{ "anything-but": [0] }]]
-            exitCode: [[{'anything-but': [0]}]],
+            exitCode: [{'anything-but': [0]}],
           },
         }),
       },


### PR DESCRIPTION
CDK syntax for exit codes caused double wrap - failing cfn deployment. Testing this resolves it.