### PR TITLE
Bring NotebookView and the plan view registry into FAIMS3

### DIFF
--- a/api/src/api/notebooks.ts
+++ b/api/src/api/notebooks.ts
@@ -98,8 +98,8 @@ import {
   updateProjectOfflineMapRegion,
   updateProjectUiSpecification,
 } from '../couchdb/notebooks';
+import {createNotebookFromTemplate, getTemplate} from '../couchdb/templates';
 import {createTombstoneDocument} from '../couchdb/tombstones';
-import {getTemplate} from '../couchdb/templates';
 import {
   filterPeopleUsersForList,
   getCouchUserFromEmailOrUserId,
@@ -481,11 +481,10 @@ api.post(
       return 'template_id' in payload;
     };
 
-    let uiSpecification;
+    let projectID: string | undefined;
     const projectName: string = req.body.name;
     const description =
       'description' in req.body ? req.body.description : undefined;
-    let templateId: string | undefined = undefined;
 
     if (isFromTemplate(req.body)) {
       const template = await getTemplate(req.body.template_id);
@@ -504,30 +503,28 @@ api.post(
         );
       }
 
-      if (template.archived === true) {
-        throw new Exceptions.InvalidRequestException(
-          'Cannot create a notebook from an archived template.'
-        );
-      }
-
-      uiSpecification = template.uiSpecification;
-      templateId = template._id;
+      projectID = await createNotebookFromTemplate({
+        template,
+        projectName,
+        description,
+        teamId: req.body.teamId,
+        createdBy: req.user.user_id,
+        planConfig: req.body.planConfig,
+      });
     } else if (isFromScratch(req.body)) {
-      uiSpecification = req.body.uiSpecification;
+      projectID = await createNotebook({
+        projectName,
+        uiSpecification: req.body.uiSpecification,
+        description,
+        teamId: req.body.teamId,
+        createdBy: req.user.user_id,
+      });
     } else {
       throw new Exceptions.ValidationException(
         'Could not parse input payload as either a from scratch or from template creation. Contact a system administrator and validate payload integrity.'
       );
     }
 
-    const projectID = await createNotebook({
-      projectName,
-      uiSpecification,
-      description,
-      templateId,
-      teamId: req.body.teamId,
-      createdBy: req.user.user_id,
-    });
     if (projectID) {
       // Make the user an admin of this notebook
       addProjectRole({

--- a/api/src/couchdb/export/utils.ts
+++ b/api/src/couchdb/export/utils.ts
@@ -396,7 +396,7 @@ const CONTENT_DISPOSITION_FILENAME = /[^\w.-]/g;
  * Does not assume the filename input was pre-sanitised. Restricts the whole
  * filename to `[A-Za-z0-9._-]` so any input cannot terminate the quoted-string,
  * inject parameters, change the extension, or smuggle CR/LF into the header.
- * 
+ *
  * For security purposes this may perform some redundant sanitisation.
  */
 export const contentDispositionAttachment = (filename: string): string => {

--- a/api/src/couchdb/templates.ts
+++ b/api/src/couchdb/templates.ts
@@ -4,6 +4,8 @@ PouchDB.plugin(PouchDBFind);
 PouchDB.plugin(require('pouchdb-security-helper'));
 
 import type {
+  NotebookDefinition,
+  Plan,
   TemplateApiDocument,
   TemplateApiListItem,
 } from '@faims3/data-model';
@@ -23,7 +25,10 @@ import {
   TEMPLATES_BY_TEAM_ID,
   TEMPLATES_LISTING_BY_TEAM_ID,
   TEMPLATES_LISTING_BY_TEMPLATE_ID,
+  getPlanTypeDefinition,
+  normalizeNotebookTemplateUiSpecification,
   normalizeRootDescriptionForStore,
+  notebookUiSpecificationValidationMessage,
 } from '@faims3/data-model';
 import {getTemplatesDb} from '.';
 import * as Exceptions from '../exceptions';
@@ -31,7 +36,7 @@ import {nowIso} from '../time';
 import {generateRandomString} from '../utils';
 import {
   clearTemplateIdFromProjectsReferencingTemplate,
-  normalizeUiSpecificationOrThrow,
+  createNotebook,
 } from './notebooks';
 import {getTeamById} from './teams';
 import {stripTemplateRolesForTemplateId} from './users';
@@ -239,9 +244,16 @@ export const createTemplate = async ({
 
   // Setup the document with id included
   const now = nowIso();
-  const uiSpecification = normalizeUiSpecificationOrThrow(
-    payload.uiSpecification
-  );
+  let uiSpecification;
+  try {
+    uiSpecification = normalizeNotebookTemplateUiSpecification(
+      payload.uiSpecification
+    );
+  } catch (error) {
+    throw new Exceptions.ValidationException(
+      notebookUiSpecificationValidationMessage(error)
+    );
+  }
   const templateDoc: TemplateDocument = {
     _id: templateId,
     version: 1,
@@ -393,8 +405,15 @@ export const updateTemplateUiSpecification = async (
     | PutUpdateTemplateUiSpecificationInput
     | NotebookUiSpecificationInput
 ): Promise<ExistingTemplateDocument> => {
-  const normalizedUiSpecification =
-    normalizeUiSpecificationOrThrow(uiSpecification);
+  let normalizedUiSpecification;
+  try {
+    normalizedUiSpecification =
+      normalizeNotebookTemplateUiSpecification(uiSpecification);
+  } catch (error) {
+    throw new Exceptions.ValidationException(
+      notebookUiSpecificationValidationMessage(error)
+    );
+  }
   // Now fetch the existing template - this will allow us to get the latest
   // revision etc
   let existingTemplate;
@@ -557,4 +576,103 @@ export const restoreTemplateFromArchive = async (id: string) => {
     );
   }
   return archiveTemplate(id, false);
+};
+
+/**
+ * Create a notebook from a template, instantiating the template's plan template
+ * when it has one. A template that carries a plan template needs a matching
+ * planConfig, since the plan's per-notebook values live in the config.
+ */
+export const createNotebookFromTemplate = async ({
+  template,
+  projectName,
+  description,
+  createdBy,
+  teamId,
+  planConfig,
+}: {
+  template: ExistingTemplateDocument;
+  projectName: string;
+  description?: string;
+  createdBy: string;
+  teamId?: string;
+  planConfig?: Record<string, unknown>;
+}) => {
+  if (template.archived === true) {
+    throw new Exceptions.InvalidRequestException(
+      'Cannot create a notebook from an archived template.'
+    );
+  }
+
+  // create the proto notebook definition from the template's uiSpecification
+  const uiSpecification: NotebookDefinition = {
+    metadata: {...template.uiSpecification.metadata},
+    uiSpec: template.uiSpecification.uiSpec,
+  };
+
+  let instantiatedPlan: Plan | undefined = undefined;
+
+  // Does the template have a plan template that we need to instantiate
+  if (template.uiSpecification.planTemplate) {
+    // what kind of plan is it
+    const planTemplate = template.uiSpecification.planTemplate;
+    const planType = planTemplate.planType;
+    // Get the instantiation function for this plan type
+    const planTypeDefinition = getPlanTypeDefinition(planType);
+    if (!planTypeDefinition) {
+      throw new Exceptions.InternalSystemError(
+        `Cannot create a notebook from template ${template._id} because it has a plan template of type ${planType}, which is not recognised.`
+      );
+    }
+    // validate the planTemplate before we use it
+    const planTemplateValidationResult =
+      planTypeDefinition.templateSchema.safeParse(planTemplate);
+    if (!planTemplateValidationResult.success) {
+      throw new Exceptions.InternalSystemError(
+        `Cannot create a notebook from template ${template._id} because its plan template of type ${planType} is invalid: ${planTemplateValidationResult.error.message}`
+      );
+    }
+
+    // we need the config payload for this plan template, defined by
+    // the configSchema property of the plan template
+    if (!planConfig) {
+      throw new Exceptions.InvalidRequestException(
+        `The template ${template._id} has a plan template of type ${planType}, so a plan config must be provided.`
+      );
+    }
+    // validate the config against the plan type's config schema
+    const configValidationResult =
+      planTypeDefinition.configSchema.safeParse(planConfig);
+    if (!configValidationResult.success) {
+      throw new Exceptions.InvalidRequestException(
+        `The plan config provided for plan type ${planType} is invalid: ${configValidationResult.error.message}`
+      );
+    }
+
+    // call the plan creator for this plan type
+    instantiatedPlan = planTypeDefinition.instantiatePlan({
+      template: planTemplate,
+      config: configValidationResult.data,
+    });
+
+    // insert the plan into the uiSpecification for the notebook we're creating
+    // parse it first to make sure it's valid according to the plan type's plan schema
+    const planParseResult =
+      planTypeDefinition.planSchema.safeParse(instantiatedPlan);
+    if (!planParseResult.success) {
+      throw new Exceptions.InvalidRequestException(
+        `The instantiated plan for plan type ${planType} is invalid: ${planParseResult.error.message}`
+      );
+    }
+    uiSpecification.plan = planParseResult.data;
+  }
+
+  return await createNotebook({
+    projectName,
+    uiSpecification: uiSpecification,
+    description: description,
+    templateId: template._id,
+    teamId: teamId,
+    createdBy: createdBy,
+  });
 };

--- a/api/test/notebookPlanTemplate.test.ts
+++ b/api/test/notebookPlanTemplate.test.ts
@@ -1,0 +1,442 @@
+import PouchDB from 'pouchdb';
+import PouchDBFind from 'pouchdb-find';
+PouchDB.plugin(require('pouchdb-adapter-memory'));
+PouchDB.plugin(PouchDBFind);
+
+import type {
+  CreateNotebookFromTemplate,
+  CreateNotebookFromScratch,
+  PostCreateTemplateInput,
+  TemplateDefinition,
+} from '@faims3/data-model';
+import {
+  GetTemplateByIdResponseSchema,
+  PostCreateNotebookResponseSchema,
+  PostCreateTemplateResponseSchema,
+} from '@faims3/data-model';
+import {beforeEach, describe, expect, it} from 'vitest';
+import request from 'supertest';
+import {getTemplatesDb} from '../src/couchdb';
+import {getProjectById} from '../src/couchdb/notebooks';
+import {app} from '../src/expressSetup';
+import {
+  sampleCreateTemplatePayload,
+  sampleCreateNotebookPayload,
+  testNotebookDescription,
+} from './sampleNotebook';
+import {beforeApiTests, requestAuthAndType} from './utils';
+
+const NOTEBOOKS_API_BASE = '/api/notebooks';
+const TEMPLATE_API_BASE = '/api/templates';
+const COUNTED_PLAN_TYPE = 'Counted' as const;
+const LIST_OF_RECORDS_PLAN_TYPE = 'ListOfRecords' as const;
+const createTemplateWithPlanTemplate = async (
+  planTemplate: TemplateDefinition['planTemplate']
+) => {
+  const sample = sampleCreateTemplatePayload('planned template');
+  const payload = {
+    ...sample,
+    uiSpecification: {
+      ...sample.uiSpecification,
+      planTemplate,
+    } satisfies TemplateDefinition,
+  } satisfies PostCreateTemplateInput;
+
+  return requestAuthAndType(request(app).post(TEMPLATE_API_BASE).send(payload))
+    .expect(200)
+    .then(res => PostCreateTemplateResponseSchema.parse(res.body));
+};
+
+const createNotebookWithPlan = async (
+  plan: TemplateDefinition['planTemplate']
+) => {
+  const sample = sampleCreateNotebookPayload('planned notebook');
+  const payload = {
+    ...sample,
+    uiSpecification: {
+      ...sample.uiSpecification,
+      plan,
+    },
+  } satisfies CreateNotebookFromScratch;
+
+  const notebookId = await requestAuthAndType(
+    request(app).post(NOTEBOOKS_API_BASE).send(payload)
+  )
+    .expect(200)
+    .then(res => PostCreateNotebookResponseSchema.parse(res.body).notebook);
+
+  return getProjectById(notebookId);
+};
+
+const getTemplateById = async (templateId: string) => {
+  return requestAuthAndType(
+    request(app).get(`${TEMPLATE_API_BASE}/${templateId}`)
+  )
+    .expect(200)
+    .then(res => GetTemplateByIdResponseSchema.parse(res.body));
+};
+
+describe('notebook creation from template with planTemplate', () => {
+  beforeEach(beforeApiTests);
+
+  it('creates a template with a counted planTemplate', async () => {
+    const template = await createTemplateWithPlanTemplate({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+    });
+
+    const fetched = await getTemplateById(template._id);
+    expect(fetched.uiSpecification.planTemplate).toEqual({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+    });
+  });
+
+  it('rejects template create when planTemplate is malformed', async () => {
+    const sample = sampleCreateTemplatePayload('broken template');
+    const response = await requestAuthAndType(
+      request(app)
+        .post(TEMPLATE_API_BASE)
+        .send({
+          ...sample,
+          uiSpecification: {
+            ...sample.uiSpecification,
+            planTemplate: {
+              planType: COUNTED_PLAN_TYPE,
+            },
+          },
+        } satisfies PostCreateTemplateInput)
+    ).expect(400);
+
+    expect(response.body.error.message).toBe(
+      'Invalid plan template in template uiSpecification'
+    );
+  });
+
+  it('updates a template with a list-of-records planTemplate', async () => {
+    const sample = sampleCreateTemplatePayload('template-update-plan-template');
+    const createdTemplate = await requestAuthAndType(
+      request(app)
+        .post(TEMPLATE_API_BASE)
+        .send(sample satisfies PostCreateTemplateInput)
+    )
+      .expect(200)
+      .then(res => PostCreateTemplateResponseSchema.parse(res.body));
+
+    const updatedUiSpecification: TemplateDefinition = {
+      ...sample.uiSpecification,
+      planTemplate: {
+        planType: LIST_OF_RECORDS_PLAN_TYPE,
+        formType: 'survey-form',
+        recordFields: ['Name', 'Location'],
+      },
+    };
+
+    await requestAuthAndType(
+      request(app)
+        .put(`${TEMPLATE_API_BASE}/${createdTemplate._id}/uiSpecification`)
+        .send(updatedUiSpecification)
+    ).expect(200);
+
+    const updatedTemplate = await getTemplateById(createdTemplate._id);
+    expect(updatedTemplate.uiSpecification.planTemplate).toEqual({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType: 'survey-form',
+      recordFields: ['Name', 'Location'],
+    });
+  });
+
+  it('rejects template update when planTemplate is malformed', async () => {
+    const sample = sampleCreateTemplatePayload('template-update-invalid');
+    const createdTemplate = await requestAuthAndType(
+      request(app)
+        .post(TEMPLATE_API_BASE)
+        .send(sample satisfies PostCreateTemplateInput)
+    )
+      .expect(200)
+      .then(res => PostCreateTemplateResponseSchema.parse(res.body));
+
+    const response = await requestAuthAndType(
+      request(app)
+        .put(`${TEMPLATE_API_BASE}/${createdTemplate._id}/uiSpecification`)
+        .send({
+          ...sample.uiSpecification,
+          planTemplate: {
+            planType: LIST_OF_RECORDS_PLAN_TYPE,
+            formType: 'survey-form',
+            recordFields: ['Name', 123],
+          },
+        })
+    ).expect(400);
+
+    expect(response.body.error.message).toBe(
+      'Invalid plan template in template uiSpecification'
+    );
+  });
+
+  it('creates a notebook with a counted plan', async () => {
+    const project = await createNotebookWithPlan({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+      numberRequired: 3,
+      allowExtraRecords: false,
+    });
+
+    expect(project.uiSpecification.plan).toEqual({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+      numberRequired: 3,
+      allowExtraRecords: false,
+    });
+  });
+
+  it('creates a notebook with a list-of-records plan', async () => {
+    const project = await createNotebookWithPlan({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType: 'survey-form',
+      records: {Record1: {Name: 'Record 1', Location: 'Trench A'}},
+      allowExtraRecords: true,
+    });
+
+    expect(project.uiSpecification.plan).toEqual({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType: 'survey-form',
+      records: {Record1: {Name: 'Record 1', Location: 'Trench A'}},
+      allowExtraRecords: true,
+    });
+  });
+
+  it('rejects notebook create when plan is malformed', async () => {
+    const sample = sampleCreateNotebookPayload('broken notebook');
+    const response = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          ...sample,
+          uiSpecification: {
+            ...sample.uiSpecification,
+            plan: {
+              planType: COUNTED_PLAN_TYPE,
+              formType: 'artefact-form',
+              numberRequired: 0,
+              allowExtraRecords: 'sometimes',
+            },
+          },
+        })
+    ).expect(400);
+
+    expect(response.body.error.message).toBe('Invalid plan in uiSpecification');
+  });
+
+  it('creates a notebook and instantiates the counted plan from planConfig', async () => {
+    const template = await createTemplateWithPlanTemplate({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+    });
+
+    const notebookId = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          name: 'planned notebook',
+          description: testNotebookDescription,
+          template_id: template._id,
+          planConfig: {
+            numberRequired: 3,
+            allowExtraRecords: false,
+          },
+        } satisfies CreateNotebookFromTemplate)
+    )
+      .expect(200)
+      .then(res => PostCreateNotebookResponseSchema.parse(res.body).notebook);
+
+    const project = await getProjectById(notebookId);
+    expect(project.templateId).toBe(template._id);
+    expect(project.uiSpecification.plan).toEqual({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+      numberRequired: 3,
+      allowExtraRecords: false,
+    });
+  });
+
+  it('rejects notebook creation when planConfig is missing for a planTemplate', async () => {
+    const template = await createTemplateWithPlanTemplate({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+    });
+
+    const response = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          name: 'missing plan config notebook',
+          description: testNotebookDescription,
+          template_id: template._id,
+        } satisfies CreateNotebookFromTemplate)
+    ).expect(400);
+
+    expect(response.body.error.message).toContain(
+      'plan config must be provided'
+    );
+  });
+
+  it('rejects notebook creation when planConfig does not match the plan schema', async () => {
+    const template = await createTemplateWithPlanTemplate({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+    });
+
+    const response = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          name: 'invalid plan config notebook',
+          description: testNotebookDescription,
+          template_id: template._id,
+          planConfig: {
+            numberRequired: 0,
+            allowExtraRecords: 'sometimes',
+          },
+        })
+    ).expect(400);
+
+    expect(response.body.error.message).toContain(
+      `The plan config provided for plan type ${COUNTED_PLAN_TYPE} is invalid`
+    );
+  });
+
+  it('creates a notebook and instantiates the list-of-records plan from planConfig', async () => {
+    const template = await createTemplateWithPlanTemplate({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType: 'survey-form',
+      recordFields: ['Name', 'Location'],
+    });
+
+    const notebookId = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          name: 'listed notebook',
+          description: testNotebookDescription,
+          template_id: template._id,
+          planConfig: {
+            recordData: {
+              Record1: {
+                Name: 'Record 1',
+                Location: 'Trench A',
+                Notes: 'ignored',
+              },
+              Record2: {Name: 'Record 2', Other: 'ignored'},
+            },
+            allowExtraRecords: true,
+          },
+        } satisfies CreateNotebookFromTemplate)
+    )
+      .expect(200)
+      .then(res => PostCreateNotebookResponseSchema.parse(res.body).notebook);
+
+    const project = await getProjectById(notebookId);
+    expect(project.uiSpecification.plan).toEqual({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType: 'survey-form',
+      records: {
+        Record1: {Name: 'Record 1', Location: 'Trench A'},
+        Record2: {Name: 'Record 2'},
+      },
+      allowExtraRecords: true,
+    });
+  });
+
+  it('rejects notebook creation when the stored planTemplate is malformed', async () => {
+    const template = await createTemplateWithPlanTemplate({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+    });
+    const templatesDb = getTemplatesDb();
+    const storedTemplate = await templatesDb.get(template._id);
+
+    await templatesDb.put({
+      ...storedTemplate,
+      uiSpecification: {
+        ...storedTemplate.uiSpecification,
+        planTemplate: {
+          planType: COUNTED_PLAN_TYPE,
+        },
+      },
+    });
+
+    const response = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          name: 'broken template notebook',
+          description: testNotebookDescription,
+          template_id: template._id,
+          planConfig: {
+            numberRequired: 2,
+            allowExtraRecords: true,
+          },
+        } satisfies CreateNotebookFromTemplate)
+    ).expect(403);
+
+    expect(response.body.error.message).toContain(
+      'plan template of type Counted is invalid'
+    );
+  });
+
+  it('persists planTemplate through PUT /api/templates/:id/uiSpecification', async () => {
+    const sample = sampleCreateTemplatePayload('template-update-plan-template');
+    const createdTemplate = await requestAuthAndType(
+      request(app)
+        .post(TEMPLATE_API_BASE)
+        .send(sample satisfies PostCreateTemplateInput)
+    )
+      .expect(200)
+      .then(res => PostCreateTemplateResponseSchema.parse(res.body));
+
+    const updatedUiSpecification: TemplateDefinition = {
+      ...sample.uiSpecification,
+      planTemplate: {
+        planType: COUNTED_PLAN_TYPE,
+        formType: 'updated-form',
+      },
+    };
+
+    await requestAuthAndType(
+      request(app)
+        .put(`${TEMPLATE_API_BASE}/${createdTemplate._id}/uiSpecification`)
+        .send(updatedUiSpecification)
+    ).expect(200);
+
+    const updatedTemplate = await getTemplateById(createdTemplate._id);
+    expect(updatedTemplate.uiSpecification.planTemplate).toEqual({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'updated-form',
+    });
+
+    const notebookId = await requestAuthAndType(
+      request(app)
+        .post(NOTEBOOKS_API_BASE)
+        .send({
+          name: 'updated template notebook',
+          description: testNotebookDescription,
+          template_id: createdTemplate._id,
+          planConfig: {
+            numberRequired: 4,
+            allowExtraRecords: false,
+          },
+        } satisfies CreateNotebookFromTemplate)
+    )
+      .expect(200)
+      .then(res => PostCreateNotebookResponseSchema.parse(res.body).notebook);
+
+    const project = await getProjectById(notebookId);
+    expect(project.uiSpecification.plan).toEqual({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'updated-form',
+      numberRequired: 4,
+      allowExtraRecords: false,
+    });
+  });
+});

--- a/app/src/gui/components/notebook/MetadataDisplay.tsx
+++ b/app/src/gui/components/notebook/MetadataDisplay.tsx
@@ -16,7 +16,6 @@ import MetadataRenderer from '../metadataRenderer';
 interface MetadataDisplayComponentProps {
   project: Project;
   templateId?: string | null | undefined;
-  handleTabChange: (index: number) => void;
 }
 export const MetadataDisplayComponent = (
   props: MetadataDisplayComponentProps

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -382,11 +382,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
         </TabPanel>
 
         <TabPanel value={tabIndex} index={3} id={'details'}>
-          <MetadataDisplayComponent
-            handleTabChange={(index: number) => setTabIndex(index as TabIndex)}
-            project={project}
-            templateId={templateId}
-          />
+          <MetadataDisplayComponent project={project} templateId={templateId} />
         </TabPanel>
 
         <TabPanel value={tabIndex} index={4} id={'settings'}>

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -1,0 +1,320 @@
+/* Provide the NotebookView component that allows different
+ * UI components for different kinds of notebook, notably those that
+ * have associated plans and those that do not
+ */
+
+import {
+  Action,
+  CompiledNotebookUiSpec,
+  DatabaseInterface,
+  DataDocument,
+  DataEngine,
+  FormUpdateData,
+  MinimalRecordMetadata,
+  ProjectStatus,
+} from '@faims3/data-model';
+import NotebookComponent from '.';
+import {addAlert} from '../../../context/slices/alertSlice';
+import {selectActiveUser} from '../../../context/slices/authSlice';
+import {compiledSpecService} from '../../../context/slices/helpers/compiledSpecService';
+import {Project} from '../../../context/slices/projectSlice';
+import {useAppDispatch, useAppSelector} from '../../../context/store';
+import * as ROUTES from '../../../constants/routes';
+import {
+  invalidateProjectHydration,
+  invalidateProjectRecordList,
+  useIsAuthorisedTo,
+  useIsRecordDownloadUnderway,
+  usePlanRecordStatusReports,
+  useRecordList,
+} from '../../../utils/customHooks';
+import CircularLoading from '../ui/circular_loading';
+import {getNotebookView} from './plans';
+import {useRecordAudit} from '../../../utils/apiHooks/notebooks';
+import {useCallback, useMemo, useState} from 'react';
+import {config} from '../../../buildconfig';
+import {useQueryClient} from '@tanstack/react-query';
+import {NotebookViewComponentProps} from './types';
+import {localGetDataDb} from '../../../utils/database';
+import {useNavigate} from 'react-router-dom';
+import NotebookSettings from './settings';
+import {MetadataDisplayComponent} from './MetadataDisplay';
+import {OverviewMap} from './OverviewMap';
+
+type NotebookViewProps = {
+  project: Project;
+};
+
+/**
+ * NotebookView takes the place of the old NotebookComponent as the
+ * way to display a notebook. It defaults to the old view but can be
+ * overridden if there is a plan associated with the notebook that has
+ * a custom view registered for it.
+ *
+ * Here we do as much of the work in preparing to render the notebook
+ * as we can so that the renderer doesn't have to reference arbitrary
+ * parts of the app state.
+ *
+ */
+export function NotebookView({project}: NotebookViewProps) {
+  const {uiSpecificationId} = project;
+  const uiSpecification = compiledSpecService.getSpec(uiSpecificationId);
+  if (!uiSpecification) {
+    return <CircularLoading label="Loading" />;
+  } else {
+    return (
+      <NotebookViewWithSpec
+        project={project}
+        uiSpecification={uiSpecification}
+      />
+    );
+  }
+}
+
+/*
+ * The core component is called when we know we have the compiled uiSpecification
+ * This avoids conditional hooks in the main component
+ */
+function NotebookViewWithSpec({
+  project,
+  uiSpecification,
+}: {
+  project: Project;
+  uiSpecification: CompiledNotebookUiSpec;
+}) {
+  const activeUser = useAppSelector(selectActiveUser);
+  const [query, setQuery] = useState<string>('');
+  const queryClient = useQueryClient();
+
+  const isAllowedToAddRecords =
+    useIsAuthorisedTo({
+      action: Action.CREATE_PROJECT_RECORD,
+      resourceId: project.projectId,
+    }) && project.status === ProjectStatus.OPEN;
+
+  // Records on the server may still be downloading into the local database:
+  // while true, a record's absence from the lists proves nothing.
+  const isDownloadingRecords = useIsRecordDownloadUnderway({
+    serverId: project.serverId,
+    projectId: project.projectId,
+    syncMode: project.database?.syncMode ?? 'none',
+  });
+
+  // get the sync status of records in this project
+  const recordStatus = useRecordAudit({
+    projectId: project.projectId,
+    listingId: project.serverId,
+    username: activeUser?.username ?? '',
+  });
+
+  const records = useRecordList({
+    query: query,
+    // Profiling enabled when debugging
+    enableProfiling: config.debugApp,
+    projectId: project.projectId,
+    filterDeleted: true,
+    // refetch every 10 seconds (local only fetch - no network traffic here)
+    metadataRefreshIntervalMs: 10000,
+    uiSpecification: uiSpecification,
+  });
+
+  const refreshRecordList = useCallback(() => {
+    invalidateProjectRecordList({
+      client: queryClient,
+      projectId: project.projectId,
+      reset: true,
+    });
+    invalidateProjectHydration({
+      client: queryClient,
+      projectId: project.projectId,
+      reset: true,
+    });
+  }, [queryClient, project.projectId]);
+
+  // Set up the data engine for creating new records
+
+  const dataDb = localGetDataDb(project.projectId);
+  const dataEngine = useCallback(() => {
+    return new DataEngine({
+      dataDb: dataDb as DatabaseInterface<DataDocument>,
+      uiSpec: uiSpecification,
+    });
+  }, [dataDb, uiSpecification]);
+
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  /**
+   * Create a new record - function passed in to the view component to create new records,
+   *  bundles up all of the app internal access that is needed to do this so that the
+   *  view component can be self-contained.
+   *
+   * Create the record with possible initial data and navigate to the record edit page with mode=new
+   * adds a planReference to the record if provided
+   *
+   * @param viewsetName The name of the viewset for the new record
+   * @param data The initial data for the new record
+   * @param planReference Optional plan reference for the new record
+   */
+  const createRecord = useCallback(
+    async (
+      viewsetName: string,
+      data: Record<string, any>,
+      planReference?: string
+    ) => {
+      // create the new record then navigate to its edit page with mode=new
+
+      // Create the initial data for the new record in the right shape
+      const initial: FormUpdateData = {};
+      for (const [key, value] of Object.entries(data)) {
+        initial[key] = {data: value};
+      }
+
+      if (!(activeUser && isAllowedToAddRecords)) return;
+
+      try {
+        // The engine tidies up after itself when applying initial data fails
+        // (the half-created record is deleted before the error propagates),
+        // so a rejection here always means no record exists.
+        const {record} = await dataEngine().form.createRecord({
+          formId: viewsetName,
+          createdBy: activeUser.username,
+          // Omit empty initial data so a data-less create is a single write
+          initial: Object.keys(initial).length > 0 ? initial : undefined,
+          planReference,
+        });
+        navigate(
+          ROUTES.getEditRecordRoute({
+            serverId: project.serverId,
+            projectId: project.projectId,
+            recordId: record._id,
+            mode: 'new',
+          })
+        );
+      } catch (err) {
+        // Surface the error and resolve (do not rethrow): a caller awaiting
+        // this to re-enable its UI must not see a rejection it would treat as
+        // an unhandled failure.
+        console.error('Failed to create record', viewsetName, err);
+        dispatch(
+          addAlert({
+            message: 'Record could not be created',
+            severity: 'error',
+          })
+        );
+      }
+    },
+    [
+      activeUser,
+      isAllowedToAddRecords,
+      dataEngine,
+      navigate,
+      project.serverId,
+      project.projectId,
+      dispatch,
+    ]
+  );
+
+  // View/Edit an existing record by navigating to the record view page
+  const navigateToRecord = useCallback(
+    (record: MinimalRecordMetadata) => {
+      const route = ROUTES.getViewRecordRoute({
+        serverId: project.serverId,
+        projectId: record.projectId,
+        recordId: record.recordId,
+      });
+
+      navigate(route);
+    },
+    [navigate, project.serverId]
+  );
+
+  // does this notebook have a plan, and do we have a view component for it
+  const planType = project.uiDefinition?.plan?.planType;
+  const PlanComponent = getNotebookView(planType);
+
+  // Completion roll-up per plan-claiming record, for its cell's status; only a
+  // registered plan view can display it, so gate the walks on one
+  const planRecordStatusReports = usePlanRecordStatusReports({
+    projectId: project.projectId,
+    uiSpecification,
+    records: records.allRecords,
+    enabled: PlanComponent !== undefined,
+  });
+
+  const props: NotebookViewComponentProps = useMemo(
+    () => ({
+      project,
+      uiSpecification: uiSpecification,
+      actions: {
+        refreshRecordList,
+        setQuery,
+        createRecord,
+        navigateToRecord,
+      },
+      status: {
+        // Never-loaded, not merely in-flight: the hook's isLoading stays true
+        // after a failed initial fetch (which would otherwise present the
+        // empty fallback list as a loaded, empty notebook) and goes false
+        // once the list has loaded, even if a later background refetch fails
+        // while it is still being served. The query refetches on an interval,
+        // so an errored initial load is effectively still loading.
+        isLoading: records.isLoading,
+        isAllowedToAddRecords,
+        // The record list is filtered to what the user may read; the hook
+        // reports whether that filter can hide records, from the same token
+        // the filter reads.
+        canReadAllRecords: records.canReadAllRecords,
+        isDownloadingRecords,
+      },
+      records: {
+        allRecords: records.allRecords,
+        myRecords: records.myRecords,
+        otherRecords: records.otherRecords,
+        syncStatus: recordStatus.data ?? {status: {}, recordHashes: {}},
+        planRecordStatusReports,
+      },
+      components: {
+        NotebookSettings: () => <NotebookSettings uiSpec={uiSpecification} />,
+        MetadataDisplayComponent: () => (
+          <MetadataDisplayComponent
+            project={project}
+            templateId={project.templateId}
+          />
+        ),
+        OverviewMap: () => (
+          <OverviewMap
+            serverId={project.serverId}
+            records={records}
+            project_id={project.projectId}
+            uiSpec={uiSpecification}
+          />
+        ),
+      },
+    }),
+    [
+      project,
+      uiSpecification,
+      refreshRecordList,
+      setQuery,
+      createRecord,
+      navigateToRecord,
+      isAllowedToAddRecords,
+      isDownloadingRecords,
+      records,
+      recordStatus.data,
+      planRecordStatusReports,
+    ]
+  );
+
+  // delegate to the plan view component
+  if (PlanComponent) {
+    return <PlanComponent {...props} />;
+  }
+
+  // fallback to the default notebook component
+  // TODO: port this component to use the same interface
+  // as our custom plan view components once we have sorted
+  // out what that interface looks like
+  return <NotebookComponent project={project} />;
+}

--- a/app/src/gui/components/notebook/plans/CountedPlanView.tsx
+++ b/app/src/gui/components/notebook/plans/CountedPlanView.tsx
@@ -53,9 +53,8 @@ export const CountedPlanView = (props: NotebookViewComponentProps) => {
     <>
       <div>
         <Alert severity="info">
-          {' '}
           <b>Counted Plan</b>: Collect {plan.numberRequired} {plan.formType}{' '}
-          records.
+          records.{' '}
           {!plan.allowExtraRecords
             ? 'Do not allow extra records'
             : 'Extra records allowed'}

--- a/app/src/gui/components/notebook/plans/CountedPlanView.tsx
+++ b/app/src/gui/components/notebook/plans/CountedPlanView.tsx
@@ -1,0 +1,132 @@
+import {COUNTED_PLAN_TYPE, CountedPlan} from '@faims3/data-model';
+import {Alert, Box, Tab} from '@mui/material';
+import AddRecordButtons from '../add_record_by_type';
+import {RecordsTable} from '../record_table';
+import {NotebookViewComponentProps} from '../types';
+import TabPanel from '@mui/lab/TabPanel';
+import TabContext from '@mui/lab/TabContext';
+import TabList from '@mui/lab/TabList';
+import {useState} from 'react';
+
+/**
+ * A view component for the counted plan type. Shows the record
+ * list and allows creation of records up to the number required by the plan.
+ *
+ */
+
+export const CountedPlanView = (props: NotebookViewComponentProps) => {
+  const {project, uiSpecification, records, actions, status} = props;
+
+  const [tabIndex, setTabIndex] = useState('0');
+
+  // Should not need this but it guards the type cast below
+  if (project.uiDefinition?.plan?.planType !== COUNTED_PLAN_TYPE) {
+    return <div>CountedPlanView: Not a counted plan</div>;
+  }
+  // this really is a counted plan
+  const plan: CountedPlan = project.uiDefinition.plan as CountedPlan;
+  if (!plan) {
+    return <div>No plan defined for this notebook</div>;
+  }
+
+  // How many records of the target type have we got
+  const targetRecordCount = records.allRecords.filter(
+    record => record.type === plan.formType
+  ).length;
+
+  // We can add records if the user has permission and we've not reached the target number
+  // Note that this doesn't prevent their being more than the target number of records
+  // because another user could be adding them at the same time. So, the plan is really
+  // just a workflow guide rather than an enforced constraint on the data collected.
+  const showAddRecordButtons =
+    status.isAllowedToAddRecords &&
+    (targetRecordCount < plan.numberRequired || plan.allowExtraRecords);
+
+  // recordLabel based on viewsets
+  const recordLabel =
+    uiSpecification.visible_types?.length === 1
+      ? uiSpecification.viewsets[uiSpecification.visible_types[0]]?.label ||
+        uiSpecification.visible_types[0]
+      : 'Record';
+
+  return (
+    <>
+      <div>
+        <Alert severity="info">
+          {' '}
+          <b>Counted Plan</b>: Collect {plan.numberRequired} {plan.formType}{' '}
+          records.
+          {!plan.allowExtraRecords
+            ? 'Do not allow extra records'
+            : 'Extra records allowed'}
+        </Alert>
+      </div>
+
+      <TabContext value={tabIndex.toString()}>
+        <TabList
+          onChange={(event, newValue) => setTabIndex(newValue)}
+          aria-label={`List of Records Plan tabs`}
+        >
+          <Tab
+            label={`Planned ${recordLabel}s`}
+            value="0"
+            id="planned-tab"
+            aria-controls="planned-tabpanel"
+          />
+
+          <Tab
+            value="1"
+            label={`Details`}
+            id="details-tab"
+            aria-controls="details-tabpanel"
+          />
+          <Tab
+            value="2"
+            label={`Settings`}
+            id="settings-tab"
+            aria-controls="settings-tabpanel"
+          />
+        </TabList>
+
+        <TabPanel value="0" id="planned-tabpanel" aria-labelledby="planned-tab">
+          {showAddRecordButtons && (
+            <Box sx={{mb: 1.5}}>
+              <AddRecordButtons
+                project={project}
+                recordLabel={recordLabel}
+                refreshList={actions.refreshRecordList}
+              />
+            </Box>
+          )}
+          {!showAddRecordButtons && (
+            <Alert severity="info">Target number of records reached.</Alert>
+          )}
+
+          <RecordsTable
+            project={project}
+            maxRows={25}
+            rows={records.allRecords ?? []}
+            loading={status.isLoading}
+            viewsets={uiSpecification.viewsets}
+            handleQueryFunction={actions.setQuery}
+            handleRefresh={() => {}} // Note this is not used in RecordsTable
+            recordLabel={recordLabel}
+            recordStatus={records.syncStatus}
+          />
+        </TabPanel>
+
+        <TabPanel value="1" id="details-tabpanel" aria-labelledby="details-tab">
+          <props.components.MetadataDisplayComponent />
+        </TabPanel>
+
+        <TabPanel
+          value="2"
+          id="settings-tabpanel"
+          aria-labelledby="settings-tab"
+        >
+          <props.components.NotebookSettings />
+        </TabPanel>
+      </TabContext>
+    </>
+  );
+};

--- a/app/src/gui/components/notebook/plans/CountedPlanView.tsx
+++ b/app/src/gui/components/notebook/plans/CountedPlanView.tsx
@@ -34,13 +34,21 @@ export const CountedPlanView = (props: NotebookViewComponentProps) => {
     record => record.type === plan.formType
   ).length;
 
+  // Records that exist may be missing from the list, so the count is a floor
+  // rather than the true total and cannot show the target as reached.
+  const countMayBeUnderstated =
+    !status.canReadAllRecords || status.isDownloadingRecords;
+
   // We can add records if the user has permission and we've not reached the target number
   // Note that this doesn't prevent their being more than the target number of records
   // because another user could be adding them at the same time. So, the plan is really
   // just a workflow guide rather than an enforced constraint on the data collected.
-  const showAddRecordButtons =
-    status.isAllowedToAddRecords &&
-    (targetRecordCount < plan.numberRequired || plan.allowExtraRecords);
+  const targetReached =
+    !countMayBeUnderstated &&
+    targetRecordCount >= plan.numberRequired &&
+    !plan.allowExtraRecords;
+
+  const showAddRecordButtons = status.isAllowedToAddRecords && !targetReached;
 
   // recordLabel based on viewsets
   const recordLabel =
@@ -64,7 +72,7 @@ export const CountedPlanView = (props: NotebookViewComponentProps) => {
       <TabContext value={tabIndex.toString()}>
         <TabList
           onChange={(event, newValue) => setTabIndex(newValue)}
-          aria-label={`List of Records Plan tabs`}
+          aria-label={'Counted Plan tabs'}
         >
           <Tab
             label={`Planned ${recordLabel}s`}
@@ -97,7 +105,13 @@ export const CountedPlanView = (props: NotebookViewComponentProps) => {
               />
             </Box>
           )}
-          {!showAddRecordButtons && (
+          {countMayBeUnderstated && (
+            <Alert severity="warning" sx={{mb: 1.5}}>
+              Some records are not visible to you yet, so this plan's progress
+              may be further along than it looks.
+            </Alert>
+          )}
+          {targetReached && (
             <Alert severity="info">Target number of records reached.</Alert>
           )}
 

--- a/app/src/gui/components/notebook/plans/ListOfRecordsPlanView.tsx
+++ b/app/src/gui/components/notebook/plans/ListOfRecordsPlanView.tsx
@@ -82,8 +82,7 @@ export const ListOfRecordsPlanView = (props: NotebookViewComponentProps) => {
   return (
     <>
       <Alert severity="info">
-        {' '}
-        <b>List of Records Plan</b>: Collect {plan.formType} records.
+        <b>List of Records Plan</b>: Collect {plan.formType} records.{' '}
         {!plan.allowExtraRecords
           ? 'Do not allow extra records'
           : 'Extra records allowed'}

--- a/app/src/gui/components/notebook/plans/ListOfRecordsPlanView.tsx
+++ b/app/src/gui/components/notebook/plans/ListOfRecordsPlanView.tsx
@@ -34,6 +34,12 @@ export const ListOfRecordsPlanView = (props: NotebookViewComponentProps) => {
         uiSpecification.visible_types[0]
       : 'Record';
 
+  // A claimed entry is proof the record exists, but an unclaimed one is not
+  // proof it does not: the list can hide records the user may not read, and
+  // records still downloading have not arrived yet.
+  const unclaimedMayBeStale =
+    !status.canReadAllRecords || status.isDownloadingRecords;
+
   // work out which records we've already created from the plan
   // by checking the planReference field in the record metadata
   const existingRecords: Record<string, boolean> = useMemo(() => {
@@ -126,6 +132,12 @@ export const ListOfRecordsPlanView = (props: NotebookViewComponentProps) => {
         </TabList>
 
         <TabPanel value="0" id="planned-tabpanel" aria-labelledby="planned-tab">
+          {unclaimedMayBeStale && (
+            <Alert severity="warning" sx={{mb: 1.5}}>
+              Some records are not visible to you yet, so an entry shown as not
+              created may already have one.
+            </Alert>
+          )}
           <Grid
             container
             spacing={{xs: 2, md: 3}}
@@ -142,6 +154,7 @@ export const ListOfRecordsPlanView = (props: NotebookViewComponentProps) => {
                       planReference={planReference}
                       created={existingRecords[planReference] ?? false}
                       createRecord={actions.createRecord}
+                      canCreateRecord={status.isAllowedToAddRecords}
                       navigateToRecord={navigateToRecord}
                     />
                   </Grid>
@@ -194,6 +207,7 @@ export const ListOfRecordsPlanView = (props: NotebookViewComponentProps) => {
  * @param type - The viewset type of the record
  * @param title - The title to display for the record card
  * @param createRecord - Function to create a new record
+ * @param canCreateRecord - Whether the user may create records in this notebook
  * @param created - Boolean indicating if the record has already been created
  * @param planReference - The unique reference for the planned record
  * @param navigateToRecord - Function to navigate to the existing record
@@ -204,6 +218,7 @@ const RecordCard = ({
   type,
   title,
   createRecord,
+  canCreateRecord,
   created,
   planReference,
   navigateToRecord,
@@ -218,6 +233,7 @@ const RecordCard = ({
     data: Record<string, any>,
     planReference?: string
   ) => void;
+  canCreateRecord: boolean;
   navigateToRecord: (planReference: string) => void;
 }) => {
   const handleCreateRecord = () => {
@@ -252,9 +268,11 @@ const RecordCard = ({
             Edit Record
           </Button>
         ) : (
-          <Button size="small" onClick={handleCreateRecord}>
-            Create Record
-          </Button>
+          canCreateRecord && (
+            <Button size="small" onClick={handleCreateRecord}>
+              Create Record
+            </Button>
+          )
         )}
       </CardActions>
     </Card>

--- a/app/src/gui/components/notebook/plans/ListOfRecordsPlanView.tsx
+++ b/app/src/gui/components/notebook/plans/ListOfRecordsPlanView.tsx
@@ -1,0 +1,263 @@
+import {LIST_OF_RECORDS_PLAN_TYPE, ListPlan} from '@faims3/data-model';
+import TabContext from '@mui/lab/TabContext';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
+import {
+  Alert,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Grid,
+  Tab,
+  Typography,
+} from '@mui/material';
+import {useCallback, useMemo, useState} from 'react';
+import {RecordsTable} from '../record_table';
+import {NotebookViewComponentProps} from '../types';
+import {config} from '../../../../buildconfig';
+
+/**
+ * A view component for the list of records plan type. Shows pre-populated cards
+ * for the planned records with a status display if the record has been created.
+ *
+ */
+export const ListOfRecordsPlanView = (props: NotebookViewComponentProps) => {
+  const {project, uiSpecification, records, actions, status} = props;
+
+  const [tabIndex, setTabIndex] = useState('0');
+
+  // recordLabel based on viewsets
+  const recordLabel =
+    uiSpecification.visible_types?.length === 1
+      ? uiSpecification.viewsets[uiSpecification.visible_types[0]]?.label ||
+        uiSpecification.visible_types[0]
+      : 'Record';
+
+  // work out which records we've already created from the plan
+  // by checking the planReference field in the record metadata
+  const existingRecords: Record<string, boolean> = useMemo(() => {
+    const existing: Record<string, boolean> = {};
+    records.allRecords.forEach(record => {
+      if (record.planReference) {
+        existing[record.planReference] = true;
+      }
+    });
+    return existing;
+  }, [records.allRecords]);
+
+  const navigateToRecord = useCallback(
+    (planReference: string) => {
+      // find the record with the given planReference
+      const record = records.allRecords.find(
+        r => r.planReference === planReference
+      );
+      // and navigate to it if we found it
+      if (record) {
+        actions.navigateToRecord(record);
+      }
+    },
+    [records.allRecords, actions.navigateToRecord]
+  );
+
+  // Should not need this but it guards the type cast below
+  if (project.uiDefinition?.plan?.planType !== LIST_OF_RECORDS_PLAN_TYPE) {
+    return (
+      <div>
+        ListOfRecordsPlanView: Not a list of records plan for this{' '}
+        {config.notebookName}
+      </div>
+    );
+  }
+  // this really is a list of records plan
+  const plan = project.uiDefinition.plan as ListPlan | undefined;
+  if (!plan) {
+    return <div>No plan defined for this {config.notebookName}</div>;
+  }
+  const plannedRecords = plan.records;
+  if (!plannedRecords) {
+    return <div>No planned records defined for this {config.notebookName}</div>;
+  }
+
+  return (
+    <>
+      <Alert severity="info">
+        {' '}
+        <b>List of Records Plan</b>: Collect {plan.formType} records.
+        {!plan.allowExtraRecords
+          ? 'Do not allow extra records'
+          : 'Extra records allowed'}
+      </Alert>
+
+      <TabContext value={tabIndex.toString()}>
+        <TabList
+          onChange={(event, newValue) => setTabIndex(newValue)}
+          aria-label={`List of Records Plan tabs`}
+        >
+          <Tab
+            label={`Planned ${recordLabel}s`}
+            value="0"
+            id="planned-tab"
+            aria-controls="planned-tabpanel"
+          />
+          <Tab
+            value="1"
+            label={`All ${recordLabel}s`}
+            id="all-tab"
+            aria-controls="all-tabpanel"
+          />
+          <Tab
+            value="2"
+            label="Details"
+            id="details-tab"
+            aria-controls="details-tabpanel"
+          />
+          <Tab
+            value="3"
+            label="Settings"
+            id="settings-tab"
+            aria-controls="settings-tabpanel"
+          />
+          <Tab
+            value="4"
+            label="Overview Map"
+            id="overview-map-tab"
+            aria-controls="overview-map-tabpanel"
+          />
+        </TabList>
+
+        <TabPanel value="0" id="planned-tabpanel" aria-labelledby="planned-tab">
+          <Grid
+            container
+            spacing={{xs: 2, md: 3}}
+            columns={{xs: 4, sm: 8, md: 12}}
+          >
+            {Object.entries(plannedRecords).map(
+              ([planReference, plannedRecord]) => {
+                return (
+                  <Grid key={planReference} size={4}>
+                    <RecordCard
+                      record={plannedRecord}
+                      type={plan.formType}
+                      title={recordLabel}
+                      planReference={planReference}
+                      created={existingRecords[planReference] ?? false}
+                      createRecord={actions.createRecord}
+                      navigateToRecord={navigateToRecord}
+                    />
+                  </Grid>
+                );
+              }
+            )}
+          </Grid>
+        </TabPanel>
+        <TabPanel value="1" id="all-tabpanel" aria-labelledby="all-tab">
+          <RecordsTable
+            project={project}
+            maxRows={25}
+            rows={records.allRecords ?? []}
+            loading={status.isLoading}
+            viewsets={uiSpecification.viewsets}
+            handleQueryFunction={actions.setQuery}
+            handleRefresh={() => {}} // Note this is not used in RecordsTable
+            recordLabel={recordLabel}
+            recordStatus={records.syncStatus}
+          />
+        </TabPanel>
+
+        <TabPanel value="2" id="details-tabpanel" aria-labelledby="details-tab">
+          <props.components.MetadataDisplayComponent />
+        </TabPanel>
+        <TabPanel
+          value="3"
+          id="settings-tabpanel"
+          aria-labelledby="settings-tab"
+        >
+          <props.components.NotebookSettings />
+        </TabPanel>
+        <TabPanel
+          value="4"
+          id="overview-map-tabpanel"
+          aria-labelledby="overview-map-tab"
+        >
+          <props.components.OverviewMap />
+        </TabPanel>
+      </TabContext>
+    </>
+  );
+};
+
+/**
+ * RecordCard component displays a single planned record and allows for either creation
+ * of the record or navigation to the existing record if it has already been created.
+ *
+ * @param record - The planned record data to display
+ * @param type - The viewset type of the record
+ * @param title - The title to display for the record card
+ * @param createRecord - Function to create a new record
+ * @param created - Boolean indicating if the record has already been created
+ * @param planReference - The unique reference for the planned record
+ * @param navigateToRecord - Function to navigate to the existing record
+ * @returns JSX.Element representing the record card
+ */
+const RecordCard = ({
+  record,
+  type,
+  title,
+  createRecord,
+  created,
+  planReference,
+  navigateToRecord,
+}: {
+  record: Record<string, unknown>;
+  type: string;
+  title: string;
+  planReference: string;
+  created: boolean;
+  createRecord: (
+    viewsetName: string,
+    data: Record<string, any>,
+    planReference?: string
+  ) => void;
+  navigateToRecord: (planReference: string) => void;
+}) => {
+  const handleCreateRecord = () => {
+    createRecord(type, record, planReference);
+  };
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography gutterBottom sx={{color: 'text.secondary', fontSize: 14}}>
+          {title}{' '}
+        </Typography>
+        <Typography variant="body2">
+          {Object.entries(record).map(([key, value]) => (
+            <div key={key}>
+              <strong>{key}:</strong> {String(value)}
+            </div>
+          ))}
+        </Typography>
+      </CardContent>
+      <CardActions
+        sx={{
+          backgroundColor: created ? 'success.light' : 'background.paper',
+        }}
+      >
+        {created ? (
+          <Button
+            size="small"
+            sx={{backgroundColor: 'background.paper'}}
+            onClick={() => navigateToRecord(planReference)}
+          >
+            Edit Record
+          </Button>
+        ) : (
+          <Button size="small" onClick={handleCreateRecord}>
+            Create Record
+          </Button>
+        )}
+      </CardActions>
+    </Card>
+  );
+};

--- a/app/src/gui/components/notebook/plans/index.tsx
+++ b/app/src/gui/components/notebook/plans/index.tsx
@@ -1,0 +1,9 @@
+import {COUNTED_PLAN_TYPE, LIST_OF_RECORDS_PLAN_TYPE} from '@faims3/data-model';
+import {CountedPlanView} from './CountedPlanView';
+import {registerNotebookView} from './planViewRegistry';
+import {ListOfRecordsPlanView} from './ListOfRecordsPlanView';
+
+registerNotebookView(COUNTED_PLAN_TYPE, CountedPlanView);
+registerNotebookView(LIST_OF_RECORDS_PLAN_TYPE, ListOfRecordsPlanView);
+
+export * from './planViewRegistry';

--- a/app/src/gui/components/notebook/plans/planViewRegistry.ts
+++ b/app/src/gui/components/notebook/plans/planViewRegistry.ts
@@ -1,0 +1,66 @@
+/**
+ * App-side registry mapping a notebook plan's `planType` to the React component
+ * that renders that notebook's record view.
+ *
+ * It mirrors the data-model plan registry but lives in the app because it holds
+ * React components, and data-model is React-free, so the component map cannot
+ * live there. FAIMS3 ships this seam and the default view ({@link RecordsTable});
+ * a downstream build (e.g. a map/grid view) registers its own component for a
+ * given `planType` from its own bootstrap.
+ */
+import type {PlanTypeMap} from '@faims3/data-model';
+import type {ComponentType} from 'react';
+import {NotebookViewComponentProps} from '../types';
+
+export type NotebookViewComponent = ComponentType<NotebookViewComponentProps>;
+
+const notebookViewRegistry = new Map<
+  keyof PlanTypeMap,
+  NotebookViewComponent
+>();
+
+/** A component's `displayName`/`name`, for the dev-only collision warning. */
+function componentName(component: NotebookViewComponent): string {
+  const named = component as {displayName?: string; name?: string};
+  return named.displayName ?? named.name ?? 'anonymous';
+}
+
+/**
+ * Register the view component to render for a notebook plan's `planType`.
+ * Re-registering a `planType` replaces the previous component (last wins), which
+ * keeps hot-reload and re-bootstrapping well-behaved. A dev-only warning fires
+ * when the replacement has a *different name*, which usually signals two views
+ * fighting over one plan type. The comparison is by name, not identity, because
+ * React Fast Refresh re-creates a component's function identity on every edit,
+ * so an identity check would warn on nearly every hot reload.
+ */
+export function registerNotebookView(
+  planType: keyof PlanTypeMap,
+  component: NotebookViewComponent
+): void {
+  if (import.meta.env.DEV) {
+    const existing = notebookViewRegistry.get(planType);
+    if (existing && componentName(existing) !== componentName(component)) {
+      console.warn(
+        `registerNotebookView: replacing the view registered for plan type ` +
+          `"${planType}" (${componentName(existing)} -> ${componentName(component)}).`
+      );
+    }
+  }
+  notebookViewRegistry.set(planType, component);
+}
+
+/**
+ * Resolve the view component for a plan's `planType`,
+ * or undefined if no view is registered.
+ */
+export function getNotebookView(
+  planType?: keyof PlanTypeMap
+): NotebookViewComponent | undefined {
+  if (planType) {
+    const registered = notebookViewRegistry.get(planType);
+    if (registered) {
+      return registered;
+    }
+  }
+}

--- a/app/src/gui/components/notebook/types.ts
+++ b/app/src/gui/components/notebook/types.ts
@@ -1,0 +1,82 @@
+import {
+  type CompiledNotebookUiSpec,
+  type MinimalRecordMetadata,
+  type RecordStatusReport,
+} from '@faims3/data-model';
+import {Project} from '../../../context/slices/projectSlice';
+import {RecordStatus} from '../../../utils/recordAudit';
+
+/**
+ * The explicit prop contract for a notebook view.  Includes the
+ * project and various artefacts and function references
+ * that a view component may need to render the notebook
+ *
+ * This interfaces is abstracted a little from the internal app
+ * apis so that it can be a more abstract API for view components
+ * to use, not so closely tied to the app state/architecture.
+ */
+
+interface RecordListProps {
+  // All records in the notebook
+  allRecords: MinimalRecordMetadata[];
+  // Records created by the current user
+  myRecords: MinimalRecordMetadata[];
+  // Records created by other users
+  otherRecords: MinimalRecordMetadata[];
+  // The current sync status of the records in the notebook
+  syncStatus: RecordStatus;
+  // Recursive completion report per record claiming a plan reference
+  // (recordId -> report); entries appear as each record's report computes
+  planRecordStatusReports: ReadonlyMap<string, RecordStatusReport>;
+}
+
+interface StatusProps {
+  // Is the record list still unloaded (loading, or errored and retrying):
+  // while true, the record lists' contents are meaningless
+  isLoading: boolean;
+  // Is the user allowed to add records to the notebook
+  isAllowedToAddRecords: boolean;
+  // Can the user read every record in the notebook. When false, the record
+  // lists hold only the records the user may see (their own), so a view must
+  // not present a record's absence as proof that none exists.
+  canReadAllRecords: boolean;
+  // Is a record download (the initial pull after activation, or a catch-up
+  // pull) underway. While true, records that exist on the server may be
+  // missing from the local lists, so a view must not present a record's
+  // absence as proof that none exists. Always false when the notebook never
+  // pulls (sync off, or push-only).
+  isDownloadingRecords: boolean;
+}
+
+interface ActionProps {
+  // Refresh the record list from the local database
+  refreshRecordList: () => void;
+  // Set the query for the record list
+  setQuery: (query: string) => void;
+  // Create a new record of the given viewset type. Resolves when the create
+  // has settled (navigated away on success, or surfaced its own error), so a
+  // caller can await it to re-enable UI it disabled for the duration.
+  createRecord: (
+    viewsetName: string,
+    data: Record<string, any>,
+    planReference?: string
+  ) => Promise<void>;
+  // Navigate to the view page for the given record
+  navigateToRecord: (record: MinimalRecordMetadata) => void;
+}
+
+// Components that might be used in the notebook display
+interface ComponentProps {
+  NotebookSettings: React.ComponentType<{}>;
+  MetadataDisplayComponent: React.ComponentType<{}>;
+  OverviewMap: React.ComponentType<{}>;
+}
+
+export interface NotebookViewComponentProps {
+  project: Project;
+  uiSpecification: CompiledNotebookUiSpec;
+  records: RecordListProps;
+  actions: ActionProps;
+  status: StatusProps;
+  components: ComponentProps;
+}

--- a/app/src/gui/pages/notebook.tsx
+++ b/app/src/gui/pages/notebook.tsx
@@ -40,9 +40,9 @@ import {useNavigate, useParams} from 'react-router-dom';
 import * as ROUTES from '../../constants/routes';
 import {useAppSelector} from '../../context/store';
 import {removedNotebookUnavailableCopy} from '../../utils/remoteProjectRemoval';
-import NotebookComponent from '../components/notebook';
 import BackButton from '../components/ui/BackButton';
 import NotFound404 from './404';
+import {NotebookView} from '../components/notebook/notebookView';
 
 /** Shown when the URL names a notebook that no longer exists locally. */
 function NotebookUnavailable() {
@@ -112,7 +112,7 @@ export default function Notebook() {
         </Typography>
       </Stack>
 
-      <NotebookComponent project={project} />
+      <NotebookView project={project} />
     </Stack>
   );
 }

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -1,6 +1,7 @@
 import {
   Action,
   CompiledNotebookUiSpec,
+  computeRecordStatusReport,
   DatabaseInterface,
   DataDbType,
   DataDocument,
@@ -8,9 +9,16 @@ import {
   fetchAndHydrateRecord,
   isAuthorized,
   MinimalRecordMetadata,
+  RecordStatusReport,
   UiSpecModel,
 } from '@faims3/data-model';
-import {QueryClient, useQuery} from '@tanstack/react-query';
+import {fieldCompletionResolver} from '@faims3/forms';
+import {
+  QueryClient,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useNavigate} from 'react-router';
@@ -328,9 +336,11 @@ export function buildHydrateKeys({
 }
 
 /**
- * Query key for a record's Status tab report. The hydration prefix only adds
- * it to project-wide cancel/reset sweeps; freshness comes from the query's
- * refetchOnMount, not invalidation.
+ * Query key for a record's status report, shared by the Status tab and
+ * {@link usePlanRecordStatusReports} so either surface serves the other's
+ * cache. The hydration prefix adds it to project-wide cancel/reset sweeps;
+ * freshness comes from the Status tab's refetchOnMount and the plan hook's
+ * revision-driven invalidation.
  */
 export function buildStatusReportKey({
   projectId,
@@ -340,6 +350,93 @@ export function buildStatusReportKey({
   recordId: string;
 }) {
   return [HYDRATION_KEY_PREFIX, projectId, recordId, 'statusReport'];
+}
+
+/**
+ * Recursive status reports for every record claiming a plan reference, for
+ * plan views that display per-record completion. One query per claiming
+ * record, on the Status tab's own key, so reports land incrementally and
+ * either surface serves the other's cache. A report spans the record's whole
+ * child subtree, so any head-revision change in the notebook invalidates every
+ * report; invalidation rather than a version in the key keeps each query's
+ * identity stable, so a recomputing entry keeps its previous result instead of
+ * flashing back to pending.
+ */
+export function usePlanRecordStatusReports({
+  projectId,
+  uiSpecification,
+  records,
+  enabled,
+}: {
+  projectId: string;
+  uiSpecification: CompiledNotebookUiSpec;
+  records: MinimalRecordMetadata[];
+  /** Pass false where no view displays the reports, to skip the walks. */
+  enabled: boolean;
+}): ReadonlyMap<string, RecordStatusReport> {
+  const queryClient = useQueryClient();
+  // Undefined while the notebook is being removed; the queries wait it out
+  const dataDb = tryLocalGetDataDb(projectId);
+  const claimingRecords = useMemo(
+    () =>
+      records.filter(
+        record => !record.deleted && record.planReference !== undefined
+      ),
+    [records]
+  );
+  // Head revisions of the whole list: unlike `updated` (the author device's
+  // clock), a synced-in edit always changes a revisionId
+  const dataVersion = useMemo(
+    () =>
+      records
+        .map(record => `${record.recordId}:${record.revisionId}`)
+        .sort()
+        .join(' '),
+    [records]
+  );
+  useEffect(() => {
+    void queryClient.invalidateQueries({
+      predicate: query =>
+        query.queryKey[0] === HYDRATION_KEY_PREFIX &&
+        query.queryKey[1] === projectId &&
+        query.queryKey[3] === 'statusReport',
+    });
+  }, [queryClient, projectId, dataVersion, uiSpecification]);
+  // Stable across renders, so an unchanged result set keeps its Map identity
+  // and downstream memos hold
+  const combineReports = useCallback(
+    (results: Array<{data: RecordStatusReport | undefined}>) => {
+      const reports = new Map<string, RecordStatusReport>();
+      results.forEach((result, index) => {
+        if (result.data) {
+          reports.set(claimingRecords[index].recordId, result.data);
+        }
+      });
+      return reports as ReadonlyMap<string, RecordStatusReport>;
+    },
+    [claimingRecords]
+  );
+  return useQueries({
+    queries: claimingRecords.map(record => ({
+      queryKey: buildStatusReportKey({projectId, recordId: record.recordId}),
+      queryFn: () =>
+        computeRecordStatusReport({
+          engine: new DataEngine({
+            dataDb: dataDb as DatabaseInterface<DataDocument>,
+            uiSpec: uiSpecification,
+          }),
+          recordId: record.recordId,
+          projectId,
+          // Same per-field scoring as the form's progress bar
+          isCompleteResolver: fieldCompletionResolver,
+        }),
+      networkMode: 'always' as const,
+      // Freshness comes from the invalidation above
+      staleTime: Infinity,
+      enabled: enabled && dataDb !== undefined,
+    })),
+    combine: combineReports,
+  });
 }
 
 /**

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -348,6 +348,7 @@ Note that this validation is at a schema level, it might not catch improperly fo
   - `forceRemoteDeletion`: (Optional) `allow` or `never` — whether the mobile app removes local survey databases after sync when a survey is archived (must match app build). Passed to `VITE_FORCE_REMOTE_DELETION` for both `/app` and Control Centre web builds. Defaults to `never` when omitted.
   - `deleteOnDeactivation`: (Optional) When `true`, manual notebook deactivation wipes local Pouch data in the mobile app (`VITE_DELETE_ON_DEACTIVATION`). Defaults to `false` when omitted.
   - `excludedTeamRoles`: (Optional) Array of team role enum values to hide from Control Centre team-role dropdowns (e.g. `["TEAM_MEMBER_CREATOR"]`). Passed to the web build as `VITE_EXCLUDED_TEAM_ROLES`. Valid values: `TEAM_MEMBER`, `TEAM_MEMBER_CREATOR`, `TEAM_MANAGER`, `TEAM_ADMIN`. When omitted, all team roles are shown.
+  - `enablePlansInDesigner`: (Optional) When `true` (default), the designer can add a plan to templates that do not already have one. When `false`, Add Plan is hidden; templates that already have a plan can still be reconfigured. Passed to the web build as `VITE_ENABLE_PLANS_IN_DESIGNER`.
   - `offlineMaps`: Map and tile configuration for the app.
     - `mapSource`: Map tile provider: `osm` or `maptiler`
     - `mapSourceKey`: (Optional) API key for the map tile service (e.g. MapTiler)

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -34,7 +34,8 @@
     },
     "forceRemoteDeletion": "never",
     "deleteOnDeactivation": false,
-    "excludedTeamRoles": ["TEAM_MEMBER_CREATOR"]
+    "excludedTeamRoles": ["TEAM_MEMBER_CREATOR"],
+    "enablePlansInDesigner": true
   },
   "supportLinks": {
     "supportEmail": "support@your-domain.com",

--- a/infrastructure/aws-cdk/lib/components/front-end.ts
+++ b/infrastructure/aws-cdk/lib/components/front-end.ts
@@ -102,6 +102,13 @@ export interface FaimsFrontEndProps {
    * Team roles hidden from Control Centre team-role dropdowns (VITE_EXCLUDED_TEAM_ROLES).
    */
   excludedTeamRoles?: string[];
+
+  /**
+   * When true (default), the designer can add a plan to templates without one
+   * (VITE_ENABLE_PLANS_IN_DESIGNER). When false, only existing plans can be
+   * reconfigured.
+   */
+  enablePlansInDesigner?: boolean;
 }
 
 export class FaimsFrontEnd extends Construct {
@@ -464,6 +471,8 @@ export class FaimsFrontEnd extends Construct {
       ...(props.excludedTeamRoles?.length
         ? {VITE_EXCLUDED_TEAM_ROLES: props.excludedTeamRoles.join(',')}
         : {}),
+      VITE_ENABLE_PLANS_IN_DESIGNER:
+        props.enablePlansInDesigner === false ? 'false' : 'true',
       // Monitoring
       ...(props.bugsnagKey ? {VITE_BUGSNAG_API_KEY: props.bugsnagKey} : {}),
     };

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -567,6 +567,13 @@ export const UiConfiguration = z
         ])
       )
       .optional(),
+    /**
+     * When true (default), the designer can add a plan to templates that do
+     * not already have one. When false, Add Plan is hidden; templates that
+     * already have a plan can still be reconfigured. Passed to the web build
+     * as VITE_ENABLE_PLANS_IN_DESIGNER.
+     */
+    enablePlansInDesigner: z.boolean().default(true),
   })
   .refine(
     data => {

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -206,6 +206,7 @@ export class FaimsInfraStack extends cdk.Stack {
         config.uiConfiguration.forceRemoteDeletion ?? 'never',
       deleteOnDeactivation: config.uiConfiguration.deleteOnDeactivation,
       excludedTeamRoles: config.uiConfiguration.excludedTeamRoles,
+      enablePlansInDesigner: config.uiConfiguration.enablePlansInDesigner,
     });
 
     // Backup setup

--- a/infrastructure/aws-cdk/test/config.test.ts
+++ b/infrastructure/aws-cdk/test/config.test.ts
@@ -117,3 +117,17 @@ describe('UiConfiguration addressAutosuggest + MapTiler key validation', () => {
     expect(() => UiConfiguration.parse(config)).not.toThrow();
   });
 });
+
+describe('UiConfiguration enablePlansInDesigner', () => {
+  it('defaults to true when omitted', () => {
+    const parsed = UiConfiguration.parse(minimalUiConfig());
+    expect(parsed.enablePlansInDesigner).toBe(true);
+  });
+
+  it('accepts an explicit false', () => {
+    const parsed = UiConfiguration.parse(
+      minimalUiConfig({enablePlansInDesigner: false})
+    );
+    expect(parsed.enablePlansInDesigner).toBe(false);
+  });
+});

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -35,6 +35,7 @@ import {
 import {
   NotebookDefinitionSchema,
   NotebookUiSpecificationInputSchema,
+  TemplateDefinition,
 } from './uiSpecification';
 import {Resource, Role, roleDetails, RoleScope} from './permission/model';
 import {
@@ -311,6 +312,8 @@ export const CreateNotebookFromTemplateSchema = z.object({
   description: CreateRootDescriptionSchema,
   template_id: IdInputSchema,
   teamId: z.string().min(1).max(INPUT_LIMITS.ID_MAX_LENGTH).optional(),
+  /** Config for instantiating the template's plan template, if it has one. */
+  planConfig: z.record(z.string(), z.unknown()).optional(),
 });
 export type CreateNotebookFromTemplate = z.infer<
   typeof CreateNotebookFromTemplateSchema
@@ -545,10 +548,8 @@ export type PutChangeTemplateTeamInput = z.infer<
 /** PUT /api/templates/:id/uiSpecification — full replace of the design bundle (loose input; migrated server-side). */
 export const PutUpdateTemplateUiSpecificationInputSchema =
   NotebookUiSpecificationInputSchema;
-/** Normalized notebook definition after migrate + strict validation. */
-export type PutUpdateTemplateUiSpecificationInput = z.infer<
-  typeof NotebookDefinitionSchema
->;
+/** Normalized template definition after migrate + strict validation. */
+export type PutUpdateTemplateUiSpecificationInput = TemplateDefinition;
 export const PutUpdateTemplateResponseSchema = ExistingTemplateDocumentSchema;
 export type PutUpdateTemplateResponse = z.infer<
   typeof PutUpdateTemplateResponseSchema

--- a/library/data-model/src/data_storage/projectsDB/types.ts
+++ b/library/data-model/src/data_storage/projectsDB/types.ts
@@ -2,7 +2,10 @@ import {z} from 'zod';
 import {DatabaseInterface, PossibleConnectionInfo} from '../../types';
 import {PersistedRootDescriptionSchema} from '../rootMetadata';
 import {CouchDocumentSchema, CouchExistingDocumentSchema} from '../utils';
-import {NotebookDefinitionSchema} from '../../uiSpecification';
+import {
+  NotebookDefinitionSchema,
+  type NotebookDefinition,
+} from '../../uiSpecification';
 import {OfflineMapRegionSchema} from './offlineMapRegion';
 
 /** Couch connection descriptor for per-project data/metadata databases. */
@@ -127,7 +130,10 @@ export const ProjectV4FieldsSchema = z.object({
 
   // UI Specification (now stored in the project)
   // NOTE: This is never 'encoded' anymore - no more fviews etc.
-  uiSpecification: NotebookDefinitionSchema,
+  // Cast so .d.ts keeps ZodType<NotebookDefinition> instead of inlining the
+  // notebook object (that inlining re-exports RegisteredPlan via the package
+  // barrel and forms a declaration cycle).
+  uiSpecification: NotebookDefinitionSchema as z.ZodType<NotebookDefinition>,
 
   /** Optional bounding box for recommended offline map download on activation. */
   offlineMapRegion: OfflineMapRegionSchema.optional(),

--- a/library/data-model/src/data_storage/templatesDB/types.ts
+++ b/library/data-model/src/data_storage/templatesDB/types.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 import {DatabaseInterface} from '../../types';
 import {PersistedRootDescriptionSchema} from '../rootMetadata';
 import {CouchDocumentSchema, CouchExistingDocumentSchema} from '../utils';
-import {NotebookDefinitionSchema} from '../../uiSpecification/types';
+import {TemplateDefinitionSchema} from '../../uiSpecification/types';
 
 // =============
 // Legacy encoded UI spec (template v1–v4, metadata DB `ui-specification`)
@@ -126,9 +126,9 @@ export const TemplateV5FieldsSchema = z.object({
   // Template lifecycle
   archived: z.boolean().default(false),
 
-  // UI Specification (now stored in the project) NOTE: This is never 'encoded'
+  // UI Specification (now stored on the template) NOTE: This is never 'encoded'
   // anymore - no more fviews etc.
-  uiSpecification: NotebookDefinitionSchema,
+  uiSpecification: TemplateDefinitionSchema,
 });
 export type TemplateV5Fields = z.infer<typeof TemplateV5FieldsSchema>;
 

--- a/library/data-model/src/databaseEngine/engine.ts
+++ b/library/data-model/src/databaseEngine/engine.ts
@@ -1107,6 +1107,11 @@ class FormOperations {
       type: validated.formId,
     };
 
+    // Add the optional plan reference if provided
+    if (validated.planReference) {
+      recordDoc.planReference = validated.planReference;
+    }
+
     // Create the new record
     const rec = await this.core.createRecord(recordDoc);
 
@@ -2250,6 +2255,7 @@ class QueryOperations {
         deleted: revisionMeta.deleted ?? false,
         type: record.type,
         relationship: revisionMeta.relationship,
+        planReference: record.planReference,
       });
     }
 

--- a/library/data-model/src/databaseEngine/types.ts
+++ b/library/data-model/src/databaseEngine/types.ts
@@ -34,6 +34,10 @@ export const v1RecordDBFieldsSchema = z
     revisions: z.array(z.string()),
     heads: z.array(z.string()),
     type: z.string(),
+    // Optional plan reference for records created as part of a plan execution (e.g., List of Records)
+    // Might need to be an array if a record can be part of multiple plans in the future but for
+    // now we'll keep it simple and allow only one plan reference per record.
+    planReference: z.string().optional(),
   })
   .strict();
 
@@ -591,6 +595,8 @@ const baseFormRecordSchema = z.object({
   createdBy: z.string().max(INPUT_LIMITS.ID_MAX_LENGTH),
   /** Optional relationship information if this is a related/child record */
   relationship: formRelationshipSchema.optional(),
+  /** Optional plan reference for records created as part of a plan execution (e.g., List of Records) */
+  planReference: z.string().optional(),
 });
 
 /**
@@ -888,6 +894,7 @@ export interface MinimalRecordMetadata {
   deleted: boolean;
   type: string;
   relationship?: FormRelationship;
+  planReference?: string;
 }
 
 /**

--- a/library/data-model/src/index.ts
+++ b/library/data-model/src/index.ts
@@ -38,3 +38,4 @@ export * from './uiSpecification';
 export * from './databaseEngine';
 export {configHelpers} from './config';
 export type {ConfigHelpers} from './config';
+export * from './plans';

--- a/library/data-model/src/plans/builtins.ts
+++ b/library/data-model/src/plans/builtins.ts
@@ -1,0 +1,7 @@
+import {countedPlanDefinition} from './countedPlan';
+import {listOfRecordsPlanDefinition} from './listOfRecordsPlan';
+
+export const builtInPlanTypes = [
+  countedPlanDefinition,
+  listOfRecordsPlanDefinition,
+] as const;

--- a/library/data-model/src/plans/countedPlan.ts
+++ b/library/data-model/src/plans/countedPlan.ts
@@ -1,0 +1,74 @@
+import z from 'zod';
+import {
+  PlanSchema,
+  PlanTemplateSchema,
+  type AnyPlanTypeDefinition,
+} from './types';
+
+export const COUNTED_PLAN_TYPE = 'Counted' as const;
+
+// Counted plan asks for some number of a specific form
+// The template defines which form from the notebook is required,
+// and defines a configuration 'form' that will be filled in when the notebook
+// is instantiated.
+
+export const countedPlanTemplateConfigSchema = z.object({
+  numberRequired: z.number().int().positive(),
+  allowExtraRecords: z.boolean(),
+});
+export type CountedPlanTemplateConfig = z.infer<
+  typeof countedPlanTemplateConfigSchema
+>;
+
+export const countedPlanTemplateSchema = PlanTemplateSchema.extend({
+  planType: z.literal(COUNTED_PLAN_TYPE),
+  formType: z.string(),
+});
+export type CountedPlanTemplate = z.infer<typeof countedPlanTemplateSchema>;
+
+export const countedPlanSchema = PlanSchema.extend({
+  planType: z.literal(COUNTED_PLAN_TYPE),
+  formType: z.string(),
+  numberRequired: z.number().int().positive(),
+  allowExtraRecords: z.boolean(),
+});
+export type CountedPlan = z.infer<typeof countedPlanSchema>;
+
+/**
+ * Create a counted plan from a counted plan template.
+ *
+ * @param template A Counted Plan template
+ * @param config A Counted Plan configuration
+ */
+export const instantiateCountedPlan = ({
+  template,
+  config,
+}: {
+  template: CountedPlanTemplate;
+  config: CountedPlanTemplateConfig;
+}) => {
+  if (!countedPlanTemplateSchema.safeParse(template).success) {
+    throw new Error('Invalid counted plan template');
+  }
+  return {
+    planType: template.planType,
+    formType: template.formType,
+    numberRequired: config.numberRequired,
+    allowExtraRecords: config.allowExtraRecords,
+  } as CountedPlan;
+};
+
+export const countedPlanDefinition = {
+  label: COUNTED_PLAN_TYPE,
+  templateSchema: countedPlanTemplateSchema,
+  configSchema: countedPlanTemplateConfigSchema,
+  planSchema: countedPlanSchema,
+  instantiatePlan: instantiateCountedPlan,
+} satisfies AnyPlanTypeDefinition;
+
+// Register this plan type in the compile-time PlanTypeMap (additive; see planTypeMap.ts).
+declare module './planTypeMap' {
+  interface PlanTypeMap {
+    Counted: typeof countedPlanDefinition;
+  }
+}

--- a/library/data-model/src/plans/countedPlan.ts
+++ b/library/data-model/src/plans/countedPlan.ts
@@ -46,7 +46,7 @@ export const instantiateCountedPlan = ({
 }: {
   template: CountedPlanTemplate;
   config: CountedPlanTemplateConfig;
-}) => {
+}): CountedPlan => {
   if (!countedPlanTemplateSchema.safeParse(template).success) {
     throw new Error('Invalid counted plan template');
   }
@@ -55,7 +55,7 @@ export const instantiateCountedPlan = ({
     formType: template.formType,
     numberRequired: config.numberRequired,
     allowExtraRecords: config.allowExtraRecords,
-  } as CountedPlan;
+  };
 };
 
 export const countedPlanDefinition = {

--- a/library/data-model/src/plans/index.ts
+++ b/library/data-model/src/plans/index.ts
@@ -1,0 +1,6 @@
+export * from './registry';
+export * from './types';
+export * from './builtins';
+export * from './countedPlan';
+export * from './listOfRecordsPlan';
+export * from './planTypeMap';

--- a/library/data-model/src/plans/listOfRecordsPlan.ts
+++ b/library/data-model/src/plans/listOfRecordsPlan.ts
@@ -1,0 +1,86 @@
+import z from 'zod';
+import {
+  PlanSchema,
+  PlanTemplateSchema,
+  type AnyPlanTypeDefinition,
+} from './types';
+
+export const LIST_OF_RECORDS_PLAN_TYPE = 'ListOfRecords' as const;
+
+// A list of records plan defines a set of records that should be
+// collected with a few properties of each record included in the plan.
+export const listPlanTemplateConfigSchema = z.object({
+  recordData: z.record(z.string(), z.record(z.string(), z.unknown())), // the data for each record, keyed by a unique plan reference id
+  allowExtraRecords: z.boolean(),
+});
+export type ListPlanTemplateConfig = z.infer<
+  typeof listPlanTemplateConfigSchema
+>;
+
+export const listPlanTemplateSchema = PlanTemplateSchema.extend({
+  planType: z.literal(LIST_OF_RECORDS_PLAN_TYPE),
+  formType: z.string(),
+  recordFields: z.array(z.string()), // a subset of the fields in the form
+});
+export type ListPlanTemplate = z.infer<typeof listPlanTemplateSchema>;
+
+export const listPlanSchema = PlanSchema.extend({
+  planType: z.literal(LIST_OF_RECORDS_PLAN_TYPE),
+  formType: z.string(),
+  // records is a map from a unique plan reference id to the initial data for that record
+  records: z.record(z.string(), z.record(z.string(), z.unknown())),
+  allowExtraRecords: z.boolean(),
+});
+export type ListPlan = z.infer<typeof listPlanSchema>;
+
+/**
+ * Create a list plan from a list plan template.
+ *
+ * @param template A list Plan template
+ */
+export const instantiateListPlan = ({
+  template,
+  config,
+}: {
+  template: ListPlanTemplate;
+  config: ListPlanTemplateConfig;
+}) => {
+  // do a local check of the template validity before we try to validate the plan
+  if (!listPlanTemplateSchema.safeParse(template).success) {
+    throw new Error('Invalid list of records plan template');
+  }
+  // Filter the records to only include the fields specified in the plan
+  const records = config.recordData;
+  Object.keys(records).forEach(recordId => {
+    const record = records[recordId];
+    const filteredRecord: Record<string, unknown> = {};
+    for (const field of template.recordFields) {
+      if (field in record) {
+        filteredRecord[field] = record[field];
+      }
+    }
+    records[recordId] = filteredRecord;
+  });
+
+  return {
+    planType: LIST_OF_RECORDS_PLAN_TYPE,
+    formType: template.formType,
+    records: records,
+    allowExtraRecords: config.allowExtraRecords,
+  } as ListPlan;
+};
+
+export const listOfRecordsPlanDefinition = {
+  label: LIST_OF_RECORDS_PLAN_TYPE,
+  templateSchema: listPlanTemplateSchema,
+  configSchema: listPlanTemplateConfigSchema,
+  planSchema: listPlanSchema,
+  instantiatePlan: instantiateListPlan,
+} satisfies AnyPlanTypeDefinition;
+
+// Register this plan type in the compile-time PlanTypeMap (additive; see planTypeMap.ts).
+declare module './planTypeMap' {
+  interface PlanTypeMap {
+    ListOfRecords: typeof listOfRecordsPlanDefinition;
+  }
+}

--- a/library/data-model/src/plans/listOfRecordsPlan.ts
+++ b/library/data-model/src/plans/listOfRecordsPlan.ts
@@ -44,7 +44,7 @@ export const instantiateListPlan = ({
 }: {
   template: ListPlanTemplate;
   config: ListPlanTemplateConfig;
-}) => {
+}): ListPlan => {
   // do a local check of the template validity before we try to validate the plan
   if (!listPlanTemplateSchema.safeParse(template).success) {
     throw new Error('Invalid list of records plan template');
@@ -68,7 +68,7 @@ export const instantiateListPlan = ({
     formType: template.formType,
     records: records,
     allowExtraRecords: config.allowExtraRecords,
-  } as ListPlan;
+  };
 };
 
 export const listOfRecordsPlanDefinition = {

--- a/library/data-model/src/plans/listOfRecordsPlan.ts
+++ b/library/data-model/src/plans/listOfRecordsPlan.ts
@@ -49,10 +49,11 @@ export const instantiateListPlan = ({
   if (!listPlanTemplateSchema.safeParse(template).success) {
     throw new Error('Invalid list of records plan template');
   }
-  // Filter the records to only include the fields specified in the plan
-  const records = config.recordData;
-  Object.keys(records).forEach(recordId => {
-    const record = records[recordId];
+  // Filter the records to only include the fields specified in the plan.
+  // Built into a new map: writing back into config.recordData would strip the
+  // unselected fields from the caller's own object.
+  const records: Record<string, Record<string, unknown>> = {};
+  for (const [recordId, record] of Object.entries(config.recordData)) {
     const filteredRecord: Record<string, unknown> = {};
     for (const field of template.recordFields) {
       if (field in record) {
@@ -60,7 +61,7 @@ export const instantiateListPlan = ({
       }
     }
     records[recordId] = filteredRecord;
-  });
+  }
 
   return {
     planType: LIST_OF_RECORDS_PLAN_TYPE,

--- a/library/data-model/src/plans/planTypeMap.ts
+++ b/library/data-model/src/plans/planTypeMap.ts
@@ -1,0 +1,72 @@
+import type z from 'zod';
+import {PlanSchema, type PlanRegistry} from './types';
+import {getPlanTypeDefinition} from './registry';
+
+/**
+ * Open, compile-time map from a plan's `planType` to its registered definition.
+ * Each plan module augments this with a one-line `declare module` (see the
+ * bottom of countedPlan.ts / listOfRecordsPlan.ts).
+ *
+ * It holds NO runtime data. It is purely the *typed view* of the string-keyed
+ * runtime {@link PlanRegistry}, and it is what lets consumers get (a) a typed
+ * lookup and (b) a narrowable stored plan. Types are erased at runtime, so this
+ * cannot populate the registry and the registry cannot produce these types; each
+ * plan therefore pairs its `declare module` here with its ordinary registration.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PlanTypeMap {}
+
+/**
+ * Drop a `{ [key: string]: unknown }` catch-all index signature, keeping only
+ * explicitly-named keys. The plan schemas are `.passthrough()` (kept at runtime
+ * for forward-compat), which otherwise leaks that catch-all into the inferred
+ * type and makes a wrong-plan field read as `unknown` instead of erroring.
+ */
+type RemoveIndexSignature<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+      ? never
+      : K]: T[K];
+};
+
+/**
+ * The plan-instance type for one registered plan type (its `planSchema`'s
+ * output), with the passthrough catch-all stripped so only the plan's own fields
+ * are visible. Runtime parsing still keeps unknown fields on the object.
+ */
+export type PlanOf<K extends keyof PlanTypeMap> = PlanTypeMap[K] extends {
+  planSchema: infer S;
+}
+  ? S extends z.ZodTypeAny
+    ? RemoveIndexSignature<z.infer<S>>
+    : never
+  : never;
+
+/**
+ * Discriminated union of every registered plan instance. Type a stored plan as
+ * this so `plan.planType === 'Counted'` narrows to that plan's own fields.
+ */
+export type RegisteredPlan = {
+  [K in keyof PlanTypeMap]: PlanOf<K>;
+}[keyof PlanTypeMap];
+
+/**
+ * Typed lookup: `getPlanDefinition('Counted')` returns the Counted definition
+ * rather than the erased `AnyPlanTypeDefinition`. Thin typed wrapper over the
+ * runtime {@link getPlanTypeDefinition} (same behaviour, precise return type).
+ */
+export const getPlanDefinition = <K extends keyof PlanTypeMap>(
+  planType: K,
+  registry?: PlanRegistry
+): PlanTypeMap[K] | undefined =>
+  getPlanTypeDefinition(planType, registry) as PlanTypeMap[K] | undefined;
+
+/**
+ * {@link PlanSchema} retyped so `z.infer` yields {@link RegisteredPlan}, without
+ * changing its runtime behaviour (still the passthrough base parse). Use it for a
+ * notebook's stored `plan` field so the parsed value narrows by `planType`; the
+ * plan's own fields are still runtime-validated by `safeValidatePlan`.
+ */
+export const RegisteredPlanSchema =
+  PlanSchema as unknown as z.ZodType<RegisteredPlan>;

--- a/library/data-model/src/plans/registry.ts
+++ b/library/data-model/src/plans/registry.ts
@@ -3,6 +3,7 @@ import {
   AnyPlanTypeDefinition,
   Plan,
   PlanRegistry,
+  PlanTemplate,
   PlanSchema,
   PlanTemplateSchema,
   PlanTemplateSchemaWithLiteral,
@@ -126,7 +127,7 @@ export const safeValidatePlan = (
 export const safeValidatePlanTemplate = (
   input: unknown,
   registry: PlanRegistry = defaultPlanRegistry
-): ValidationResult<Plan> => {
+): ValidationResult<PlanTemplate> => {
   if (registry === defaultPlanRegistry) {
     installBuiltInPlanTypes();
   }

--- a/library/data-model/src/plans/registry.ts
+++ b/library/data-model/src/plans/registry.ts
@@ -1,0 +1,148 @@
+import z from 'zod';
+import {
+  AnyPlanTypeDefinition,
+  Plan,
+  PlanRegistry,
+  PlanSchema,
+  PlanTemplateSchema,
+  PlanTemplateSchemaWithLiteral,
+  PlanTypeDefinition,
+  ValidationResult,
+} from './types';
+import {builtInPlanTypes} from './builtins';
+
+// Plan registry is a map from planType to plan type definition.
+export const createPlanRegistry = (): PlanRegistry => new Map();
+
+// Default registry will be used at runtime but we allow for other
+// registries for testing
+const defaultPlanRegistry = createPlanRegistry();
+// Built in plan types are not registered at compile time, only when
+// we first need to validate a plan, this allows for easier testing
+let builtInsInstalled = false;
+
+// Get the plan type from a plan template schema leveraging the zod schema
+export const getPlanTypeFromTemplateSchema = <
+  P extends string,
+  TTemplateSchema extends PlanTemplateSchemaWithLiteral<P>,
+>(
+  templateSchema: TTemplateSchema
+): P => {
+  return templateSchema.shape.planType.value as P;
+};
+
+// use the plan registry to retrieve the plan definition for a given plan type
+export const getPlanTypeDefinition = (
+  planType: string,
+  registry: PlanRegistry = defaultPlanRegistry
+): AnyPlanTypeDefinition | undefined => {
+  // install built in plan types if we are using the default registry
+  if (registry === defaultPlanRegistry) {
+    installBuiltInPlanTypes();
+  }
+
+  return registry.get(planType);
+};
+
+// Register a plan type definition with a plan registry, by default with
+// the defaultPlanRegistry. The planType from the plan template schema is used
+// as the key in the registry.
+export const registerPlanType = <
+  P extends string,
+  TTemplateSchema extends PlanTemplateSchemaWithLiteral<P>,
+  TConfigSchema extends z.ZodTypeAny,
+  TPlanSchema extends z.ZodType<{planType: P} & Record<string, unknown>>,
+>(
+  definition: PlanTypeDefinition<
+    P,
+    TTemplateSchema,
+    TConfigSchema,
+    TPlanSchema
+  >,
+  registry: PlanRegistry = defaultPlanRegistry
+) => {
+  const planType = getPlanTypeFromTemplateSchema(definition.templateSchema);
+
+  if (registry.has(planType)) {
+    throw new Error(`Plan type ${planType} is already registered`);
+  }
+
+  registry.set(planType, definition as unknown as AnyPlanTypeDefinition);
+};
+
+export const registerPlanTypes = (
+  definitions: readonly AnyPlanTypeDefinition[],
+  registry: PlanRegistry = defaultPlanRegistry
+) => {
+  for (const definition of definitions) {
+    registerPlanType(definition, registry);
+  }
+};
+
+// Here we install the built in plan types into the default registry.
+// Doing this lazily allows for easier testing of plan types in isolation.
+export const installBuiltInPlanTypes = (
+  registry: PlanRegistry = defaultPlanRegistry
+) => {
+  if (registry === defaultPlanRegistry && builtInsInstalled) {
+    return;
+  }
+
+  registerPlanTypes(builtInPlanTypes, registry);
+
+  if (registry === defaultPlanRegistry) {
+    builtInsInstalled = true;
+  }
+};
+
+// Validate an object (probably from JSON) as a plan based on the claimed planType using the
+// plan registry. If the plan type is unknown, returns an error.
+export const safeValidatePlan = (
+  input: unknown,
+  registry: PlanRegistry = defaultPlanRegistry
+): ValidationResult<Plan> => {
+  if (registry === defaultPlanRegistry) {
+    installBuiltInPlanTypes();
+  }
+
+  const baseResult = PlanSchema.safeParse(input);
+  if (!baseResult.success) {
+    return baseResult;
+  }
+
+  const definition = registry.get(baseResult.data.planType);
+  if (!definition) {
+    return {
+      success: false,
+      error: new Error(`Unknown plan type: ${baseResult.data.planType}`),
+    };
+  }
+
+  return definition.planSchema.safeParse(input);
+};
+
+// Validate an object (probably from JSON) as a plan template based on
+// the claimed planType using the plan registry. If the plan type is unknown, returns an error.
+export const safeValidatePlanTemplate = (
+  input: unknown,
+  registry: PlanRegistry = defaultPlanRegistry
+): ValidationResult<Plan> => {
+  if (registry === defaultPlanRegistry) {
+    installBuiltInPlanTypes();
+  }
+
+  const baseResult = PlanTemplateSchema.safeParse(input);
+  if (!baseResult.success) {
+    return baseResult;
+  }
+
+  const definition = registry.get(baseResult.data.planType);
+  if (!definition) {
+    return {
+      success: false,
+      error: new Error(`Unknown plan type: ${baseResult.data.planType}`),
+    };
+  }
+
+  return definition.templateSchema.safeParse(input);
+};

--- a/library/data-model/src/plans/types.ts
+++ b/library/data-model/src/plans/types.ts
@@ -1,0 +1,74 @@
+import z from 'zod';
+
+// Base schema for plan and plan template. These use passthrough to allow
+// for extra fields and will be used to parse JSON payloads with plans
+// or plan templates
+
+// A plan template is an optional part of a Notebook Template and will
+// be used to instantiate a plan when a notebook is created from the template.
+export const PlanTemplateSchema = z
+  .object({
+    planType: z.string(),
+  })
+  .passthrough();
+export type PlanTemplate = z.infer<typeof PlanTemplateSchema>;
+
+// A plan is an optional part of a Notebook Definition and can be used
+// to guide the data collection workflow.  The plan is instantiated
+// from the plan template when a notebook is created from a template.
+export const PlanSchema = z
+  .object({
+    planType: z.string(),
+  })
+  .passthrough();
+export type Plan = z.infer<typeof PlanSchema>;
+
+// A plan template schema with a literal planType property.
+// This will be used mainly in the registry since we use planType as
+// the registry key and we want to ensure that the planType property
+// of the plan template matches the registry key.
+export type PlanTemplateSchemaWithLiteral<P extends string = string> =
+  z.ZodObject<
+    {planType: z.ZodLiteral<P>} & z.ZodRawShape,
+    z.core.$ZodObjectConfig
+  >;
+
+export type PlanTypeFromTemplateSchema<
+  TTemplateSchema extends PlanTemplateSchemaWithLiteral,
+> =
+  TTemplateSchema['shape']['planType'] extends z.ZodLiteral<
+    infer P extends string
+  >
+    ? P
+    : string;
+
+// A plan type definition is used to register a
+// plan type with the plan registry.
+// planType of the plan template and plan schemas must be the same
+// and we'll ensure that the plan is stored under this key in the registry
+export type PlanTypeDefinition<
+  P extends string,
+  TTemplateSchema extends PlanTemplateSchemaWithLiteral<P>,
+  TConfigSchema extends z.ZodTypeAny,
+  TPlanSchema extends z.ZodType<{planType: P} & Record<string, unknown>>,
+> = {
+  label: string; // display name for this plan type
+  templateSchema: TTemplateSchema;
+  configSchema: TConfigSchema;
+  planSchema: TPlanSchema;
+  instantiatePlan: ({
+    template,
+    config,
+  }: {
+    template: z.infer<TTemplateSchema>;
+    config: z.infer<TConfigSchema>;
+  }) => z.infer<TPlanSchema>;
+};
+
+export type AnyPlanTypeDefinition = PlanTypeDefinition<any, any, any, any>;
+
+export type PlanRegistry = Map<string, AnyPlanTypeDefinition>;
+
+export type ValidationResult<T> =
+  | {success: true; data: T}
+  | {success: false; error: z.ZodError | Error};

--- a/library/data-model/src/uiSpecification/normalize.ts
+++ b/library/data-model/src/uiSpecification/normalize.ts
@@ -80,95 +80,96 @@ function assertLatestSchemaVersion(notebook: NotebookDefinition): void {
 }
 
 /**
- * Accept a legacy or current notebook template JSON bundle. When the reported schema version
- * is missing or below {@link CURRENT_NOTEBOOK_UI_SCHEMA_VERSION}, runs
- * {@link migrateNotebook}, then validates with {@link TemplateDefinitionSchema}.
+ * Shared migrate + strict validate pass for a notebook or template JSON bundle.
+ * Both kinds carry the same uiSpec, so they share the size cap, the migration
+ * and the post-migration version assertion, and differ only in the schema they
+ * validate against and the wording of their errors.
  */
-export function normalizeNotebookTemplateUiSpecification(
-  raw: unknown
-): TemplateDefinition {
+function normalizeUiSpecificationBundle<
+  T extends {uiSpec: {schemaVersion?: unknown}},
+>({
+  raw,
+  schema,
+  label,
+}: {
+  raw: unknown;
+  schema: z.ZodType<T>;
+  /** Names the bundle kind in every error message. */
+  label: string;
+}): T {
   if (!isPlainObject(raw)) {
-    throw new Error('template uiSpecification must be a JSON object');
+    throw new Error(`${label} must be a JSON object`);
+  }
+
+  if (estimateJsonBytes(raw) > UI_SPEC_MAX_BYTES) {
+    throw new Error(
+      `${label} is too large (maximum ${Math.floor(UI_SPEC_MAX_BYTES / (1024 * 1024))} MB)`
+    );
   }
 
   let candidate: unknown = raw;
 
-  // this works for templates as well as notebooks since it's checking the uiSpec
   if (notebookUiSpecificationNeedsMigration(raw)) {
     try {
       candidate = migrateNotebook(raw).migrated;
     } catch (cause) {
       const detail =
         cause instanceof Error ? cause.message : 'unknown migration error';
-      throw new Error(`template uiSpecification migration failed: ${detail}`);
+      throw new Error(`${label} migration failed: ${detail}`);
     }
   }
 
-  const parsed = TemplateDefinitionSchema.safeParse(candidate);
+  const parsed = schema.safeParse(candidate);
   if (!parsed.success) {
-    throw new Error(
-      `Invalid template uiSpecification: ${formatZodIssues(parsed.error)}`
-    );
+    throw new Error(`Invalid ${label}: ${formatZodIssues(parsed.error)}`);
   }
 
-  // Validate the planTemplate against its own plan type's schema, if present
-  if (
-    parsed.data.planTemplate &&
-    !safeValidatePlanTemplate(parsed.data.planTemplate).success
-  ) {
-    throw new Error('Invalid plan template in template uiSpecification');
-  }
-
-  assertLatestSchemaVersion(parsed.data);
+  assertLatestSchemaVersion(parsed.data as unknown as NotebookDefinition);
 
   return parsed.data;
 }
 
 /**
- * Accept a legacy or current notebook JSON bundle. When the reported schema version
- * is missing or below {@link CURRENT_NOTEBOOK_UI_SCHEMA_VERSION}, runs
- * {@link migrateNotebook}, then validates with {@link NotebookDefinitionSchema}.
+ * Accept a legacy or current notebook template JSON bundle, then validate its
+ * plan template, if any, against that plan type's own schema.
+ */
+export function normalizeNotebookTemplateUiSpecification(
+  raw: unknown
+): TemplateDefinition {
+  const definition = normalizeUiSpecificationBundle({
+    raw,
+    schema: TemplateDefinitionSchema,
+    label: 'template uiSpecification',
+  });
+
+  if (
+    definition.planTemplate &&
+    !safeValidatePlanTemplate(definition.planTemplate).success
+  ) {
+    throw new Error('Invalid plan template in template uiSpecification');
+  }
+
+  return definition;
+}
+
+/**
+ * Accept a legacy or current notebook JSON bundle, then validate its plan, if
+ * any, against that plan type's own schema.
  */
 export function normalizeNotebookUiSpecification(
   raw: unknown
 ): NotebookDefinition {
-  if (!isPlainObject(raw)) {
-    throw new Error('uiSpecification must be a JSON object');
-  }
+  const definition = normalizeUiSpecificationBundle({
+    raw,
+    schema: NotebookDefinitionSchema,
+    label: 'uiSpecification',
+  });
 
-  if (estimateJsonBytes(raw) > UI_SPEC_MAX_BYTES) {
-    throw new Error(
-      `uiSpecification is too large (maximum ${Math.floor(UI_SPEC_MAX_BYTES / (1024 * 1024))} MB)`
-    );
-  }
-
-  let candidate: unknown = raw;
-
-  if (notebookUiSpecificationNeedsMigration(raw)) {
-    try {
-      candidate = migrateNotebook(raw).migrated;
-    } catch (cause) {
-      const detail =
-        cause instanceof Error ? cause.message : 'unknown migration error';
-      throw new Error(`uiSpecification migration failed: ${detail}`);
-    }
-  }
-
-  const parsed = NotebookDefinitionSchema.safeParse(candidate);
-  if (!parsed.success) {
-    throw new Error(
-      `Invalid uiSpecification: ${formatZodIssues(parsed.error)}`
-    );
-  }
-
-  assertLatestSchemaVersion(parsed.data);
-
-  // Validate the plan against its own plan type's schema, if present
-  if (parsed.data.plan && !safeValidatePlan(parsed.data.plan).success) {
+  if (definition.plan && !safeValidatePlan(definition.plan).success) {
     throw new Error('Invalid plan in uiSpecification');
   }
 
-  return parsed.data;
+  return definition;
 }
 
 export type PrepareNotebookUiSpecificationInputResult =

--- a/library/data-model/src/uiSpecification/normalize.ts
+++ b/library/data-model/src/uiSpecification/normalize.ts
@@ -8,8 +8,11 @@ import {
 import {
   NotebookDefinitionSchema,
   NotebookDefinitionUploadSchema,
+  TemplateDefinition,
+  TemplateDefinitionSchema,
   type NotebookDefinition,
 } from './types';
+import {safeValidatePlan, safeValidatePlanTemplate} from '../plans';
 
 export {CURRENT_NOTEBOOK_UI_SCHEMA_VERSION};
 
@@ -77,6 +80,51 @@ function assertLatestSchemaVersion(notebook: NotebookDefinition): void {
 }
 
 /**
+ * Accept a legacy or current notebook template JSON bundle. When the reported schema version
+ * is missing or below {@link CURRENT_NOTEBOOK_UI_SCHEMA_VERSION}, runs
+ * {@link migrateNotebook}, then validates with {@link TemplateDefinitionSchema}.
+ */
+export function normalizeNotebookTemplateUiSpecification(
+  raw: unknown
+): TemplateDefinition {
+  if (!isPlainObject(raw)) {
+    throw new Error('template uiSpecification must be a JSON object');
+  }
+
+  let candidate: unknown = raw;
+
+  // this works for templates as well as notebooks since it's checking the uiSpec
+  if (notebookUiSpecificationNeedsMigration(raw)) {
+    try {
+      candidate = migrateNotebook(raw).migrated;
+    } catch (cause) {
+      const detail =
+        cause instanceof Error ? cause.message : 'unknown migration error';
+      throw new Error(`template uiSpecification migration failed: ${detail}`);
+    }
+  }
+
+  const parsed = TemplateDefinitionSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid template uiSpecification: ${formatZodIssues(parsed.error)}`
+    );
+  }
+
+  // Validate the planTemplate against its own plan type's schema, if present
+  if (
+    parsed.data.planTemplate &&
+    !safeValidatePlanTemplate(parsed.data.planTemplate).success
+  ) {
+    throw new Error('Invalid plan template in template uiSpecification');
+  }
+
+  assertLatestSchemaVersion(parsed.data);
+
+  return parsed.data;
+}
+
+/**
  * Accept a legacy or current notebook JSON bundle. When the reported schema version
  * is missing or below {@link CURRENT_NOTEBOOK_UI_SCHEMA_VERSION}, runs
  * {@link migrateNotebook}, then validates with {@link NotebookDefinitionSchema}.
@@ -114,6 +162,11 @@ export function normalizeNotebookUiSpecification(
   }
 
   assertLatestSchemaVersion(parsed.data);
+
+  // Validate the plan against its own plan type's schema, if present
+  if (parsed.data.plan && !safeValidatePlan(parsed.data.plan).success) {
+    throw new Error('Invalid plan in uiSpecification');
+  }
 
   return parsed.data;
 }

--- a/library/data-model/src/uiSpecification/types.ts
+++ b/library/data-model/src/uiSpecification/types.ts
@@ -1,4 +1,8 @@
 import {z} from 'zod';
+import {PlanTemplateSchema} from '../plans/types';
+// Barrel import (not '../plans/planTypeMap') so the per-plan PlanTypeMap
+// augmentations are in scope here, making the stored `plan` a narrowable union.
+import {RegisteredPlanSchema} from '../plans';
 import {ExprValue} from './expressions';
 
 // ============================================================================
@@ -349,9 +353,31 @@ export type CompiledNotebookUiSpec = z.infer<
   typeof CompiledNotebookUiSpecSchema
 >;
 
+/*
+ * A template is a notebook definition that will be used to instantiate many notebooks.
+ * It has the same uiSpec and metadata as a notebook but includes an optional plan template
+ * that will be used to instantiate a plan when a notebook is created from the template.
+ */
+export const TemplateDefinitionSchema = z.object({
+  uiSpec: NotebookUiSpecSchema,
+  metadata: NotebookMetadataSchema,
+  planTemplate: PlanTemplateSchema.optional(),
+});
+export type TemplateDefinition = z.infer<typeof TemplateDefinitionSchema>;
+
+/*
+ * Notebook definition is what is stored in the DB and downloaded/uploaded as JSON.
+ *
+ * Todo: the plan is attached to both templates and notebooks since they currently share the
+ * same type but our intention is that templates will have a plan 'schema' while the notebook
+ * has the actual plan. This means we probably want to split the NotebookDefinition type in two
+ * at some point. Until we work out how to do this we can use the plan slot in the template for
+ * the schema.
+ */
 export const NotebookDefinitionSchema = z.object({
   uiSpec: NotebookUiSpecSchema,
   metadata: NotebookMetadataSchema,
+  plan: RegisteredPlanSchema.optional(),
 });
 export type NotebookDefinition = z.infer<typeof NotebookDefinitionSchema>;
 
@@ -362,6 +388,7 @@ export type NotebookDefinition = z.infer<typeof NotebookDefinitionSchema>;
 export const CompiledNotebookDefinitionSchema = z.object({
   uiSpec: CompiledNotebookUiSpecSchema,
   metadata: NotebookMetadataSchema,
+  plan: RegisteredPlanSchema.optional(),
 });
 export type CompiledNotebookDefinition = z.infer<
   typeof CompiledNotebookDefinitionSchema

--- a/library/data-model/tests/engine.form.test.ts
+++ b/library/data-model/tests/engine.form.test.ts
@@ -246,6 +246,29 @@ describe('Form Operations', () => {
       expect(firstAvp.faims_attachments?.[0].filename).toBe('initial.txt');
       expect(firstAvp.faims_attachments?.[0].file_type).toBe('text/plain');
     });
+
+    test('should create record with planReference', async () => {
+      const formRecord: NewFormRecord = {
+        formId: 'A',
+        createdBy: 'test-user',
+        planReference: 'plan-123',
+      };
+
+      const result = await engine.form.createRecord(formRecord);
+
+      expect(result.record.planReference).toBe('plan-123');
+    });
+
+    test('should not include planReference if not provided', async () => {
+      const formRecord: NewFormRecord = {
+        formId: 'A',
+        createdBy: 'test-user',
+      };
+
+      const result = await engine.form.createRecord(formRecord);
+
+      expect(result.record.planReference).toBeUndefined();
+    });
   });
 
   describe('createRevision', () => {

--- a/library/data-model/tests/plans.countedPlan.test.ts
+++ b/library/data-model/tests/plans.countedPlan.test.ts
@@ -1,0 +1,58 @@
+import {z} from 'zod';
+import {
+  COUNTED_PLAN_TYPE,
+  countedPlanDefinition,
+  countedPlanTemplateConfigSchema,
+  countedPlanTemplateSchema,
+  instantiateCountedPlan,
+} from '../src/plans/countedPlan';
+
+describe('counted plan definition', () => {
+  test('uses the counted discriminator in its template schema and definition', () => {
+    expect(countedPlanTemplateSchema.shape.planType.value).toBe(
+      COUNTED_PLAN_TYPE
+    );
+    expect(countedPlanDefinition.label).toBe(COUNTED_PLAN_TYPE);
+  });
+
+  test('config schema accepts valid configuration', () => {
+    const result = countedPlanTemplateConfigSchema.safeParse({
+      numberRequired: 2,
+      allowExtraRecords: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('config schema rejects invalid configuration', () => {
+    const result = countedPlanTemplateConfigSchema.safeParse({
+      numberRequired: 0,
+      allowExtraRecords: 'yes',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(z.ZodError);
+    }
+  });
+
+  test('instantiateCountedPlan combines template and config into a counted plan', () => {
+    const plan = instantiateCountedPlan({
+      template: {
+        planType: COUNTED_PLAN_TYPE,
+        formType: 'artefact-form',
+      },
+      config: {
+        numberRequired: 5,
+        allowExtraRecords: true,
+      },
+    });
+
+    expect(plan).toEqual({
+      planType: COUNTED_PLAN_TYPE,
+      formType: 'artefact-form',
+      numberRequired: 5,
+      allowExtraRecords: true,
+    });
+  });
+});

--- a/library/data-model/tests/plans.listOfRecordsPlan.test.ts
+++ b/library/data-model/tests/plans.listOfRecordsPlan.test.ts
@@ -1,0 +1,59 @@
+import {
+  LIST_OF_RECORDS_PLAN_TYPE,
+  instantiateListPlan,
+  listOfRecordsPlanDefinition,
+  listPlanTemplateConfigSchema,
+  listPlanTemplateSchema,
+} from '../src/plans/listOfRecordsPlan';
+
+describe('list of records plan definition', () => {
+  test('uses the list-of-records discriminator in its template schema and definition', () => {
+    expect(listPlanTemplateSchema.shape.planType.value).toBe(
+      LIST_OF_RECORDS_PLAN_TYPE
+    );
+    expect(listOfRecordsPlanDefinition.label).toBe(LIST_OF_RECORDS_PLAN_TYPE);
+  });
+
+  test('config schema accepts record data maps', () => {
+    const result = listPlanTemplateConfigSchema.safeParse({
+      recordData: {Record1: {Name: 'Record 1'}},
+      allowExtraRecords: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('instantiateListPlan keeps only requested record fields', () => {
+    const plan = instantiateListPlan({
+      template: {
+        planType: LIST_OF_RECORDS_PLAN_TYPE,
+        formType: 'survey-form',
+        recordFields: ['Name', 'Location'],
+      },
+      config: {
+        recordData: {
+          Record1: {
+            Name: 'Record 1',
+            Location: 'Trench A',
+            Notes: 'Ignored',
+          },
+          Record2: {
+            Name: 'Record 2',
+            Other: 'Skipped field',
+          },
+        },
+        allowExtraRecords: true,
+      },
+    });
+
+    expect(plan).toEqual({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType: 'survey-form',
+      records: {
+        Record1: {Name: 'Record 1', Location: 'Trench A'},
+        Record2: {Name: 'Record 2'},
+      },
+      allowExtraRecords: true,
+    });
+  });
+});

--- a/library/data-model/tests/plans.registry.test.ts
+++ b/library/data-model/tests/plans.registry.test.ts
@@ -1,0 +1,172 @@
+import z from 'zod';
+import {
+  createPlanRegistry,
+  getPlanTypeDefinition,
+  getPlanTypeFromTemplateSchema,
+  installBuiltInPlanTypes,
+  registerPlanType,
+  registerPlanTypes,
+  safeValidatePlan,
+} from '../src/plans/registry';
+import type {PlanTypeDefinition} from '../src/plans/types';
+
+const TEST_PLAN_TYPE = 'TestPlan' as const;
+
+const testTemplateSchema = z
+  .object({
+    planType: z.literal(TEST_PLAN_TYPE),
+    formType: z.string(),
+  })
+  .passthrough();
+
+const testConfigSchema = z.object({
+  requiredCount: z.number().int().positive(),
+});
+
+const testPlanSchema = z
+  .object({
+    planType: z.literal(TEST_PLAN_TYPE),
+    formType: z.string(),
+    requiredCount: z.number().int().positive(),
+  })
+  .passthrough();
+
+const testPlanDefinition: PlanTypeDefinition<
+  typeof TEST_PLAN_TYPE,
+  typeof testTemplateSchema,
+  typeof testConfigSchema,
+  typeof testPlanSchema
+> = {
+  label: 'Test plan',
+  templateSchema: testTemplateSchema,
+  configSchema: testConfigSchema,
+  planSchema: testPlanSchema,
+  instantiatePlan: ({template, config}) => ({
+    planType: template.planType,
+    formType: template.formType,
+    requiredCount: config.requiredCount,
+  }),
+};
+
+describe('plan registry', () => {
+  test('createPlanRegistry returns an empty registry', () => {
+    const registry = createPlanRegistry();
+
+    expect(registry.size).toBe(0);
+  });
+
+  test('getPlanTypeFromTemplateSchema extracts the literal plan type', () => {
+    expect(getPlanTypeFromTemplateSchema(testTemplateSchema)).toBe(
+      TEST_PLAN_TYPE
+    );
+  });
+
+  test('registerPlanType stores a definition under its template discriminator', () => {
+    const registry = createPlanRegistry();
+
+    registerPlanType(testPlanDefinition, registry);
+
+    expect(getPlanTypeDefinition(TEST_PLAN_TYPE, registry)).toBe(
+      testPlanDefinition
+    );
+  });
+
+  test('registerPlanType rejects duplicate registration in the same registry', () => {
+    const registry = createPlanRegistry();
+
+    registerPlanType(testPlanDefinition, registry);
+
+    expect(() => registerPlanType(testPlanDefinition, registry)).toThrow(
+      `Plan type ${TEST_PLAN_TYPE} is already registered`
+    );
+  });
+
+  test('registerPlanTypes registers multiple definitions into a custom registry', () => {
+    const registry = createPlanRegistry();
+    const otherPlanType = 'OtherPlan' as const;
+    const otherTemplateSchema = z
+      .object({
+        planType: z.literal(otherPlanType),
+      })
+      .passthrough();
+    const otherPlanDefinition: PlanTypeDefinition<
+      typeof otherPlanType,
+      typeof otherTemplateSchema,
+      typeof testConfigSchema,
+      typeof testPlanSchema
+    > = {
+      label: 'Other plan',
+      templateSchema: otherTemplateSchema,
+      configSchema: testConfigSchema,
+      planSchema: z
+        .object({
+          planType: z.literal(otherPlanType),
+          requiredCount: z.number().int().positive(),
+        })
+        .passthrough(),
+      instantiatePlan: ({config}) => ({
+        planType: otherPlanType,
+        requiredCount: config.requiredCount,
+      }),
+    };
+
+    registerPlanTypes([testPlanDefinition, otherPlanDefinition], registry);
+
+    expect(registry.size).toBe(2);
+    expect(getPlanTypeDefinition(otherPlanType, registry)).toBe(
+      otherPlanDefinition
+    );
+  });
+
+  test('safeValidatePlan rejects payloads without a valid base plan shape', () => {
+    const registry = createPlanRegistry();
+    const result = safeValidatePlan({}, registry);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(z.ZodError);
+    }
+  });
+
+  test('safeValidatePlan rejects unknown plan types', () => {
+    const registry = createPlanRegistry();
+    const result = safeValidatePlan({planType: 'UnknownPlan'}, registry);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error.message).toContain('Unknown plan type: UnknownPlan');
+    }
+  });
+
+  test('safeValidatePlan validates a known plan with the registered schema', () => {
+    const registry = createPlanRegistry();
+    registerPlanType(testPlanDefinition, registry);
+
+    const result = safeValidatePlan(
+      {
+        planType: TEST_PLAN_TYPE,
+        formType: 'record-form',
+        requiredCount: 3,
+      },
+      registry
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        planType: TEST_PLAN_TYPE,
+        formType: 'record-form',
+        requiredCount: 3,
+      },
+    });
+  });
+
+  test('installBuiltInPlanTypes is safe to call repeatedly for the default registry', () => {
+    expect(() => installBuiltInPlanTypes()).not.toThrow();
+    expect(() => installBuiltInPlanTypes()).not.toThrow();
+
+    expect(getPlanTypeDefinition('Counted')).toBeDefined();
+    expect(getPlanTypeDefinition('ListOfRecords')).toBeDefined();
+  });
+});

--- a/web/.env.dist
+++ b/web/.env.dist
@@ -24,6 +24,9 @@ VITE_MAXIMUM_LONG_LIVED_DURATION_DAYS=90
 # VITE_MAX_DESIGN_FILE_SIZE_MB=10
 # Enable designer template edit protections (default false)
 # VITE_TEMPLATE_PROTECTIONS=false
+# Allow adding a plan in the designer for templates without one (default true).
+# When false, templates that already have a plan can still be reconfigured (default true).
+# VITE_ENABLE_PLANS_IN_DESIGNER=true
 # Configuration for maps (in designer form previews)
 # Set to one of 'osm', 'maptiler', ''
 VITE_MAP_SOURCE=maptiler

--- a/web/src/components/dialogs/designer-dialog.tsx
+++ b/web/src/components/dialogs/designer-dialog.tsx
@@ -1,10 +1,15 @@
 import React, {useEffect, useState} from 'react';
 import {DesignerWidget} from '../../designer/DesignerWidget';
-import type {NotebookWithHistory} from '../../designer/state/initial';
+import type {
+  DesignerDocumentMode,
+  NotebookWithHistory,
+} from '../../designer/state/initial';
 
 interface DesignerDialogProps {
   open: boolean;
   notebook?: NotebookWithHistory;
+  /** Whether the designer session edits a notebook or a template. */
+  designerMode?: DesignerDocumentMode;
   /** Survey/template display name for the exported JSON filename. */
   exportBaseName?: string;
   onClose: (file?: File) => void;
@@ -15,6 +20,7 @@ interface DesignerDialogProps {
 export function DesignerDialog({
   open,
   notebook,
+  designerMode,
   exportBaseName,
   onClose,
   animationDuration = 300,
@@ -108,6 +114,7 @@ export function DesignerDialog({
           notebook={sessionNotebook}
           exportBaseName={exportBaseName}
           onClose={handleWidgetClose}
+          designerMode={designerMode}
         />
       </div>
     </div>

--- a/web/src/components/forms/create-project-from-template.tsx
+++ b/web/src/components/forms/create-project-from-template.tsx
@@ -67,6 +67,10 @@ export function CreateProjectFromTemplateForm({
     possibleTeams,
   });
 
+  // A plan template is instantiated from a planConfig the dashboard cannot yet
+  // collect, so creating from such a template has to go through the API.
+  const planTemplate = template?.uiSpecification?.planTemplate;
+
   const teamLabel = `Create ${config.notebookName} in this team${
     canCreateGlobally ? ' (optional)' : ''
   }`;
@@ -178,6 +182,14 @@ export function CreateProjectFromTemplateForm({
         onSubmit={onSubmit}
         submitButtonText={`Create ${config.notebookNameCapitalized}`}
         defaultValues={defaultTeamId ? {team: defaultTeamId} : undefined}
+        disableSubmission={
+          planTemplate
+            ? {
+                disabled: true,
+                reason: `This template defines a ${planTemplate.planType} plan. Create the ${config.notebookName} through the API, which takes the plan's configuration.`,
+              }
+            : undefined
+        }
       />
     </div>
   );

--- a/web/src/components/tabs/templates/actions.tsx
+++ b/web/src/components/tabs/templates/actions.tsx
@@ -50,7 +50,7 @@ const TemplateActions = () => {
   });
 
   const initialNotebook = useMemo<NotebookWithHistory | undefined>(() => {
-    return toDesignerNotebookWithHistory(data);
+    return toDesignerNotebookWithHistory(data, 'template');
   }, [data]);
 
   const handleEditorClose = (file?: File) => {
@@ -274,6 +274,7 @@ const TemplateActions = () => {
         notebook={initialNotebook}
         exportBaseName={data?.name}
         onClose={handleEditorClose}
+        designerMode="template"
       />
     </>
   );

--- a/web/src/designer/DesignerWidget.tsx
+++ b/web/src/designer/DesignerWidget.tsx
@@ -121,6 +121,7 @@ export function DesignerWidget({
         future: [],
       },
       planTemplate: notebook.planTemplate ?? null,
+      plan: notebook.plan ?? null,
     };
   }, [notebook]);
 

--- a/web/src/designer/DesignerWidget.tsx
+++ b/web/src/designer/DesignerWidget.tsx
@@ -40,7 +40,11 @@ import {
 } from 'react-router-dom';
 import {createDesignerStore} from './createDesignerStore';
 import {createDesignerTheme} from './theme';
-import type {Notebook, NotebookWithHistory} from './state/initial';
+import type {
+  DesignerDocumentMode,
+  Notebook,
+  NotebookWithHistory,
+} from './state/initial';
 import {stripDesignerIdentifiers, toNotebook} from './domain/notebook/adapters';
 import {THEME} from '../lib/theme';
 import {NotebookEditor} from './components/notebook-editor';
@@ -55,6 +59,8 @@ import {DesignPanel} from './components/design-panel';
 export interface DesignerWidgetProps {
   /** Initial notebook; undefined shows empty state until parent supplies data. */
   notebook?: NotebookWithHistory;
+  /** Whether this session edits a notebook or a template (templates may carry a planTemplate). */
+  designerMode?: DesignerDocumentMode;
   /** Used for the exported JSON filename (survey/template display name). */
   exportBaseName?: string;
   /** Called with exported JSON `File` on Done, or undefined on cancel. */
@@ -77,6 +83,7 @@ export interface DesignerWidgetProps {
  */
 export function DesignerWidget({
   notebook,
+  designerMode = 'project',
   exportBaseName,
   onClose,
   themeOverride,
@@ -113,17 +120,18 @@ export function DesignerWidget({
         past: [],
         future: [],
       },
+      planTemplate: notebook.planTemplate ?? null,
     };
   }, [notebook]);
 
   // 2. Keep one Redux store for a notebook identity; do not reset on same-notebook refetch.
   const [store, setStore] = useState(() =>
-    createDesignerStore(processedNotebook, debug)
+    createDesignerStore(processedNotebook, debug, designerMode)
   );
 
   useEffect(() => {
-    setStore(createDesignerStore(processedNotebook, debug));
-  }, [notebookIdentity, debug]);
+    setStore(createDesignerStore(processedNotebook, debug, designerMode));
+  }, [notebookIdentity, debug, designerMode]);
 
   // Local UI state
   const [loading, setLoading] = useState(true);

--- a/web/src/designer/buildconfig.ts
+++ b/web/src/designer/buildconfig.ts
@@ -15,8 +15,8 @@
  *
  * Filename: buildconfig.ts
  * Description:
- *   This module exports the configuration for the designer, specifically
- *   managing template protections. Configuration is parsed from Vite's
+ *   This module exports the configuration for the designer (template
+ *   protections and plan-authoring flags). Configuration is parsed from Vite's
  *   `import.meta.env` with a single zod schema (coerce + rename) and exposed
  *   via the `config` singleton. Document env keys on the schema; the transform
  *   is rename-only.
@@ -32,11 +32,19 @@ const EnvSchema = z
      * when unset.
      */
     VITE_TEMPLATE_PROTECTIONS: configHelpers.truthyBool(false),
+    /**
+     * Enables adding a plan in the designer for templates that do not already
+     * have one. Defaults to true. When false, existing plans can still be
+     * reconfigured.
+     */
+    VITE_ENABLE_PLANS_IN_DESIGNER: configHelpers.boolWithDefault(true),
   })
   .strip()
-  .transform(({VITE_TEMPLATE_PROTECTIONS}) => ({
+  .transform(({VITE_TEMPLATE_PROTECTIONS, VITE_ENABLE_PLANS_IN_DESIGNER}) => ({
     /** Whether template protections are enabled. */
     templateProtections: VITE_TEMPLATE_PROTECTIONS,
+    /** Whether the designer can add a plan to templates without one. */
+    enablePlansInDesigner: VITE_ENABLE_PLANS_IN_DESIGNER,
   }));
 
 /**

--- a/web/src/designer/components/design-panel.tsx
+++ b/web/src/designer/components/design-panel.tsx
@@ -41,6 +41,7 @@ import {TabContext} from '@mui/lab';
 import {useState, useEffect, useRef} from 'react';
 import {useAppDispatch, useAppSelector} from '../state/hooks';
 import {FormEditor} from './form-editor';
+import {PlanTemplateManager} from './plans/PlanTemplateManager';
 import {
   designerCancelButtonSx,
   designerDialogActionsSx,
@@ -398,6 +399,7 @@ export const DesignPanel = () => {
           >
             New Form
           </Button>
+          <PlanTemplateManager />
         </Box>
 
         <Box

--- a/web/src/designer/components/plans/CountedPlanDialog.tsx
+++ b/web/src/designer/components/plans/CountedPlanDialog.tsx
@@ -1,0 +1,142 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Authoring dialog for a Counted plan template: pick the target form.
+ */
+
+import {useEffect, useState} from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  TextField,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import {COUNTED_PLAN_TYPE, countedPlanTemplateSchema} from '@faims3/data-model';
+import {
+  designerCancelButtonSx,
+  designerDialogActionsSx,
+  designerDialogContentSx,
+  designerDialogTitleSx,
+} from '../designer-style';
+import {SimpleFieldWrapper} from '../Fields/SimpleFieldWrapper';
+import type {PlanDialogProps} from '../../plans';
+
+/** Pick the form a Counted plan counts; the count is instantiation-time config. */
+export const CountedPlanDialog = ({
+  open,
+  uiSpec,
+  initialTemplate,
+  onClose,
+  onSave,
+}: PlanDialogProps) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const viewSets = uiSpec.viewsets;
+
+  const [formType, setFormType] = useState('');
+  const [alertMessage, setAlertMessage] = useState('');
+
+  // Re-derive local state each time the dialog opens
+  useEffect(() => {
+    if (!open) return;
+    const initial = initialTemplate?.formType as string | undefined;
+    if (initial && initial in viewSets) {
+      setFormType(initial);
+      setAlertMessage('');
+    } else {
+      setFormType('');
+      setAlertMessage(
+        initial
+          ? 'The previously selected form no longer exists. Choose another.'
+          : ''
+      );
+    }
+  }, [open, initialTemplate, viewSets]);
+
+  const handleSave = () => {
+    const result = countedPlanTemplateSchema.safeParse({
+      planType: COUNTED_PLAN_TYPE,
+      formType,
+    });
+    if (!result.success) {
+      setAlertMessage('Please choose a form for this plan.');
+      return;
+    }
+    onSave(result.data);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      fullScreen={fullScreen}
+    >
+      <DialogTitle sx={designerDialogTitleSx}>
+        <Typography variant="h6" component="span" sx={{fontWeight: 800}}>
+          Counted Plan
+        </Typography>
+      </DialogTitle>
+      <DialogContent sx={{...designerDialogContentSx, pt: 4}}>
+        <Box sx={{maxWidth: 740, width: '100%', mx: 'auto'}}>
+          <SimpleFieldWrapper
+            heading="Form"
+            helperText={
+              alertMessage ||
+              'Records of this form count towards the plan. The number required is set when a notebook is created from this template.'
+            }
+          >
+            <TextField
+              select
+              fullWidth
+              value={formType}
+              error={Boolean(alertMessage)}
+              onChange={event => {
+                setAlertMessage('');
+                setFormType(event.target.value);
+              }}
+              sx={{mt: 0.85}}
+            >
+              {Object.entries(viewSets).map(([id, viewSet]) =>
+                viewSet ? (
+                  <MenuItem key={id} value={id}>
+                    {viewSet.label}
+                  </MenuItem>
+                ) : null
+              )}
+            </TextField>
+          </SimpleFieldWrapper>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={designerDialogActionsSx}>
+        <Button onClick={onClose} sx={designerCancelButtonSx}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!formType} onClick={handleSave}>
+          Save Plan
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/web/src/designer/components/plans/ListOfRecordsPlanDialog.test.tsx
+++ b/web/src/designer/components/plans/ListOfRecordsPlanDialog.test.tsx
@@ -127,4 +127,17 @@ describe('ListOfRecordsPlanDialog', () => {
       expect.objectContaining({recordFields: ['Sample-Photograph']})
     );
   });
+
+  test('a field since deleted from the form is still shown, to be removed', () => {
+    const {onSave} = renderDialog(['Gone-Field', 'Identifier']);
+
+    expect(chosenFieldLabels()).toEqual(['Gone-Field', 'Identifier']);
+
+    fireEvent.click(within(chipFor('Gone-Field')).getByTestId('CancelIcon'));
+
+    fireEvent.click(screen.getByRole('button', {name: 'Save Plan'}));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({recordFields: ['Identifier']})
+    );
+  });
 });

--- a/web/src/designer/components/plans/ListOfRecordsPlanDialog.test.tsx
+++ b/web/src/designer/components/plans/ListOfRecordsPlanDialog.test.tsx
@@ -1,0 +1,130 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Interaction tests for the List of Records plan dialog's field picker.
+ */
+
+import {LIST_OF_RECORDS_PLAN_TYPE, migrateNotebook} from '@faims3/data-model';
+import {ThemeProvider} from '@mui/material/styles';
+import {ToolkitStore} from '@reduxjs/toolkit/dist/configureStore';
+import {fireEvent, render, screen, within} from '@testing-library/react';
+import {ReactNode} from 'react';
+import {Provider} from 'react-redux';
+import {describe, expect, test, vi} from 'vitest';
+import {createDesignerStore} from '../../createDesignerStore';
+import {AppState, NotebookUISpec} from '../../state/initial';
+import {loaded} from '../../store/slices/uiSpec';
+import {sampleNotebook} from '../../test-notebook';
+import globalTheme from '../../theme/index';
+import {ListOfRecordsPlanDialog} from './ListOfRecordsPlanDialog';
+
+const WithProviders = ({
+  children,
+  store,
+}: {
+  children: ReactNode;
+  store: ToolkitStore<AppState>;
+}) => (
+  <ThemeProvider theme={globalTheme}>
+    <Provider store={store}>{children}</Provider>
+  </ThemeProvider>
+);
+
+/** Render the dialog editing a plan on the sample notebook's one form. */
+const renderDialog = (recordFields: string[]) => {
+  const store = createDesignerStore();
+  const {migrated: notebook} = migrateNotebook(sampleNotebook);
+  store.dispatch(loaded(notebook.uiSpec as NotebookUISpec));
+  const onSave = vi.fn();
+
+  render(
+    <WithProviders store={store}>
+      <ListOfRecordsPlanDialog
+        open
+        uiSpec={store.getState().notebook.uiSpec.present}
+        initialTemplate={{
+          planType: LIST_OF_RECORDS_PLAN_TYPE,
+          formType: 'Primary',
+          recordFields,
+        }}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />
+    </WithProviders>
+  );
+
+  return {onSave};
+};
+
+/** Labels of the chips standing for the chosen fields, in order. */
+const chosenFieldLabels = (): string[] =>
+  [...document.querySelectorAll('.MuiChip-label')].map(
+    chip => chip.textContent ?? ''
+  );
+
+/** The chip standing for one chosen field. */
+const chipFor = (label: string): HTMLElement => {
+  const chip = screen.getByText(label).closest('.MuiChip-root');
+  if (!chip) throw new Error(`No chip for ${label}`);
+  return chip as HTMLElement;
+};
+
+describe('ListOfRecordsPlanDialog', () => {
+  test('searching for a field adds it to the chosen list', async () => {
+    const {onSave} = renderDialog(['Identifier']);
+
+    // The already-chosen field shows underneath the picker
+    expect(chipFor('Identifier')).toBeDefined();
+
+    const input = within(screen.getByTestId('list-plan-field-add')).getByRole(
+      'combobox'
+    );
+    fireEvent.change(input, {target: {value: 'photograph'}});
+    fireEvent.click(await screen.findByRole('option', {name: /photograph/i}));
+
+    expect(chipFor('Sample Photograph')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Save Plan'}));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formType: 'Primary',
+        recordFields: ['Identifier', 'Sample-Photograph'],
+      })
+    );
+  });
+
+  test('a chosen field can be removed and is offered again', async () => {
+    const {onSave} = renderDialog(['Identifier', 'Sample-Photograph']);
+
+    const input = within(screen.getByTestId('list-plan-field-add')).getByRole(
+      'combobox'
+    );
+    fireEvent.change(input, {target: {value: 'identifier'}});
+    // Chosen fields are excluded from the picker, so this search finds nothing
+    expect(await screen.findByText('No fields left to add')).toBeDefined();
+
+    fireEvent.click(within(chipFor('Identifier')).getByTestId('CancelIcon'));
+    expect(chosenFieldLabels()).toEqual(['Sample Photograph']);
+    // Removing it puts it back in the picker
+    expect(
+      await screen.findByRole('option', {name: /identifier/i})
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Save Plan'}));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({recordFields: ['Sample-Photograph']})
+    );
+  });
+});

--- a/web/src/designer/components/plans/ListOfRecordsPlanDialog.tsx
+++ b/web/src/designer/components/plans/ListOfRecordsPlanDialog.tsx
@@ -1,0 +1,207 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Authoring dialog for a List of Records plan template: pick the target
+ * form and the subset of its fields the record list pre-fills.
+ */
+
+import {useEffect, useMemo, useState} from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  MenuItem,
+  TextField,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import {
+  LIST_OF_RECORDS_PLAN_TYPE,
+  listPlanTemplateSchema,
+} from '@faims3/data-model';
+import {
+  designerCancelButtonSx,
+  designerDialogActionsSx,
+  designerDialogContentSx,
+  designerDialogTitleSx,
+} from '../designer-style';
+import {SimpleFieldWrapper} from '../Fields/SimpleFieldWrapper';
+import type {PlanDialogProps} from '../../plans';
+
+/** Pick the form and pre-filled fields for a List of Records plan. */
+export const ListOfRecordsPlanDialog = ({
+  open,
+  uiSpec,
+  initialTemplate,
+  onClose,
+  onSave,
+}: PlanDialogProps) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const viewSets = uiSpec.viewsets;
+
+  const [formType, setFormType] = useState('');
+  const [recordFields, setRecordFields] = useState<string[]>([]);
+  const [alertMessage, setAlertMessage] = useState('');
+
+  // Fields belonging to the chosen form, across all its sections
+  const formFields = useMemo(() => {
+    if (!formType || !(formType in viewSets)) return [];
+    return (viewSets[formType]?.views ?? []).flatMap(
+      viewId => uiSpec.views[viewId]?.fields ?? []
+    );
+  }, [formType, uiSpec]);
+
+  // Re-derive local state each time the dialog opens
+  useEffect(() => {
+    if (!open) return;
+    const initial = initialTemplate?.formType as string | undefined;
+    if (initial && initial in viewSets) {
+      setFormType(initial);
+      setRecordFields((initialTemplate?.recordFields as string[]) ?? []);
+      setAlertMessage('');
+    } else {
+      setFormType('');
+      setRecordFields([]);
+      setAlertMessage(
+        initial
+          ? 'The previously selected form no longer exists. Choose another.'
+          : ''
+      );
+    }
+  }, [open, initialTemplate, viewSets]);
+
+  const fieldLabel = (fieldName: string): string => {
+    const label = uiSpec.fields[fieldName]?.['component-parameters']?.label;
+    return typeof label === 'string' && label ? label : fieldName;
+  };
+
+  const toggleField = (fieldName: string) => {
+    setRecordFields(current =>
+      current.includes(fieldName)
+        ? current.filter(f => f !== fieldName)
+        : [...current, fieldName]
+    );
+  };
+
+  const handleFormChange = (newFormType: string) => {
+    setAlertMessage('');
+    setFormType(newFormType);
+    // Field subset belongs to a form; changing form resets it
+    setRecordFields([]);
+  };
+
+  const handleSave = () => {
+    const result = listPlanTemplateSchema.safeParse({
+      planType: LIST_OF_RECORDS_PLAN_TYPE,
+      formType,
+      recordFields,
+    });
+    if (!result.success) {
+      setAlertMessage('Please choose a form for this plan.');
+      return;
+    }
+    onSave(result.data);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      fullScreen={fullScreen}
+    >
+      <DialogTitle sx={designerDialogTitleSx}>
+        <Typography variant="h6" component="span" sx={{fontWeight: 800}}>
+          List of Records Plan
+        </Typography>
+      </DialogTitle>
+      <DialogContent sx={{...designerDialogContentSx, pt: 4}}>
+        <Box sx={{maxWidth: 740, width: '100%', mx: 'auto'}}>
+          <SimpleFieldWrapper
+            heading="Form"
+            helperText={
+              alertMessage ||
+              'Records of this form are created from the planned list. The list itself is supplied when a notebook is created from this template.'
+            }
+          >
+            <TextField
+              select
+              fullWidth
+              value={formType}
+              error={Boolean(alertMessage)}
+              onChange={event => handleFormChange(event.target.value)}
+              sx={{mt: 0.85}}
+            >
+              {Object.entries(viewSets).map(([id, viewSet]) =>
+                viewSet ? (
+                  <MenuItem key={id} value={id}>
+                    {viewSet.label}
+                  </MenuItem>
+                ) : null
+              )}
+            </TextField>
+          </SimpleFieldWrapper>
+
+          {formType && (
+            <Box sx={{mt: 3}}>
+              <SimpleFieldWrapper
+                heading="Pre-filled fields"
+                helperText="Fields of the form that each planned record supplies values for."
+              >
+                <FormGroup sx={{mt: 0.85}}>
+                  {formFields.map(fieldName => (
+                    <FormControlLabel
+                      key={fieldName}
+                      control={
+                        <Checkbox
+                          checked={recordFields.includes(fieldName)}
+                          onChange={() => toggleField(fieldName)}
+                        />
+                      }
+                      label={fieldLabel(fieldName)}
+                    />
+                  ))}
+                  {formFields.length === 0 && (
+                    <Typography variant="body2" color="text.secondary">
+                      This form has no fields yet.
+                    </Typography>
+                  )}
+                </FormGroup>
+              </SimpleFieldWrapper>
+            </Box>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions sx={designerDialogActionsSx}>
+        <Button onClick={onClose} sx={designerCancelButtonSx}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!formType} onClick={handleSave}>
+          Save Plan
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/web/src/designer/components/plans/ListOfRecordsPlanDialog.tsx
+++ b/web/src/designer/components/plans/ListOfRecordsPlanDialog.tsx
@@ -172,13 +172,13 @@ export const ListOfRecordsPlanDialog = ({
                 heading="Pre-filled fields"
                 helperText="Fields of the form that each planned record supplies values for."
               >
-                {formFields.length === 0 ? (
-                  <Typography variant="body2" color="text.secondary">
-                    This form has no fields yet.
-                  </Typography>
-                ) : (
-                  <Box sx={{mt: 0.85}}>
-                    {/* Picker reads the designer store, the same uiSpec the dialog is given */}
+                <Box sx={{mt: 0.85}}>
+                  {formFields.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      This form has no fields yet.
+                    </Typography>
+                  ) : (
+                    /* Picker reads the designer store, the same uiSpec the dialog is given */
                     <FieldSearchAutocomplete
                       value={null}
                       onChange={fieldName => {
@@ -186,6 +186,8 @@ export const ListOfRecordsPlanDialog = ({
                       }}
                       scope={{kind: 'viewset', viewsetId: formType}}
                       filters={{excludeFieldIds: recordFields}}
+                      // Every field of the form stays reachable by browsing, not only the first page
+                      limit={formFields.length}
                       label="Add field"
                       placeholder="Search fields…"
                       size="small"
@@ -193,39 +195,39 @@ export const ListOfRecordsPlanDialog = ({
                       noOptionsText="No fields left to add"
                       data-testid="list-plan-field-add"
                     />
-                    <Box
-                      sx={{display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.5}}
-                    >
-                      {recordFields.map(fieldName => {
-                        // A field can be deleted from the form after the plan chose it
-                        const onForm = formFields.includes(fieldName);
-                        const chip = (
-                          <Chip
-                            key={fieldName}
-                            label={fieldLabel(fieldName)}
-                            color={onForm ? 'default' : 'warning'}
-                            onDelete={() => removeField(fieldName)}
-                          />
-                        );
-                        return onForm ? (
-                          chip
-                        ) : (
-                          <Tooltip
-                            key={fieldName}
-                            title="This field is no longer on the form"
-                          >
-                            <span>{chip}</span>
-                          </Tooltip>
-                        );
-                      })}
-                      {recordFields.length === 0 && (
-                        <Typography variant="body2" color="text.secondary">
-                          No fields chosen yet.
-                        </Typography>
-                      )}
-                    </Box>
+                  )}
+                  <Box
+                    sx={{display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.5}}
+                  >
+                    {recordFields.map(fieldName => {
+                      // A field can be deleted from the form after the plan chose it
+                      const onForm = formFields.includes(fieldName);
+                      const chip = (
+                        <Chip
+                          key={fieldName}
+                          label={fieldLabel(fieldName)}
+                          color={onForm ? 'default' : 'warning'}
+                          onDelete={() => removeField(fieldName)}
+                        />
+                      );
+                      return onForm ? (
+                        chip
+                      ) : (
+                        <Tooltip
+                          key={fieldName}
+                          title="This field is no longer on the form"
+                        >
+                          <span>{chip}</span>
+                        </Tooltip>
+                      );
+                    })}
+                    {recordFields.length === 0 && (
+                      <Typography variant="body2" color="text.secondary">
+                        No fields chosen yet.
+                      </Typography>
+                    )}
                   </Box>
-                )}
+                </Box>
               </SimpleFieldWrapper>
             </Box>
           )}

--- a/web/src/designer/components/plans/ListOfRecordsPlanDialog.tsx
+++ b/web/src/designer/components/plans/ListOfRecordsPlanDialog.tsx
@@ -21,15 +21,14 @@ import {useEffect, useMemo, useState} from 'react';
 import {
   Box,
   Button,
-  Checkbox,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControlLabel,
-  FormGroup,
   MenuItem,
   TextField,
+  Tooltip,
   Typography,
   useMediaQuery,
   useTheme,
@@ -45,6 +44,7 @@ import {
   designerDialogTitleSx,
 } from '../designer-style';
 import {SimpleFieldWrapper} from '../Fields/SimpleFieldWrapper';
+import {FieldSearchAutocomplete} from '../field-selector';
 import type {PlanDialogProps} from '../../plans';
 
 /** Pick the form and pre-filled fields for a List of Records plan. */
@@ -96,12 +96,14 @@ export const ListOfRecordsPlanDialog = ({
     return typeof label === 'string' && label ? label : fieldName;
   };
 
-  const toggleField = (fieldName: string) => {
+  const addField = (fieldName: string) => {
     setRecordFields(current =>
-      current.includes(fieldName)
-        ? current.filter(f => f !== fieldName)
-        : [...current, fieldName]
+      current.includes(fieldName) ? current : [...current, fieldName]
     );
+  };
+
+  const removeField = (fieldName: string) => {
+    setRecordFields(current => current.filter(f => f !== fieldName));
   };
 
   const handleFormChange = (newFormType: string) => {
@@ -170,25 +172,60 @@ export const ListOfRecordsPlanDialog = ({
                 heading="Pre-filled fields"
                 helperText="Fields of the form that each planned record supplies values for."
               >
-                <FormGroup sx={{mt: 0.85}}>
-                  {formFields.map(fieldName => (
-                    <FormControlLabel
-                      key={fieldName}
-                      control={
-                        <Checkbox
-                          checked={recordFields.includes(fieldName)}
-                          onChange={() => toggleField(fieldName)}
-                        />
-                      }
-                      label={fieldLabel(fieldName)}
+                {formFields.length === 0 ? (
+                  <Typography variant="body2" color="text.secondary">
+                    This form has no fields yet.
+                  </Typography>
+                ) : (
+                  <Box sx={{mt: 0.85}}>
+                    {/* Picker reads the designer store, the same uiSpec the dialog is given */}
+                    <FieldSearchAutocomplete
+                      value={null}
+                      onChange={fieldName => {
+                        if (fieldName) addField(fieldName);
+                      }}
+                      scope={{kind: 'viewset', viewsetId: formType}}
+                      filters={{excludeFieldIds: recordFields}}
+                      label="Add field"
+                      placeholder="Search fields…"
+                      size="small"
+                      clearOnSelect
+                      noOptionsText="No fields left to add"
+                      data-testid="list-plan-field-add"
                     />
-                  ))}
-                  {formFields.length === 0 && (
-                    <Typography variant="body2" color="text.secondary">
-                      This form has no fields yet.
-                    </Typography>
-                  )}
-                </FormGroup>
+                    <Box
+                      sx={{display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.5}}
+                    >
+                      {recordFields.map(fieldName => {
+                        // A field can be deleted from the form after the plan chose it
+                        const onForm = formFields.includes(fieldName);
+                        const chip = (
+                          <Chip
+                            key={fieldName}
+                            label={fieldLabel(fieldName)}
+                            color={onForm ? 'default' : 'warning'}
+                            onDelete={() => removeField(fieldName)}
+                          />
+                        );
+                        return onForm ? (
+                          chip
+                        ) : (
+                          <Tooltip
+                            key={fieldName}
+                            title="This field is no longer on the form"
+                          >
+                            <span>{chip}</span>
+                          </Tooltip>
+                        );
+                      })}
+                      {recordFields.length === 0 && (
+                        <Typography variant="body2" color="text.secondary">
+                          No fields chosen yet.
+                        </Typography>
+                      )}
+                    </Box>
+                  </Box>
+                )}
               </SimpleFieldWrapper>
             </Box>
           )}

--- a/web/src/designer/components/plans/PlanTemplateManager.test.tsx
+++ b/web/src/designer/components/plans/PlanTemplateManager.test.tsx
@@ -1,0 +1,100 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Visibility tests for PlanTemplateManager: feature flag hides Add
+ * Plan when a template has no existing plan, but leaves existing plans
+ * editable.
+ */
+
+import {COUNTED_PLAN_TYPE} from '@faims3/data-model';
+import {ThemeProvider} from '@mui/material/styles';
+import {ToolkitStore} from '@reduxjs/toolkit/dist/configureStore';
+import {render, screen} from '@testing-library/react';
+import {ReactNode} from 'react';
+import {Provider} from 'react-redux';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {createDesignerStore} from '../../createDesignerStore';
+import {AppState, initialState} from '../../state/initial';
+import globalTheme from '../../theme/index';
+import {PlanTemplateManager} from './PlanTemplateManager';
+
+const {designerConfig} = vi.hoisted(() => ({
+  designerConfig: {enablePlansInDesigner: true, templateProtections: false},
+}));
+
+vi.mock('../../buildconfig', () => ({
+  config: designerConfig,
+}));
+
+const WithProviders = ({
+  children,
+  store,
+}: {
+  children: ReactNode;
+  store: ToolkitStore<AppState>;
+}) => (
+  <ThemeProvider theme={globalTheme}>
+    <Provider store={store}>{children}</Provider>
+  </ThemeProvider>
+);
+
+const countedTemplate = {planType: COUNTED_PLAN_TYPE, formType: 'FORM1'};
+
+const renderManager = (
+  mode: AppState['mode'],
+  planTemplate: AppState['notebook']['planTemplate']
+) => {
+  const store = createDesignerStore(
+    {...initialState.notebook, planTemplate},
+    false,
+    mode
+  );
+  return render(
+    <WithProviders store={store}>
+      <PlanTemplateManager />
+    </WithProviders>
+  );
+};
+
+describe('PlanTemplateManager feature flag', () => {
+  beforeEach(() => {
+    designerConfig.enablePlansInDesigner = true;
+  });
+
+  test('shows Add Plan in template mode when the flag is on and there is no plan', () => {
+    renderManager('template', null);
+    expect(screen.getByTestId('web-designer-add-plan-button')).toBeDefined();
+  });
+
+  test('hides Add Plan in template mode when the flag is off and there is no plan', () => {
+    designerConfig.enablePlansInDesigner = false;
+    const {container} = renderManager('template', null);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('web-designer-add-plan-button')).toBeNull();
+  });
+
+  test('keeps existing plan controls when the flag is off', () => {
+    designerConfig.enablePlansInDesigner = false;
+    renderManager('template', countedTemplate);
+    expect(screen.getByLabelText('edit plan')).toBeDefined();
+    expect(screen.getByText(/Counted plan/)).toBeDefined();
+    expect(screen.queryByTestId('web-designer-add-plan-button')).toBeNull();
+  });
+
+  test('hides the manager outside template mode even when the flag is on', () => {
+    const {container} = renderManager('project', countedTemplate);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/designer/components/plans/PlanTemplateManager.tsx
+++ b/web/src/designer/components/plans/PlanTemplateManager.tsx
@@ -48,6 +48,7 @@ import {
   planTemplateRemoved,
   planTemplateSet,
 } from '../../state/planTemplate-reducer';
+import {config} from '../../buildconfig';
 import {getDesignerPlanType, getDesignerPlanTypes} from '../../plans';
 import {
   designerCancelButtonSx,
@@ -76,8 +77,12 @@ export const PlanTemplateManager = () => {
   const [editorPlanType, setEditorPlanType] = useState<string | null>(null);
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
 
-  // Plans are only authored on templates
+  // Plans are only authored on templates. When the feature flag is off, hide
+  // Add Plan for templates without a plan; existing plans stay editable.
   if (mode !== 'template') {
+    return null;
+  }
+  if (!config.enablePlansInDesigner && !planTemplate) {
     return null;
   }
 
@@ -107,6 +112,7 @@ export const PlanTemplateManager = () => {
           size="small"
           startIcon={<AddRoundedIcon />}
           onClick={() => setChooserOpen(true)}
+          data-testid="web-designer-add-plan-button"
           sx={{
             ...designerPrimaryActionButtonSx,
             boxShadow: 'none',

--- a/web/src/designer/components/plans/PlanTemplateManager.tsx
+++ b/web/src/designer/components/plans/PlanTemplateManager.tsx
@@ -1,0 +1,254 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Plan template controls for the design panel: an Add Plan button in
+ * template mode, a chooser for plan types, per-type authoring dialogs, and
+ * edit/remove for the single existing plan template.
+ */
+
+import {useState} from 'react';
+import {
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  IconButton,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import {alpha} from '@mui/material/styles';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import {shallowEqual} from 'react-redux';
+import type {PlanTemplate} from '@faims3/data-model';
+import {useAppDispatch, useAppSelector} from '../../state/hooks';
+import {selectDesignerMode} from '../../store/selectors';
+import {
+  planTemplateRemoved,
+  planTemplateSet,
+} from '../../state/planTemplate-reducer';
+import {getDesignerPlanType, getDesignerPlanTypes} from '../../plans';
+import {
+  designerCancelButtonSx,
+  designerDialogActionsSx,
+  designerDialogTitleSx,
+  designerPrimaryActionButtonSx,
+} from '../designer-style';
+
+/** Add/edit/remove the template's single plan template; hidden outside template mode. */
+export const PlanTemplateManager = () => {
+  const theme = useTheme();
+  const dispatch = useAppDispatch();
+
+  const mode = useAppSelector(selectDesignerMode);
+  const planTemplate = useAppSelector(
+    state => state.notebook.planTemplate,
+    shallowEqual
+  );
+  const uiSpec = useAppSelector(
+    state => state.notebook.uiSpec.present,
+    shallowEqual
+  );
+  const viewSets = uiSpec.viewsets;
+
+  const [chooserOpen, setChooserOpen] = useState(false);
+  const [editorPlanType, setEditorPlanType] = useState<string | null>(null);
+  const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
+
+  // Plans are only authored on templates
+  if (mode !== 'template') {
+    return null;
+  }
+
+  const definition = planTemplate
+    ? getDesignerPlanType(planTemplate.planType)
+    : undefined;
+  const EditorDialog = editorPlanType
+    ? getDesignerPlanType(editorPlanType)?.Dialog
+    : undefined;
+
+  const formType = planTemplate?.formType as string | undefined;
+  const formLabel = formType ? viewSets[formType]?.label : undefined;
+  const formMissing = Boolean(planTemplate && formType && !formLabel);
+
+  const planTypes = getDesignerPlanTypes();
+
+  const handleSave = (saved: PlanTemplate) => {
+    dispatch(planTemplateSet(saved));
+    setEditorPlanType(null);
+  };
+
+  return (
+    <>
+      {!planTemplate ? (
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddRoundedIcon />}
+          onClick={() => setChooserOpen(true)}
+          sx={{
+            ...designerPrimaryActionButtonSx,
+            boxShadow: 'none',
+            whiteSpace: 'nowrap',
+            textTransform: 'none',
+            fontWeight: 700,
+          }}
+        >
+          Add Plan
+        </Button>
+      ) : (
+        <>
+          <Chip
+            icon={formMissing ? <WarningAmberRoundedIcon /> : undefined}
+            label={
+              formMissing
+                ? `${definition?.label ?? planTemplate.planType} plan: form missing`
+                : `${definition?.label ?? planTemplate.planType} plan: ${formLabel}`
+            }
+            color={formMissing ? 'warning' : 'default'}
+            onClick={() => setEditorPlanType(planTemplate.planType as string)}
+            onDelete={() => setRemoveConfirmOpen(true)}
+            deleteIcon={
+              <Tooltip title="Remove plan">
+                <DeleteOutlineRoundedIcon />
+              </Tooltip>
+            }
+            sx={{fontWeight: 600}}
+          />
+          <Tooltip title="Edit plan">
+            <IconButton
+              size="small"
+              aria-label="edit plan"
+              onClick={() => setEditorPlanType(planTemplate.planType as string)}
+            >
+              <EditRoundedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </>
+      )}
+
+      {/* Plan type chooser */}
+      <Dialog
+        open={chooserOpen}
+        onClose={() => setChooserOpen(false)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle sx={designerDialogTitleSx}>Add a plan</DialogTitle>
+        <DialogContent sx={{pt: 2}}>
+          <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+            A plan guides data collection for notebooks created from this
+            template. Choose a plan type.
+          </Typography>
+          <Grid container spacing={2}>
+            {planTypes.map(plan => (
+              <Grid size={{xs: 12}} key={plan.planType}>
+                <Card
+                  variant="outlined"
+                  sx={{
+                    borderColor: alpha(theme.palette.text.primary, 0.15),
+                    '&:hover': {
+                      borderColor: alpha(theme.palette.primary.main, 0.35),
+                      boxShadow: '0 8px 18px rgba(15, 23, 42, 0.12)',
+                    },
+                  }}
+                >
+                  <CardActionArea
+                    onClick={() => {
+                      setChooserOpen(false);
+                      setEditorPlanType(plan.planType);
+                    }}
+                  >
+                    <CardContent>
+                      <Typography variant="subtitle2" sx={{fontWeight: 700}}>
+                        {plan.label}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {plan.description}
+                      </Typography>
+                    </CardContent>
+                  </CardActionArea>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </DialogContent>
+        <DialogActions sx={designerDialogActionsSx}>
+          <Button
+            onClick={() => setChooserOpen(false)}
+            sx={designerCancelButtonSx}
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Per-type authoring dialog */}
+      {EditorDialog && (
+        <EditorDialog
+          open={Boolean(editorPlanType)}
+          uiSpec={uiSpec}
+          initialTemplate={
+            planTemplate?.planType === editorPlanType ? planTemplate : undefined
+          }
+          onClose={() => setEditorPlanType(null)}
+          onSave={handleSave}
+        />
+      )}
+
+      {/* Remove confirmation */}
+      <Dialog
+        open={removeConfirmOpen}
+        onClose={() => setRemoveConfirmOpen(false)}
+      >
+        <DialogTitle sx={designerDialogTitleSx}>Remove plan?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{mt: 1}}>
+            Notebooks created from this template will no longer include a data
+            collection plan.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={designerDialogActionsSx}>
+          <Button
+            onClick={() => setRemoveConfirmOpen(false)}
+            sx={designerCancelButtonSx}
+            autoFocus
+          >
+            Cancel
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => {
+              dispatch(planTemplateRemoved());
+              setRemoveConfirmOpen(false);
+            }}
+          >
+            Remove
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/web/src/designer/createDesignerStore.ts
+++ b/web/src/designer/createDesignerStore.ts
@@ -25,6 +25,7 @@ import {
   initialState as blankState,
 } from './state/initial';
 import metadataReducer from './state/metadata-reducer';
+import planReducer from './state/plan-reducer';
 import planTemplateReducer from './state/planTemplate-reducer';
 import modifiedStatusReducer from './state/modifiedStatus-reducer';
 import modeReducer from './state/mode-reducer';
@@ -54,6 +55,7 @@ export function createDesignerStore(
         metadata: metadataReducer,
         uiSpec: undoable(uiSpecificationReducer.reducer, uiSpecUndoConfig),
         planTemplate: planTemplateReducer,
+        plan: planReducer,
       }),
       modified: modifiedStatusReducer,
       mode: modeReducer,

--- a/web/src/designer/createDesignerStore.ts
+++ b/web/src/designer/createDesignerStore.ts
@@ -20,11 +20,14 @@ import {configureStore, combineReducers, Middleware} from '@reduxjs/toolkit';
 import undoable from 'redux-undo';
 import {
   AppState,
+  DesignerDocumentMode,
   NotebookWithHistory,
   initialState as blankState,
 } from './state/initial';
 import metadataReducer from './state/metadata-reducer';
+import planTemplateReducer from './state/planTemplate-reducer';
 import modifiedStatusReducer from './state/modifiedStatus-reducer';
+import modeReducer from './state/mode-reducer';
 import {uiSpecificationReducer} from './store/slices/uiSpec';
 import {uiSpecUndoConfig} from './store/undoConfig';
 
@@ -34,7 +37,8 @@ import {uiSpecUndoConfig} from './store/undoConfig';
  */
 export function createDesignerStore(
   notebook?: NotebookWithHistory,
-  debug = false
+  debug = false,
+  mode: DesignerDocumentMode = 'project'
 ) {
   const logger: Middleware<object, AppState> = () => next => action => {
     if (debug) console.log('[designer]', action);
@@ -43,14 +47,16 @@ export function createDesignerStore(
 
   return configureStore({
     preloadedState: notebook
-      ? ({...blankState, notebook} as AppState)
-      : undefined,
+      ? ({...blankState, notebook, mode} as AppState)
+      : ({...blankState, mode} as AppState),
     reducer: {
       notebook: combineReducers<NotebookWithHistory>({
         metadata: metadataReducer,
         uiSpec: undoable(uiSpecificationReducer.reducer, uiSpecUndoConfig),
+        planTemplate: planTemplateReducer,
       }),
       modified: modifiedStatusReducer,
+      mode: modeReducer,
     },
     middleware: g => g().concat(logger),
   });

--- a/web/src/designer/domain/notebook/adapters.ts
+++ b/web/src/designer/domain/notebook/adapters.ts
@@ -42,6 +42,7 @@ export const toNotebookWithHistory = (
     past: [],
     future: [],
   },
+  planTemplate: notebook.planTemplate ?? null,
 });
 
 /**

--- a/web/src/designer/domain/notebook/adapters.ts
+++ b/web/src/designer/domain/notebook/adapters.ts
@@ -43,6 +43,7 @@ export const toNotebookWithHistory = (
     future: [],
   },
   planTemplate: notebook.planTemplate ?? null,
+  plan: notebook.plan ?? null,
 });
 
 /**

--- a/web/src/designer/integration/legacyNotebook.ts
+++ b/web/src/designer/integration/legacyNotebook.ts
@@ -1,7 +1,7 @@
 /**
  * @file Normalize API/upload `uiSpecification` JSON for the designer: detect schema version
  * (legacy `metadata.schema_version` or `uiSpec.schemaVersion`), migrate when needed, then
- * validate as {@link NotebookDefinition}.
+ * validate as {@link NotebookDefinition} (or {@link TemplateDefinition} in template mode).
  */
 
 import {
@@ -12,7 +12,13 @@ import {
   notebookUiSpecificationNeedsMigration,
   notebookUiSpecificationValidationMessage,
   type NotebookDefinition,
+  safeValidatePlanTemplate,
+  TemplateDefinitionSchema,
+  type PlanTemplate,
 } from '@faims3/data-model';
+
+/** Which document kind the designer is editing; templates may carry a planTemplate. */
+export type DesignerDocumentMode = 'project' | 'template';
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -32,7 +38,7 @@ export class UiSpecificationNormalizeError extends Error {
 export type NormalizeApiUiSpecificationResult =
   | {
       ok: true;
-      data: NotebookDefinition;
+      data: NotebookDefinition & {planTemplate?: PlanTemplate};
       /** True when {@link migrateNotebook} ran because the version was missing or below current. */
       migrated: boolean;
       /** Present when migration ran — design was upgraded in memory before editing. */
@@ -57,10 +63,12 @@ export function readUiSpecificationSchemaVersion(
  *
  * 1. Reads version via {@link getNotebookSchemaVersion} (legacy or current field).
  * 2. Runs {@link migrateNotebook} when version is missing or below {@link CURRENT_NOTEBOOK_UI_SCHEMA_VERSION}.
- * 3. Validates with {@link NotebookDefinitionSchema}.
+ * 3. Validates with {@link NotebookDefinitionSchema}, or {@link TemplateDefinitionSchema}
+ *    in template mode so an optional planTemplate is preserved.
  */
 export function tryNormalizeApiUiSpecification(
-  raw: unknown
+  raw: unknown,
+  mode: DesignerDocumentMode = 'project'
 ): NormalizeApiUiSpecificationResult {
   if (!isPlainObject(raw)) {
     return {ok: false, message: 'uiSpecification must be a JSON object'};
@@ -82,7 +90,10 @@ export function tryNormalizeApiUiSpecification(
     }
   }
 
-  const parsed = NotebookDefinitionSchema.safeParse(candidate);
+  // Templates carry an optional planTemplate the notebook schema would strip
+  const schema =
+    mode === 'template' ? TemplateDefinitionSchema : NotebookDefinitionSchema;
+  const parsed = schema.safeParse(candidate);
   if (!parsed.success) {
     return {
       ok: false,
@@ -106,14 +117,40 @@ export function tryNormalizeApiUiSpecification(
         : `This design used schema version ${versionBefore} and was migrated to ${CURRENT_NOTEBOOK_UI_SCHEMA_VERSION}. Save to persist the updated structure.`
       : undefined;
 
-  return {ok: true, data: parsed.data, migrated, warning};
+  // Read from candidate: the ternary-selected schema's inferred type drops
+  // planTemplate, but safeValidatePlanTemplate handles unknown input anyway
+  const rawPlanTemplate =
+    mode === 'template'
+      ? (candidate as Record<string, unknown>).planTemplate
+      : undefined;
+
+  // Warn rather than fail on an invalid planTemplate so the template stays editable
+  let planWarning: string | undefined;
+  if (rawPlanTemplate) {
+    const planResult = safeValidatePlanTemplate(rawPlanTemplate);
+    if (!planResult.success) {
+      planWarning = `This template's plan failed validation and may need to be re-created: ${planResult.error.message}`;
+    }
+  }
+
+  return {
+    ok: true,
+    data: rawPlanTemplate
+      ? {...parsed.data, planTemplate: rawPlanTemplate as PlanTemplate}
+      : parsed.data,
+    migrated,
+    warning: [warning, planWarning].filter(Boolean).join(' ') || undefined,
+  };
 }
 
 /**
  * Same as {@link tryNormalizeApiUiSpecification} but throws {@link UiSpecificationNormalizeError} on failure.
  */
-export function normalizeApiUiSpecification(raw: unknown): NotebookDefinition {
-  const result = tryNormalizeApiUiSpecification(raw);
+export function normalizeApiUiSpecification(
+  raw: unknown,
+  mode: DesignerDocumentMode = 'project'
+) {
+  const result = tryNormalizeApiUiSpecification(raw, mode);
   if (result.ok === false) {
     throw new UiSpecificationNormalizeError(result.message);
   }

--- a/web/src/designer/integration/notebookAdapters.test.ts
+++ b/web/src/designer/integration/notebookAdapters.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @file Round-trip tests for notebook adapters: planTemplate survives
+ * hydration and export, and null serialises to an absent key.
+ */
+import {describe, expect, it} from 'vitest';
+import type {Notebook} from '../state/initial';
+import {CURRENT_NOTEBOOK_UI_SCHEMA_VERSION} from '../state/initial';
+import {
+  designerHistoryToNotebookDefinition,
+  notebookDefinitionToDesignerHistory,
+} from './notebookAdapters';
+
+const createDefinition = (): Notebook => ({
+  metadata: {
+    information: {
+      notebookVersion: '1.0',
+      purposeMarkdown: '',
+      projectLeadLabel: '',
+      leadInstitution: '',
+    },
+  },
+  uiSpec: {
+    fields: {},
+    views: {},
+    viewsets: {},
+    visible_types: [],
+    settings: {showQrCodeButton: false},
+    schemaVersion: CURRENT_NOTEBOOK_UI_SCHEMA_VERSION,
+  },
+});
+
+const countedTemplate = {planType: 'Counted', formType: 'FORM1'};
+
+describe('notebook adapters planTemplate round-trip', () => {
+  it('hydrates a definition with planTemplate into designer state', () => {
+    const definition = {...createDefinition(), planTemplate: countedTemplate};
+    const history = notebookDefinitionToDesignerHistory(definition);
+    expect(history.planTemplate).toEqual(countedTemplate);
+  });
+
+  it('hydrates a definition without planTemplate as null', () => {
+    const history = notebookDefinitionToDesignerHistory(createDefinition());
+    expect(history.planTemplate).toBeNull();
+  });
+
+  it('exports planTemplate when present', () => {
+    const history = notebookDefinitionToDesignerHistory({
+      ...createDefinition(),
+      planTemplate: countedTemplate,
+    });
+    const exported = designerHistoryToNotebookDefinition(history);
+    expect(exported.planTemplate).toEqual(countedTemplate);
+  });
+
+  it('omits the planTemplate key entirely when null', () => {
+    const history = notebookDefinitionToDesignerHistory(createDefinition());
+    const exported = designerHistoryToNotebookDefinition(history);
+    // Absent key, not "planTemplate": null, so saved JSON stays clean
+    expect('planTemplate' in exported).toBe(false);
+  });
+
+  it('round-trips a full definition unchanged', () => {
+    const definition = {...createDefinition(), planTemplate: countedTemplate};
+    const exported = designerHistoryToNotebookDefinition(
+      notebookDefinitionToDesignerHistory(definition)
+    );
+    expect(exported).toEqual(definition);
+  });
+});

--- a/web/src/designer/integration/notebookAdapters.test.ts
+++ b/web/src/designer/integration/notebookAdapters.test.ts
@@ -31,6 +31,13 @@ const createDefinition = (): Notebook => ({
 
 const countedTemplate = {planType: 'Counted', formType: 'FORM1'};
 
+const countedPlan = {
+  planType: 'Counted' as const,
+  formType: 'FORM1',
+  numberRequired: 3,
+  allowExtraRecords: false,
+};
+
 describe('notebook adapters planTemplate round-trip', () => {
   it('hydrates a definition with planTemplate into designer state', () => {
     const definition = {...createDefinition(), planTemplate: countedTemplate};
@@ -65,5 +72,42 @@ describe('notebook adapters planTemplate round-trip', () => {
       notebookDefinitionToDesignerHistory(definition)
     );
     expect(exported).toEqual(definition);
+  });
+});
+
+describe('notebook adapters plan round-trip', () => {
+  it('hydrates a definition with a plan into designer state', () => {
+    const history = notebookDefinitionToDesignerHistory({
+      ...createDefinition(),
+      plan: countedPlan,
+    });
+    expect(history.plan).toEqual(countedPlan);
+  });
+
+  it('hydrates a definition without a plan as null', () => {
+    const history = notebookDefinitionToDesignerHistory(createDefinition());
+    expect(history.plan).toBeNull();
+  });
+
+  it('keeps the plan through an edit and export', () => {
+    // Saving a design must not strip the plan the notebook was created with
+    const history = notebookDefinitionToDesignerHistory({
+      ...createDefinition(),
+      plan: countedPlan,
+    });
+    const edited = {
+      ...history,
+      uiSpec: {...history.uiSpec, present: {...history.uiSpec.present}},
+    };
+    expect(designerHistoryToNotebookDefinition(edited).plan).toEqual(
+      countedPlan
+    );
+  });
+
+  it('omits the plan key entirely when null', () => {
+    const exported = designerHistoryToNotebookDefinition(
+      notebookDefinitionToDesignerHistory(createDefinition())
+    );
+    expect('plan' in exported).toBe(false);
   });
 });

--- a/web/src/designer/integration/notebookAdapters.ts
+++ b/web/src/designer/integration/notebookAdapters.ts
@@ -63,6 +63,7 @@ export const notebookDefinitionToDesignerHistory = (
     future: [],
   },
   planTemplate: definition.planTemplate ?? null,
+  plan: definition.plan ?? null,
 });
 
 /** Flat definition for API PUT / export (present UI spec only). */
@@ -73,4 +74,7 @@ export const designerHistoryToNotebookDefinition = (
   uiSpec: notebook.uiSpec.present,
   // null becomes an absent key so saved JSON stays clean
   ...(notebook.planTemplate ? {planTemplate: notebook.planTemplate} : {}),
+  // Carried through untouched: the designer does not author an instantiated
+  // plan, and dropping it here would strip it from the saved notebook
+  ...(notebook.plan ? {plan: notebook.plan} : {}),
 });

--- a/web/src/designer/integration/notebookAdapters.ts
+++ b/web/src/designer/integration/notebookAdapters.ts
@@ -16,7 +16,6 @@
  * @file Map API/template records into the designer's `NotebookWithHistory` shape.
  */
 
-import type {NotebookDefinition} from '@faims3/data-model';
 import type {
   Notebook,
   NotebookUISpec,
@@ -26,6 +25,7 @@ import {
   normalizeApiUiSpecification,
   type NormalizeApiUiSpecificationResult,
   tryNormalizeApiUiSpecification,
+  DesignerDocumentMode,
 } from './legacyNotebook';
 
 export type {NormalizeApiUiSpecificationResult};
@@ -41,19 +41,20 @@ type ApiRecordWithUiSpecification = {
  * `NotebookWithHistory` shape (present-only undo stack).
  */
 export const toDesignerNotebookWithHistory = (
-  record?: ApiRecordWithUiSpecification
+  record?: ApiRecordWithUiSpecification,
+  mode: DesignerDocumentMode = 'project'
 ): NotebookWithHistory | undefined => {
   if (!record?.uiSpecification) {
     return undefined;
   }
 
-  const definition = normalizeApiUiSpecification(record.uiSpecification);
+  const definition = normalizeApiUiSpecification(record.uiSpecification, mode);
   return notebookDefinitionToDesignerHistory(definition);
 };
 
 /** Wrap a normalized definition for Redux (empty undo stacks). */
 export const notebookDefinitionToDesignerHistory = (
-  definition: NotebookDefinition
+  definition: Notebook
 ): NotebookWithHistory => ({
   metadata: definition.metadata,
   uiSpec: {
@@ -61,6 +62,7 @@ export const notebookDefinitionToDesignerHistory = (
     past: [],
     future: [],
   },
+  planTemplate: definition.planTemplate ?? null,
 });
 
 /** Flat definition for API PUT / export (present UI spec only). */
@@ -69,4 +71,6 @@ export const designerHistoryToNotebookDefinition = (
 ): Notebook => ({
   metadata: notebook.metadata,
   uiSpec: notebook.uiSpec.present,
+  // null becomes an absent key so saved JSON stays clean
+  ...(notebook.planTemplate ? {planTemplate: notebook.planTemplate} : {}),
 });

--- a/web/src/designer/plans.tsx
+++ b/web/src/designer/plans.tsx
@@ -1,0 +1,118 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Designer registry of plan types: maps each planType to its label,
+ * description, and authoring dialog. Mirrors the runtime plan registry in
+ * @faims3/data-model (plans/registry.ts): a Map with lazy built-in
+ * installation, so external modules can register additional plan types
+ * alongside their data-model registration.
+ */
+
+import type {ComponentType} from 'react';
+import type {PlanTemplate} from '@faims3/data-model';
+import {COUNTED_PLAN_TYPE, LIST_OF_RECORDS_PLAN_TYPE} from '@faims3/data-model';
+import {CountedPlanDialog} from './components/plans/CountedPlanDialog';
+import {ListOfRecordsPlanDialog} from './components/plans/ListOfRecordsPlanDialog';
+
+/**
+ * The uiSpec slice plan dialogs read. Structural, not the designer's
+ * NotebookUISpec, so external plan types can implement it.
+ */
+export type PlanDialogUiSpec = {
+  viewsets: Record<string, {label: string; views: string[]} | undefined>;
+  views: Record<string, {fields: string[]} | undefined>;
+  fields: Record<
+    string,
+    {'component-parameters'?: {label?: unknown}} | undefined
+  >;
+};
+
+/** Common props for every plan authoring dialog. */
+export type PlanDialogProps = {
+  open: boolean;
+  /** Forms and fields the dialog picks plan targets from. */
+  uiSpec: PlanDialogUiSpec;
+  /** Present when editing an existing plan template; absent when creating. */
+  initialTemplate?: PlanTemplate;
+  onClose: () => void;
+  /** Called with a schema-valid plan template; the caller stores it and closes. */
+  onSave: (planTemplate: PlanTemplate) => void;
+};
+
+export type DesignerPlanType = {
+  planType: string;
+  label: string;
+  description: string;
+  Dialog: ComponentType<PlanDialogProps>;
+};
+
+export type DesignerPlanRegistry = Map<string, DesignerPlanType>;
+
+export const createDesignerPlanRegistry = (): DesignerPlanRegistry => new Map();
+
+// Default registry used at runtime; injectable for testing, as in data-model
+const defaultRegistry = createDesignerPlanRegistry();
+let builtInsInstalled = false;
+
+export const registerDesignerPlanType = (
+  definition: DesignerPlanType,
+  registry: DesignerPlanRegistry = defaultRegistry
+) => {
+  if (registry.has(definition.planType)) {
+    throw new Error(
+      `Designer plan type ${definition.planType} is already registered`
+    );
+  }
+  registry.set(definition.planType, definition);
+};
+
+const builtInDesignerPlanTypes: DesignerPlanType[] = [
+  {
+    planType: COUNTED_PLAN_TYPE,
+    label: 'Counted',
+    description:
+      'Collect a set number of records of one form. The number required is chosen when a notebook is created from this template.',
+    Dialog: CountedPlanDialog,
+  },
+  {
+    planType: LIST_OF_RECORDS_PLAN_TYPE,
+    label: 'List of Records',
+    description:
+      'Collect records against a pre-defined list. Choose the form and which of its fields the list pre-fills; the list itself is supplied when a notebook is created.',
+    Dialog: ListOfRecordsPlanDialog,
+  },
+];
+
+// Built-ins install lazily on first lookup, matching data-model's registry
+const installBuiltIns = (registry: DesignerPlanRegistry) => {
+  if (registry === defaultRegistry && builtInsInstalled) return;
+  builtInDesignerPlanTypes.forEach(d => registerDesignerPlanType(d, registry));
+  if (registry === defaultRegistry) builtInsInstalled = true;
+};
+
+export const getDesignerPlanType = (
+  planType: string,
+  registry: DesignerPlanRegistry = defaultRegistry
+): DesignerPlanType | undefined => {
+  if (registry === defaultRegistry) installBuiltIns(registry);
+  return registry.get(planType);
+};
+
+export const getDesignerPlanTypes = (
+  registry: DesignerPlanRegistry = defaultRegistry
+): DesignerPlanType[] => {
+  if (registry === defaultRegistry) installBuiltIns(registry);
+  return [...registry.values()];
+};

--- a/web/src/designer/state/initial.ts
+++ b/web/src/designer/state/initial.ts
@@ -27,8 +27,10 @@ import {
   type NotebookInformation,
   type NotebookMetadata,
   type NotebookSettings,
+  type PlanTemplate,
 } from '@faims3/data-model';
 import {ConditionType} from '../types/condition';
+import type {DesignerDocumentMode} from '../integration';
 
 export {CURRENT_NOTEBOOK_UI_SCHEMA_VERSION};
 export type {
@@ -37,6 +39,7 @@ export type {
   NotebookMetadata,
   NotebookSettings,
 };
+export type {DesignerDocumentMode};
 
 /**
  * The component-parameters envelope shared by every designer field.
@@ -110,15 +113,18 @@ export type NotebookUISpec = {
 export type AppState = {
   modified: boolean;
   notebook: NotebookWithHistory;
+  mode: DesignerDocumentMode;
 };
 
 /** Flat notebook definition as persisted via PUT /uiSpecification. */
-export type Notebook = NotebookDefinition;
+export type Notebook = NotebookDefinition & {planTemplate?: PlanTemplate};
 
 /** Notebook with `uiSpec` wrapped for undo/redo in the designer. */
 export type NotebookWithHistory = {
   metadata: NotebookMetadata;
   uiSpec: StateWithHistory<NotebookUISpec>;
+  // null when absent; only templates carry a plan template
+  planTemplate: PlanTemplate | null;
 };
 
 export const defaultNotebookInformation = (): NotebookInformation => ({
@@ -151,5 +157,7 @@ export const initialState: AppState = {
       past: [],
       future: [],
     },
+    planTemplate: null,
   },
+  mode: 'project',
 };

--- a/web/src/designer/state/initial.ts
+++ b/web/src/designer/state/initial.ts
@@ -28,6 +28,7 @@ import {
   type NotebookMetadata,
   type NotebookSettings,
   type PlanTemplate,
+  type RegisteredPlan,
 } from '@faims3/data-model';
 import {ConditionType} from '../types/condition';
 import type {DesignerDocumentMode} from '../integration';
@@ -125,6 +126,9 @@ export type NotebookWithHistory = {
   uiSpec: StateWithHistory<NotebookUISpec>;
   // null when absent; only templates carry a plan template
   planTemplate: PlanTemplate | null;
+  // null when absent; only notebooks carry an instantiated plan, and the
+  // designer carries it through untouched rather than editing it
+  plan: RegisteredPlan | null;
 };
 
 export const defaultNotebookInformation = (): NotebookInformation => ({
@@ -158,6 +162,7 @@ export const initialState: AppState = {
       future: [],
     },
     planTemplate: null,
+    plan: null,
   },
   mode: 'project',
 };

--- a/web/src/designer/state/mode-reducer.ts
+++ b/web/src/designer/state/mode-reducer.ts
@@ -1,0 +1,29 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Read-only slice recording whether the designer is editing a notebook or a template.
+ */
+
+import {createSlice} from '@reduxjs/toolkit';
+import {initialState} from './initial';
+
+// Set once via preloadedState in createDesignerStore; never changes mid-session
+const modeReducer = createSlice({
+  name: 'mode',
+  initialState: initialState.mode,
+  reducers: {},
+});
+
+export default modeReducer.reducer;

--- a/web/src/designer/state/modifiedStatus-reducer.ts
+++ b/web/src/designer/state/modifiedStatus-reducer.ts
@@ -24,6 +24,7 @@ import {
   customFieldUpdated,
   informationUpdated,
 } from './metadata-reducer';
+import {planTemplateRemoved, planTemplateSet} from './planTemplate-reducer';
 import {
   fieldAdded,
   fieldDeleted,
@@ -75,7 +76,9 @@ const modifiedStatusReducer = createSlice({
       .addCase(viewSetDeleted, () => true)
       .addCase(viewSetMoved, () => true)
       .addCase(viewSetRenamed, () => true)
-      .addCase(formVisibilityUpdated, () => true);
+      .addCase(formVisibilityUpdated, () => true)
+      .addCase(planTemplateSet, () => true)
+      .addCase(planTemplateRemoved, () => true);
   },
 });
 

--- a/web/src/designer/state/plan-reducer.ts
+++ b/web/src/designer/state/plan-reducer.ts
@@ -1,0 +1,30 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Read-only slice holding a notebook's instantiated plan.
+ */
+
+import {createSlice} from '@reduxjs/toolkit';
+import {initialState} from './initial';
+
+// The designer never edits an instantiated plan, it only carries it through so
+// that saving a design does not drop it. Set via preloadedState on hydration.
+const planReducer = createSlice({
+  name: 'plan',
+  initialState: initialState.notebook.plan,
+  reducers: {},
+});
+
+export default planReducer.reducer;

--- a/web/src/designer/state/planTemplate-reducer.test.ts
+++ b/web/src/designer/state/planTemplate-reducer.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @file Tests for the planTemplate partition slice.
+ */
+import {describe, expect, it} from 'vitest';
+import reducer, {
+  planTemplateLoaded,
+  planTemplateRemoved,
+  planTemplateSet,
+} from './planTemplate-reducer';
+
+const countedTemplate = {planType: 'Counted', formType: 'FORM1'};
+
+describe('planTemplate reducer', () => {
+  it('has null initial state', () => {
+    expect(reducer(undefined, {type: 'noop'})).toBeNull();
+  });
+
+  it('replaces state with the payload on loaded', () => {
+    expect(reducer(null, planTemplateLoaded(countedTemplate))).toEqual(
+      countedTemplate
+    );
+  });
+
+  it('clears state on loaded with null', () => {
+    expect(reducer(countedTemplate, planTemplateLoaded(null))).toBeNull();
+  });
+
+  it('replaces an existing plan template wholesale on set', () => {
+    const replacement = {
+      planType: 'ListOfRecords',
+      formType: 'FORM2',
+      recordFields: ['field-a'],
+    };
+    expect(reducer(countedTemplate, planTemplateSet(replacement))).toEqual(
+      replacement
+    );
+  });
+
+  it('resets to null on removed', () => {
+    expect(reducer(countedTemplate, planTemplateRemoved())).toBeNull();
+  });
+});

--- a/web/src/designer/state/planTemplate-reducer.test.ts
+++ b/web/src/designer/state/planTemplate-reducer.test.ts
@@ -3,7 +3,6 @@
  */
 import {describe, expect, it} from 'vitest';
 import reducer, {
-  planTemplateLoaded,
   planTemplateRemoved,
   planTemplateSet,
 } from './planTemplate-reducer';
@@ -15,14 +14,10 @@ describe('planTemplate reducer', () => {
     expect(reducer(undefined, {type: 'noop'})).toBeNull();
   });
 
-  it('replaces state with the payload on loaded', () => {
-    expect(reducer(null, planTemplateLoaded(countedTemplate))).toEqual(
+  it('sets a plan template from nothing on set', () => {
+    expect(reducer(null, planTemplateSet(countedTemplate))).toEqual(
       countedTemplate
     );
-  });
-
-  it('clears state on loaded with null', () => {
-    expect(reducer(countedTemplate, planTemplateLoaded(null))).toBeNull();
   });
 
   it('replaces an existing plan template wholesale on set', () => {

--- a/web/src/designer/state/planTemplate-reducer.ts
+++ b/web/src/designer/state/planTemplate-reducer.ts
@@ -1,0 +1,43 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Plan template partition slice: optional planTemplate authored on templates.
+ */
+
+import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import type {PlanTemplate} from '@faims3/data-model';
+
+// null means no plan template; combineReducers cannot store undefined
+type PlanTemplateState = PlanTemplate | null;
+
+const planTemplateReducer = createSlice({
+  name: 'planTemplate',
+  initialState: null as PlanTemplateState,
+  reducers: {
+    /** Replace the plan template when hydrating the store from a template record. */
+    planTemplateLoaded: (_state, action: PayloadAction<PlanTemplateState>) =>
+      action.payload,
+    /** Set or replace the plan template from the designer UI. */
+    planTemplateSet: (_state, action: PayloadAction<PlanTemplate>) =>
+      action.payload,
+    /** Remove the plan template. */
+    planTemplateRemoved: () => null,
+  },
+});
+
+export const {planTemplateLoaded, planTemplateSet, planTemplateRemoved} =
+  planTemplateReducer.actions;
+
+export default planTemplateReducer.reducer;

--- a/web/src/designer/state/planTemplate-reducer.ts
+++ b/web/src/designer/state/planTemplate-reducer.ts
@@ -26,9 +26,6 @@ const planTemplateReducer = createSlice({
   name: 'planTemplate',
   initialState: null as PlanTemplateState,
   reducers: {
-    /** Replace the plan template when hydrating the store from a template record. */
-    planTemplateLoaded: (_state, action: PayloadAction<PlanTemplateState>) =>
-      action.payload,
     /** Set or replace the plan template from the designer UI. */
     planTemplateSet: (_state, action: PayloadAction<PlanTemplate>) =>
       action.payload,
@@ -37,7 +34,7 @@ const planTemplateReducer = createSlice({
   },
 });
 
-export const {planTemplateLoaded, planTemplateSet, planTemplateRemoved} =
+export const {planTemplateSet, planTemplateRemoved} =
   planTemplateReducer.actions;
 
 export default planTemplateReducer.reducer;

--- a/web/src/designer/store/selectors.ts
+++ b/web/src/designer/store/selectors.ts
@@ -53,3 +53,6 @@ export const selectVisibleTypes = (state: AppState) =>
 
 /** True after local edits until save/reset (see `modifiedStatus-reducer`). */
 export const selectModifiedFlag = (state: AppState) => state.modified;
+
+/** Whether this designer session edits a notebook or a template. */
+export const selectDesignerMode = (state: AppState) => state.mode;

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -14,4 +14,6 @@ interface ImportMetaEnv {
   readonly VITE_DELETE_ON_DEACTIVATION?: string;
   /** Comma-separated team Role enum values to hide from team-role dropdowns */
   readonly VITE_EXCLUDED_TEAM_ROLES?: string;
+  /** When false, hide Add Plan in the designer unless the template already has one */
+  readonly VITE_ENABLE_PLANS_IN_DESIGNER?: string;
 }


### PR DESCRIPTION
## Ticket

#2265

## Description

The notebook body is rendered by `NotebookComponent`, with no way for a notebook to ask for a different view. This adds the plan seam #2265 describes.

## Proposed Changes

- A plan type registry in the data model, with two built in types: Counted and List of Records.
- An optional `plan` on a notebook definition and an optional `planTemplate` on a template definition, both validated against the registry.
- `POST /api/notebooks` instantiates the template's plan template into the new notebook's plan, from a `planConfig` in the body.
- An optional `planReference` on a record, so a plan view can tell claimed plan entries from unclaimed ones.
- `NotebookView` resolves a view by the plan's `planType` and falls back to `NotebookComponent`.
- Template mode in the designer, the only mode that offers the plan template controls.

## Review notes

Not everything here is a straight port. These parts changed and are worth reading rather than skimming:

- `normalize.ts` runs one migrate-and-validate pass for notebooks and templates. The separate template path had lost the input size cap and validated its plan in a different order.
- `safeValidatePlanTemplate` returns `ValidationResult<PlanTemplate>` rather than `ValidationResult<Plan>`.
- The plan views no longer read a record's absence from the list as proof it does not exist. `CountedPlanView` holds off reporting the target as reached while the count may be understated, and `ListOfRecordsPlanView` offers Create Record only to a user who may create.
- The designer carries an instantiated `plan` through untouched, so a designer edit does not strip the plan from the saved notebook.
- Three doc comments were wrong and are corrected: `designerMode` on `DesignerDialogProps` described a filename, `PutUpdateTemplateUiSpecificationInput` said notebook where it is a template, and `notebookAdapters.ts` had a duplicated line.
- `createNotebookFromTemplate`'s doc comment is now three lines, to say that a template carrying a plan template needs a matching `planConfig`. Say if that is longer than you want and I will trim it.

## How to Test

Add `"plan": {"planType": "Counted", "formType": "Main", "numberRequired": 3, "allowExtraRecords": false}` next to `uiSpec` in `api/notebooks/e2e-minimal.json`, load it with `pnpm --filter @faims3/api load-projects`, and open it in the app. It shows a Counted Plan banner and a Planned tab rather than the usual record tabs.

## Additional Information

A notebook with no plan, or with a plan type that has no registered view, renders exactly as it does today.

The dashboard cannot collect a `planConfig` yet, so creating from a plan carrying template has to go through the API. The create form says so and disables submission rather than letting the request fail.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

