### PR TITLE
fix: keep the record list's identity stable across renders

### DIFF
--- a/api/src/couchdb/export/utils.ts
+++ b/api/src/couchdb/export/utils.ts
@@ -396,7 +396,7 @@ const CONTENT_DISPOSITION_FILENAME = /[^\w.-]/g;
  * Does not assume the filename input was pre-sanitised. Restricts the whole
  * filename to `[A-Za-z0-9._-]` so any input cannot terminate the quoted-string,
  * inject parameters, change the extension, or smuggle CR/LF into the header.
- * 
+ *
  * For security purposes this may perform some redundant sanitisation.
  */
 export const contentDispositionAttachment = (filename: string): string => {

--- a/app/src/gui/components/notebook/index.tsx
+++ b/app/src/gui/components/notebook/index.tsx
@@ -167,7 +167,7 @@ export default function NotebookComponent({project}: NotebookComponentProps) {
     uiSpecification,
     enabled: !!uiSpecification,
   });
-  const forceRecordRefresh = records.initialQuery.refetch;
+  const forceRecordRefresh = records.refetch;
 
   const templateId = useAppSelector(
     state => selectProjectById(state, project.projectId)?.templateId

--- a/app/src/utils/customHooks.test.ts
+++ b/app/src/utils/customHooks.test.ts
@@ -1,8 +1,11 @@
+import type {MinimalRecordMetadata} from '@faims3/data-model';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {act, renderHook} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {syncStateService} from '../context/slices/helpers/syncStateService';
 import type {SyncMode} from '../sync/syncMode';
-import {useIsRecordDownloadUnderway} from './customHooks';
+import {useIsRecordDownloadUnderway, useRecordList} from './customHooks';
 
 // The hook reads the sync state service, not the redux store, but importing
 // its module pulls the store in, which initialises its slices in the wrong
@@ -118,5 +121,80 @@ describe('useIsRecordDownloadUnderway', () => {
     expect(clearInterval).toHaveBeenCalledWith(intervalId);
     setInterval.mockRestore();
     clearInterval.mockRestore();
+  });
+});
+
+/**
+ * A caller memoising on this hook's result rebuilds that memo whenever the
+ * result changes identity, remounting whatever the memo built.
+ */
+describe('useRecordList', () => {
+  const projectId = 'test-project';
+
+  /**
+   * The key the hook builds with no search, no active user and no token, which
+   * is what the mocked store gives it.
+   */
+  const recordListKey = [
+    'allrecords',
+    projectId,
+    undefined,
+    true,
+    undefined,
+    undefined,
+    undefined,
+  ];
+
+  const record: MinimalRecordMetadata = {
+    projectId,
+    recordId: 'rec-1',
+    revisionId: 'frev-1',
+    type: 'Site',
+    created: new Date(0),
+    createdBy: 'tester',
+    updated: new Date(0),
+    updatedBy: 'tester',
+    conflicts: false,
+    deleted: false,
+  };
+
+  /** Render against a client, with the fetch gated off so only its cache reads. */
+  const renderRecordList = (client: QueryClient) =>
+    renderHook(
+      () =>
+        useRecordList({
+          projectId,
+          filterDeleted: true,
+          uiSpecification: undefined,
+          enabled: false,
+        }),
+      {
+        wrapper: ({children}: {children: ReactNode}) =>
+          createElement(QueryClientProvider, {client}, children),
+      }
+    );
+
+  it('holds its identity across renders once the list has loaded', () => {
+    const client = new QueryClient();
+    client.setQueryData(recordListKey, [record]);
+
+    const {result, rerender} = renderRecordList(client);
+    const first = result.current;
+    expect(first.allRecords).toEqual([record]);
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('holds its identity across renders before the list has loaded', () => {
+    // The empty fallback is where a fresh array per render would leak through
+    const {result, rerender} = renderRecordList(new QueryClient());
+    const first = result.current;
+    expect(first.isLoading).toBe(true);
+
+    rerender();
+
+    expect(result.current).toBe(first);
   });
 });

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -667,15 +667,29 @@ export const useRecordList = ({
     );
   }
 
-  // return both curated record lists and the underlying query where necessary
-  return {
-    allRecords: nonDraftRecords,
-    myRecords: myRecords,
-    otherRecords: otherRecords,
-    isLoading,
-    canReadAllRecords,
-    initialQuery: unhydratedRecordQuery,
-  };
+  // Memoized so an unchanged result set keeps its identity and a caller's own
+  // memos hold; a fresh object each render remounts whatever they build. The
+  // query's own result object is not identity stable, so this exposes its
+  // refetch (which is) rather than the query itself.
+  const refetch = unhydratedRecordQuery.refetch;
+  return useMemo(
+    () => ({
+      allRecords: nonDraftRecords,
+      myRecords: myRecords,
+      otherRecords: otherRecords,
+      isLoading,
+      canReadAllRecords,
+      refetch,
+    }),
+    [
+      nonDraftRecords,
+      myRecords,
+      otherRecords,
+      isLoading,
+      canReadAllRecords,
+      refetch,
+    ]
+  );
 };
 
 /** Poll interval for the in-memory per-project sync state. */

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -416,6 +416,9 @@ export function invalidateProjectRecordList({
   }
 }
 
+/** Shared empty list for a record query that has not loaded. */
+const NO_RECORDS: MinimalRecordMetadata[] = [];
+
 /**
  * Returns a list of all records, and active user records. This applies the
  * built in getMetadataForAllRecords filtering (which does client side
@@ -586,8 +589,9 @@ export const useRecordList = ({
    */
   const isLoading = unhydratedRecordQuery.data === undefined;
 
-  // Get all rows - defaulting to an empty list
-  const allRows = unhydratedRecordQuery.data ?? [];
+  // Get all rows - defaulting to an empty list. The fallback is shared so an
+  // unloaded query keeps the same identity across renders.
+  const allRows = unhydratedRecordQuery.data ?? NO_RECORDS;
 
   // Memoize the calculation of the non-draft rows
   const nonDraftRecords = useMemo(() => {
@@ -667,10 +671,8 @@ export const useRecordList = ({
     );
   }
 
-  // Memoized so an unchanged result set keeps its identity and a caller's own
-  // memos hold; a fresh object each render remounts whatever they build. The
-  // query's own result object is not identity stable, so this exposes its
-  // refetch (which is) rather than the query itself.
+  // Memoized so a caller's own memos hold over an unchanged result set. Exposes
+  // `refetch`, which is identity stable, rather than the query, which is not.
   const refetch = unhydratedRecordQuery.refetch;
   return useMemo(
     () => ({

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -583,7 +583,7 @@ export const useRecordList = ({
    * Whether the list has never loaded, so an empty list means "not known yet"
    * rather than "no records".
    *
-   * Deliberately not `initialQuery.isLoading`, which goes false when the
+   * Deliberately not the query's own `isLoading`, which goes false when the
    * initial fetch fails, presenting the empty fallback as a loaded, empty
    * list.
    */


### PR DESCRIPTION
## Ticket

None.

## Description

`useRecordList` returned a fresh object every render, so a caller memoising on it rebuilt that memo every render and remounted whatever it built. A component mounted that way loses the state it holds itself, such as a table's page, sort and typed search text.

## Proposed Changes

- The hook memoises its return, so an unchanged result set keeps its identity.
- It exposes `refetch` in place of the query object: a react-query result is not identity stable across renders, while its `refetch` is.
- The empty-list fallback for a query that has not loaded is a shared constant, so the memos below it hold before the first fetch lands too.

## How to Test

`pnpm --filter @faims3/app test`. The notebook's record tabs should behave unchanged: records list, the refresh button still refetches, and tab switching keeps its state.

## Additional Information

Stacked on #2263 and merges it, so review that one first. GitHub will retarget this to `main` when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
