### PR TITLE
fix: pin trapeze project build package at 7.1.8 so that we don't get trust downgrade errors

### DIFF
--- a/app/bin/prebuildConfig.sh
+++ b/app/bin/prebuildConfig.sh
@@ -46,10 +46,10 @@ THEME=${VITE_THEME:-default}
 
 echo "Generating assets for ${THEME} theme"
 
-pnpm dlx sssf-capacitor-assets generate --assetPath "./public/base-assets/${THEME}" \
-  --pwaManifestPath ./public/manifest.json \
-  --iconBackgroundColorDark '#001d34' \
-  --splashBackgroundColorDark '#001d34'
+pnpm exec capacitor-assets generate --assetPath "./public/base-assets/${THEME}" \
+    --pwaManifestPath ./public/manifest.json \
+    --iconBackgroundColorDark '#001d34' \
+    --splashBackgroundColorDark '#001d34'
 
 ## capacitor-assets can put the pwa icons in the wrong place sometimes
 if test -f icons/icon-192.png; then

--- a/app/package.json
+++ b/app/package.json
@@ -134,6 +134,7 @@
     "jss": "^10.10.0",
     "msw": "^2.3.1",
     "node-gyp": "^9.3.1",
+    "sssf-capacitor-assets": "4.1.5",
     "type-fest": "^4.20.0",
     "typescript": "^7.0.2",
     "vite": "^7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   level: ^7.0.0
   sharp: ^0.34.2
+  sssf-capacitor-assets>@trapezedev/project: 7.1.8
 
 importers:
 
@@ -576,6 +577,9 @@ importers:
       node-gyp:
         specifier: ^9.3.1
         version: 9.4.1(supports-color@8.1.1)
+      sssf-capacitor-assets:
+        specifier: 4.1.5
+        version: 4.1.5(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2)
       type-fest:
         specifier: ^4.20.0
         version: 4.41.0
@@ -4891,8 +4895,14 @@ packages:
   '@trapezedev/gradle-parse@7.1.3':
     resolution: {integrity: sha512-WQVF5pEJ5o/mUyvfGTG9nBKx9Te/ilKM3r2IT69GlbaooItT5ao7RyF1MUTBNjHLPk/xpGUY3c6PyVnjDlz0Vw==}
 
+  '@trapezedev/gradle-parse@7.1.8':
+    resolution: {integrity: sha512-7esS5gyDbxF4B2g0lzIioG6zEnsAqbao41VblO26ehOWHkK7Z87Fv5+KoSdZPpCtoz3QQYsr1W8/pXZS4cAqtA==}
+
   '@trapezedev/project@7.1.4':
     resolution: {integrity: sha512-b5rszBgT5XiRp/m4V2S2Ara2fdFXhPiduxhvCIVTSHq51PgLBjiTEStL6NbUz3V0K5bebF971O+SLRtyBxfCNA==}
+
+  '@trapezedev/project@7.1.8':
+    resolution: {integrity: sha512-4AoDe0lTL4mfaHDj7v6hoy3F2Bc6/N1d2HfbKicATRo0tqF6o0zX/GC3tJcbEA1/ymqMasM/7Dwf4ukGrD/gkg==}
 
   '@ts-graphviz/adapter@2.0.6':
     resolution: {integrity: sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==}
@@ -5738,10 +5748,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@zarrita/storage@0.2.0':
     resolution: {integrity: sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==}
@@ -6497,6 +6509,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -6586,6 +6602,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -7879,6 +7899,10 @@ packages:
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
 
   fs-extra@9.1.0:
@@ -11446,6 +11470,11 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  sssf-capacitor-assets@4.1.5:
+    resolution: {integrity: sha512-+GyexC0dVcmxtP2XRnjUrrxt06a5wx3+jBQeplHoY6J5Ai40hjzPogFFlC5lv1uDmiaFeBMrl7iSRhOthLL35A==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
   stack-generator@2.0.10:
     resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
 
@@ -12678,6 +12707,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -12693,6 +12726,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -13232,7 +13269,7 @@ snapshots:
     dependencies:
       '@ionic/cli-framework-output': 2.2.8
       '@ionic/utils-fs': 3.1.7
-      '@ionic/utils-subprocess': 2.1.14(supports-color@8.1.1)
+      '@ionic/utils-subprocess': 2.1.14
       '@ionic/utils-terminal': 2.3.5
       commander: 9.5.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -14174,17 +14211,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ionic/utils-process@2.1.11(supports-color@8.1.1)':
-    dependencies:
-      '@ionic/utils-object': 2.1.6
-      '@ionic/utils-terminal': 2.3.4
-      debug: 4.4.3(supports-color@8.1.1)
-      signal-exit: 3.0.7
-      tree-kill: 1.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@ionic/utils-process@2.1.12(supports-color@8.1.1)':
     dependencies:
       '@ionic/utils-object': 2.1.6
@@ -14199,13 +14225,6 @@ snapshots:
   '@ionic/utils-stream@3.1.6':
     dependencies:
       debug: 4.4.3
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ionic/utils-stream@3.1.6(supports-color@8.1.1)':
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -14226,19 +14245,6 @@ snapshots:
       '@ionic/utils-terminal': 2.3.4
       cross-spawn: 7.0.6
       debug: 4.4.3
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ionic/utils-subprocess@2.1.14(supports-color@8.1.1)':
-    dependencies:
-      '@ionic/utils-array': 2.1.6
-      '@ionic/utils-fs': 3.1.7
-      '@ionic/utils-process': 2.1.11(supports-color@8.1.1)
-      '@ionic/utils-stream': 3.1.6(supports-color@8.1.1)
-      '@ionic/utils-terminal': 2.3.4
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -16624,6 +16630,8 @@ snapshots:
 
   '@trapezedev/gradle-parse@7.1.3': {}
 
+  '@trapezedev/gradle-parse@7.1.8': {}
+
   '@trapezedev/project@7.1.4(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2)':
     dependencies:
       '@ionic/utils-fs': 3.1.7
@@ -16643,6 +16651,38 @@ snapshots:
       prettier: 2.8.8
       prompts: 2.4.2
       replace: 1.2.2
+      tempy: 3.2.0
+      tmp: 0.2.7
+      ts-node: 10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2)
+      xcode: 3.0.1
+      xml-js: 1.6.11
+      xpath: 0.0.32
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+
+  '@trapezedev/project@7.1.8(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2)':
+    dependencies:
+      '@ionic/utils-fs': 3.1.7
+      '@ionic/utils-subprocess': 2.1.14
+      '@prettier/plugin-xml': 2.2.0
+      '@trapezedev/gradle-parse': 7.1.8
+      '@xmldom/xmldom': 0.9.10
+      conventional-changelog: 3.1.25
+      cross-spawn: 7.0.6
+      diff: 5.2.2
+      env-paths: 3.0.0
+      gradle-to-js: 2.0.1
+      ini: 2.0.0
+      kleur: 4.1.5
+      lodash: 4.18.1
+      plist: 3.1.1
+      prettier: 2.8.8
+      prompts: 2.4.2
       tempy: 3.2.0
       tmp: 0.2.7
       ts-node: 10.9.2(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2)
@@ -17410,7 +17450,7 @@ snapshots:
   '@vitest/browser-webdriverio@4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@7.0.2))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)(webdriverio@9.27.2)':
     dependencies:
       '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@7.0.2))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@4.1.10)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@7.0.2))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@7.0.2))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       webdriverio: 9.27.2
     transitivePeerDependencies:
       - bufferutil
@@ -17480,7 +17520,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@4.1.10)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@7.0.2))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/browser-webdriverio@4.1.8)(@vitest/coverage-v8@2.1.9)(jsdom@22.1.0)(msw@2.14.6(@types/node@24.13.1)(typescript@7.0.2))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -18836,6 +18876,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clone@1.0.4: {}
 
   clone@2.1.2: {}
@@ -18917,6 +18963,8 @@ snapshots:
   commander@12.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@4.1.1: {}
 
@@ -20441,6 +20489,12 @@ snapshots:
       universalify: 2.0.1
 
   fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@11.4.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
@@ -24977,6 +25031,29 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  sssf-capacitor-assets@4.1.5(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2):
+    dependencies:
+      '@ionic/cli-framework-output': 2.2.8
+      '@ionic/utils-array': 2.1.6
+      '@ionic/utils-fs': 3.1.7
+      '@ionic/utils-subprocess': 2.1.14
+      '@ionic/utils-terminal': 2.3.5
+      '@trapezedev/project': 7.1.8(@swc/core@1.15.40)(@types/node@24.13.1)(typescript@7.0.2)
+      commander: 15.0.0
+      debug: 4.4.3
+      fs-extra: 11.4.0
+      kleur: 4.1.5
+      prompts: 2.4.2
+      sharp: 0.34.5
+      tslib: 2.8.1
+      yargs: 18.1.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+
   stack-generator@2.0.10:
     dependencies:
       stackframe: 1.3.4
@@ -26315,6 +26392,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs-unparser@2.0.0:
     dependencies:
       camelcase: 6.3.0
@@ -26355,6 +26434,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.1
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ ignoreScripts: true
 overrides:
   'level': '^7.0.0'
   'sharp': '^0.34.2'
+  # 7.1.9 was published without trusted-publisher evidence; sssf-capacitor-assets asks for ^7.1.9
+  'sssf-capacitor-assets>@trapezedev/project': '7.1.8'
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
Pin by installing package explicitly with peer dep override then using pnpm exec instead of dlx. 

Alternatively we could exclude from the trust downgrade policy?