### PR TITLE
fix: security - prevent header injection from form name

### DIFF
--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -52,7 +52,6 @@ import {
   PutUpdateNotebookUiSpecificationInputSchema,
   removeProjectRole,
   Role,
-  slugify,
   userCanReadTemplateDocument,
   userHasProjectRole,
 } from '@faims3/data-model';
@@ -81,6 +80,10 @@ import {
 } from '../couchdb/export/geospatialExport';
 import {stripDeletedRelatedRefsFromRecordData} from '../couchdb/export/stripDeletedRelatedRefs';
 import {FullExportConfigSchema} from '../couchdb/export/types';
+import {
+  contentDispositionAttachment,
+  sanitizeDownloadFilename,
+} from '../couchdb/export/utils';
 import {deleteAllInvitesForProject} from '../couchdb/invites';
 import {
   applyNotebookLifecycleStatus,
@@ -913,22 +916,26 @@ api.get(
           `Form with id ${payload.viewID} not found in notebook`
         );
       }
-      exportLabel = uiSpec.viewsets[payload.viewID].label ?? payload.viewID;
+      // Form labels are user-controlled; never interpolate them raw into headers.
+      exportLabel = sanitizeDownloadFilename(
+        uiSpec.viewsets[payload.viewID].label ?? payload.viewID,
+        sanitizeDownloadFilename(payload.viewID, 'export')
+      );
     } else {
-      exportLabel = slugify(payload.projectID);
+      exportLabel = sanitizeDownloadFilename(payload.projectID);
     }
 
     if (payload.format === 'csv') {
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${exportLabel}-export.csv"`
+        contentDispositionAttachment(`${exportLabel}-export.csv`)
       );
       streamNotebookRecordsAsCSV(payload.projectID, payload.viewID!, res);
     } else if (payload.format === 'zip') {
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${exportLabel}-photos.zip"`
+        contentDispositionAttachment(`${exportLabel}-photos.zip`)
       );
       res.setHeader('Content-Type', 'application/zip');
       streamNotebookFilesAsZip({
@@ -940,14 +947,14 @@ api.get(
       res.setHeader('Content-Type', 'application/geo+json');
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${slugify(payload.projectID)}-export.geojson"`
+        contentDispositionAttachment(`${exportLabel}-export.geojson`)
       );
       streamNotebookRecordsAsGeoJSON(payload.projectID, res);
     } else if (payload.format === 'kml') {
       res.setHeader('Content-Type', 'application/vnd.google-earth.kml+xml');
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${slugify(payload.projectID)}-export.kml"`
+        contentDispositionAttachment(`${exportLabel}-export.kml`)
       );
       streamNotebookRecordsAsKML(payload.projectID, res);
     } else if (payload.format === 'geopackage') {
@@ -956,7 +963,7 @@ api.get(
       res.setHeader('Content-Type', 'application/geopackage+sqlite3');
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${slugify(payload.projectID)}-export.gpkg"`
+        contentDispositionAttachment(`${exportLabel}-export.gpkg`)
       );
       await streamNotebookRecordsAsGeoPackage(payload.projectID, res);
     } else if (payload.format === 'full') {
@@ -964,7 +971,7 @@ api.get(
       res.setHeader('Content-Type', 'application/zip');
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${fullFilename}"`
+        contentDispositionAttachment(fullFilename)
       );
       await streamFullExport({
         projectId: payload.projectID,

--- a/api/src/couchdb/export/utils.ts
+++ b/api/src/couchdb/export/utils.ts
@@ -373,6 +373,41 @@ export const slugifyLabel = (label: string, maxLength = 50): string => {
 };
 
 /**
+ * Filename stem from user-controlled text (form labels, project ids).
+ *
+ * Quotes, path separators, control characters, and other header
+ * metacharacters are stripped so the result is safe to place in
+ * Content-Disposition `filename="..."`.
+ */
+export const sanitizeDownloadFilename = (
+  label: string,
+  fallback = 'export'
+): string => {
+  const slug = slugifyLabel(label);
+  return slug.length > 0 ? slug : fallback;
+};
+
+/** Conservative token set for a Content-Disposition quoted filename. */
+const CONTENT_DISPOSITION_FILENAME = /[^\w.-]/g;
+
+/**
+ * Build a Content-Disposition attachment header.
+ *
+ * Restricts the filename to `[A-Za-z0-9._-]` so user-controlled names cannot
+ * terminate the quoted-string, inject extra parameters, change the extension,
+ * or smuggle CR/LF into the header.
+ */
+export const contentDispositionAttachment = (filename: string): string => {
+  const safe = filename
+    .replace(CONTENT_DISPOSITION_FILENAME, '_')
+    .replace(/^\.+/, '')
+    .replace(/_{2,}/g, '_')
+    .slice(0, 180);
+  const finalName = safe.length > 0 ? safe : 'download';
+  return `attachment; filename="${finalName}"`;
+};
+
+/**
  * Helper to ensure unique filenames in a list
  */
 export const ensureUniqueFilename = (

--- a/api/src/couchdb/export/utils.ts
+++ b/api/src/couchdb/export/utils.ts
@@ -391,11 +391,13 @@ export const sanitizeDownloadFilename = (
 const CONTENT_DISPOSITION_FILENAME = /[^\w.-]/g;
 
 /**
- * Build a Content-Disposition attachment header.
+ * Content-Disposition wrapper function: emits `attachment; filename="..."`.
  *
- * Restricts the filename to `[A-Za-z0-9._-]` so user-controlled names cannot
- * terminate the quoted-string, inject extra parameters, change the extension,
- * or smuggle CR/LF into the header.
+ * Does not assume the filename input was pre-sanitised. Restricts the whole
+ * filename to `[A-Za-z0-9._-]` so any input cannot terminate the quoted-string,
+ * inject parameters, change the extension, or smuggle CR/LF into the header.
+ * 
+ * For security purposes this may perform some redundant sanitisation.
  */
 export const contentDispositionAttachment = (filename: string): string => {
   const safe = filename

--- a/api/src/utils/emailHelpers.ts
+++ b/api/src/utils/emailHelpers.ts
@@ -8,6 +8,16 @@
 import {config, emailService} from '../buildconfig';
 import {EmailOptions} from '../services/emailService';
 
+/** Escape user-controlled text before interpolating it into HTML email bodies. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Build a URL with the verification code embedded for easy user access
  *
@@ -135,7 +145,7 @@ If you did not request this verification, please ignore this email.
     <div class="header">
       <h1>Verify Your Email Address</h1>
     </div>
-    <p>Hello ${username},</p>
+    <p>Hello ${escapeHtml(username)},</p>
     <p>Thank you for registering your email address with us. To complete the verification process, please click the button below:</p>
     <a href="${verificationUrl}" class="button">Verify Email</a>
     <p>This verification code will expire in ${expiryHours} hours.</p>
@@ -171,7 +181,7 @@ export function buildPasswordResetUrl({
   code: string;
   redirect: string;
 }): string {
-  return `${config.conductorPublicUrl}/auth/reset-password?code=${encodeURIComponent(code)}&redirect=${redirect}`;
+  return `${config.conductorPublicUrl}/auth/reset-password?code=${encodeURIComponent(code)}&redirect=${encodeURIComponent(redirect)}`;
 }
 
 /**
@@ -285,7 +295,7 @@ If you did not request a password reset, you can safely ignore this email. Your 
     <div class="header">
       <h1>Reset Your Password</h1>
     </div>
-    <p>Hello ${username},</p>
+    <p>Hello ${escapeHtml(username)},</p>
     <p>We received a request to reset your password. To proceed with the password reset, please click the button below:</p>
     <a href="${resetUrl}" class="button">Reset Password</a>
     <p>This link will expire in ${expiryHours} hours.</p>

--- a/api/test/utils.test.ts
+++ b/api/test/utils.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, it} from 'vitest';
-import {simpleHash} from '../src/couchdb/export/utils';
+import {
+  contentDispositionAttachment,
+  sanitizeDownloadFilename,
+  simpleHash,
+} from '../src/couchdb/export/utils';
 
 describe('simpleHash', () => {
   it('returns deterministic results', () => {
@@ -55,5 +59,55 @@ describe('simpleHash', () => {
     const a = simpleHash('test1', 8);
     const b = simpleHash('test2', 8);
     expect(a).not.toBe(b);
+  });
+});
+
+describe('sanitizeDownloadFilename', () => {
+  it('slugifies ordinary form labels', () => {
+    expect(sanitizeDownloadFilename('Site Survey')).toBe('site_survey');
+  });
+
+  it('strips quotes used to break Content-Disposition', () => {
+    expect(sanitizeDownloadFilename('Form"; filename="evil.html')).toBe(
+      'form_filenameevilhtml'
+    );
+  });
+
+  it('strips CR/LF header-injection characters', () => {
+    expect(sanitizeDownloadFilename('Form\r\nX-Injected: yes')).toBe(
+      'form_x-injected_yes'
+    );
+  });
+
+  it('falls back when the label is only unsafe characters', () => {
+    expect(sanitizeDownloadFilename('"""')).toBe('export');
+    expect(sanitizeDownloadFilename('"""', 'form')).toBe('form');
+  });
+});
+
+describe('contentDispositionAttachment', () => {
+  it('quotes a safe filename', () => {
+    expect(contentDispositionAttachment('site_survey-export.csv')).toBe(
+      'attachment; filename="site_survey-export.csv"'
+    );
+  });
+
+  it('cannot be terminated by a double-quote in the form name', () => {
+    const header = contentDispositionAttachment('Form"; filename="pwned.html');
+    expect(header).toBe('attachment; filename="Form_filename_pwned.html"');
+    expect(header).not.toContain('"pwned');
+    expect(header.match(/filename="/g)).toHaveLength(1);
+  });
+
+  it('strips CR/LF so extra headers cannot be injected', () => {
+    const header = contentDispositionAttachment('name\r\nSet-Cookie: a=b.csv');
+    expect(header).not.toMatch(/[\r\n]/);
+    expect(header).toBe('attachment; filename="name_Set-Cookie_a_b.csv"');
+  });
+
+  it('preserves a single extension after sanitising', () => {
+    const header = contentDispositionAttachment('survey-export.csv');
+    expect(header).toMatch(/\.csv"$/);
+    expect(header).not.toMatch(/\.html/);
   });
 });

--- a/web/src/designer/DesignerWidget.tsx
+++ b/web/src/designer/DesignerWidget.tsx
@@ -42,6 +42,7 @@ import {createDesignerStore} from './createDesignerStore';
 import {createDesignerTheme} from './theme';
 import type {Notebook, NotebookWithHistory} from './state/initial';
 import {stripDesignerIdentifiers, toNotebook} from './domain/notebook/adapters';
+import {slugify} from './domain/notebook/ids';
 import {THEME} from '../lib/theme';
 import {NotebookEditor} from './components/notebook-editor';
 import {InfoPanel} from './components/info-panel';
@@ -163,8 +164,7 @@ export function DesignerWidget({
     const blob = new Blob([JSON.stringify(exportNotebook, null, 2)], {
       type: 'application/json',
     });
-    const filename =
-      String(exportBaseName ?? 'notebook').replace(/\s+/g, '_') + '.json';
+    const filename = `${slugify(String(exportBaseName ?? 'notebook')) || 'notebook'}.json`;
     const file = new File([blob], filename, {
       type: 'application/json',
     });
@@ -172,7 +172,7 @@ export function DesignerWidget({
     setAnimateOut(true);
     setAnimateIn(false);
     window.setTimeout(() => doClose(file), animationDuration);
-  }, [animationDuration, doClose, store]);
+  }, [animationDuration, doClose, exportBaseName, store]);
 
   /** Close without saving after user confirms cancel dialog. */
   const handleCancel = useCallback(() => {

--- a/web/src/designer/domain/notebook/ids.test.ts
+++ b/web/src/designer/domain/notebook/ids.test.ts
@@ -3,7 +3,7 @@
  */
 
 import {describe, expect, it} from 'vitest';
-import {resolveAddedFieldKey} from './ids';
+import {resolveAddedFieldKey, sanitizeUserLabel} from './ids';
 
 describe('resolveAddedFieldKey', () => {
   it('slugifies templated string fields like any other field', () => {
@@ -20,5 +20,20 @@ describe('resolveAddedFieldKey', () => {
     expect(resolveAddedFieldKey('New Field', ['Existing-Field'])).toBe(
       'New-Field'
     );
+  });
+});
+
+describe('sanitizeUserLabel', () => {
+  it('keeps ordinary form names', () => {
+    expect(sanitizeUserLabel('Site Survey')).toBe('Site Survey');
+  });
+
+  it('strips CR/LF and other control characters', () => {
+    expect(sanitizeUserLabel('Form\r\nInjected')).toBe('FormInjected');
+    expect(sanitizeUserLabel('Form\u0000Name')).toBe('FormName');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeUserLabel('  Form  ')).toBe('Form');
   });
 });

--- a/web/src/designer/domain/notebook/ids.ts
+++ b/web/src/designer/domain/notebook/ids.ts
@@ -41,6 +41,22 @@ export const slugify = (value: string): string => {
 };
 
 /**
+ * Strip ASCII control characters from a user-supplied display label.
+ *
+ * Printable characters (including quotes) are kept for display. Callers that
+ * interpolate labels into HTTP headers or filenames must still sanitise for
+ * that context.
+ */
+export const sanitizeUserLabel = (label: string): string =>
+  Array.from(label)
+    .filter(ch => {
+      const code = ch.charCodeAt(0);
+      return code >= 32 && code !== 127;
+    })
+    .join('')
+    .trim();
+
+/**
  * Picks a slugified field id that does not collide with existing keys.
  *
  * @param preferredName - User-facing label or desired base id.

--- a/web/src/designer/store/slices/uiSpec/sectionReducers.ts
+++ b/web/src/designer/store/slices/uiSpec/sectionReducers.ts
@@ -14,7 +14,11 @@
 
 import {PayloadAction} from '@reduxjs/toolkit';
 import {cloneField} from '../../../domain/notebook/fieldFactory';
-import {buildUniqueFieldName, slugify} from '../../../domain/notebook/ids';
+import {
+  buildUniqueFieldName,
+  sanitizeUserLabel,
+  slugify,
+} from '../../../domain/notebook/ids';
 import {NotebookUISpec} from '../../../state/initial';
 import {ConditionType} from '../../../types/condition';
 
@@ -27,7 +31,7 @@ export const sectionReducers = {
   ) => {
     const {viewId, label} = action.payload;
     if (viewId in state.views) {
-      state.views[viewId].label = label;
+      state.views[viewId].label = sanitizeUserLabel(label);
     } else {
       throw new Error(
         `Can't update unknown section ${viewId} via sectionRenamed action`
@@ -40,9 +44,10 @@ export const sectionReducers = {
     action: PayloadAction<{viewSetId: string; sectionLabel: string}>
   ) => {
     const {viewSetId, sectionLabel} = action.payload;
-    const sectionId = viewSetId + '-' + slugify(sectionLabel);
+    const safeSectionLabel = sanitizeUserLabel(sectionLabel);
+    const sectionId = viewSetId + '-' + slugify(safeSectionLabel);
     const newSection = {
-      label: sectionLabel,
+      label: safeSectionLabel,
       fields: [],
     };
     if (sectionId in state.views) {
@@ -83,17 +88,18 @@ export const sectionReducers = {
       }
     }
 
-    const newSectionId = destViewSetId + '-' + slugify(newSectionLabel);
+    const safeSectionLabel = sanitizeUserLabel(newSectionLabel);
+    const newSectionId = destViewSetId + '-' + slugify(safeSectionLabel);
     if (newSectionId in state.views) {
       throw new Error(
-        `Section ${newSectionLabel} already exists in form ${destViewSetId}.`
+        `Section ${safeSectionLabel} already exists in form ${destViewSetId}.`
       );
     }
 
     const sourceSection = state.views[sourceViewId];
 
     const newSection = {
-      label: newSectionLabel,
+      label: safeSectionLabel,
       fields: [] as string[],
       condition: sourceSection.condition,
     };

--- a/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
+++ b/web/src/designer/store/slices/uiSpec/viewSetReducers.ts
@@ -14,7 +14,7 @@
 
 import {PayloadAction} from '@reduxjs/toolkit';
 import {NotebookUISpec} from '../../../state/initial';
-import {slugify} from '../../../domain/notebook/ids';
+import {sanitizeUserLabel, slugify} from '../../../domain/notebook/ids';
 
 /** Form (viewset) RTK reducers merged into `uiSpecificationReducer`. */
 export const viewSetReducers = {
@@ -24,11 +24,12 @@ export const viewSetReducers = {
     action: PayloadAction<{formName: string}>
   ) => {
     const {formName} = action.payload;
+    const safeFormName = sanitizeUserLabel(formName);
     const newViewSet = {
-      label: formName,
+      label: safeFormName,
       views: [],
     };
-    const formID = slugify(formName);
+    const formID = slugify(safeFormName);
     if (formID in state.viewsets) {
       throw new Error(`Form ${formID} already exists in notebook.`);
     } else {
@@ -99,7 +100,7 @@ export const viewSetReducers = {
   ) => {
     const {viewSetId, label} = action.payload;
     if (viewSetId in state.viewsets) {
-      state.viewsets[viewSetId].label = label;
+      state.viewsets[viewSetId].label = sanitizeUserLabel(label);
     }
   },
   /** Record list UI: which field ids appear in the form summary header. */


### PR DESCRIPTION
- Stop putting raw form labels into Content-Disposition, so a quote or CR/LF in a form name cannot change the download filename or inject extra headers.

- Strip control characters from designer form/section labels, slugify designer JSON download names, and HTML-escape usernames in email bodies.