### PR TITLE
feat: Reference parent and related record values in field and section conditions

### DIFF
--- a/app/src/gui/pages/viewRecord.tsx
+++ b/app/src/gui/pages/viewRecord.tsx
@@ -25,6 +25,10 @@ import {
   RecordID,
   RevisionHistoryEntry,
   formatTimestamp,
+  getRecordContextFromRecord,
+  RecordContext,
+  resolveParentValues,
+  resolveRelatedValues,
 } from '@faims3/data-model';
 import {
   DataView,
@@ -215,6 +219,7 @@ const InfoTabContent: React.FC<InfoTabContentProps> = ({
 interface ViewTabContentProps {
   /** The notebook tab this page sits under, which its record links stay on. */
   notebook: RecordRouteNotebook;
+  recordId: RecordID;
   formData: NonNullable<
     Awaited<ReturnType<DataEngine['form']['getExistingFormData']>>
   >;
@@ -238,8 +243,35 @@ const ViewTabContent: React.FC<ViewTabContentProps> = ({
   getDataEngine,
   getAttachmentService,
   isDeleted,
+  recordId,
 }) => {
   const nav = useNavigate();
+
+  // Resolve parent and linked-record values so field/section conditions
+  // referencing them evaluate correctly. Until resolved, conditions see
+  // missing values, matching previous behaviour.
+  const {data: recordContext} = useQuery({
+    queryKey: ['recordContext', recordId, formData.formId],
+    queryFn: async (): Promise<RecordContext> => {
+      const engine = getDataEngine();
+      const parentValues = await resolveParentValues({
+        engine,
+        recordId,
+        formId: formData.formId,
+      });
+      const relatedValues = await resolveRelatedValues({
+        engine,
+        values: formData.data,
+        formId: formData.formId,
+      });
+      return {
+        ...getRecordContextFromRecord({record: formData.context.record}),
+        parentValues: parentValues ?? undefined,
+        relatedValues,
+      };
+    },
+    networkMode: 'always',
+  });
 
   const nestedEditButton: React.FC<{recordId: string}> = isDeleted
     ? () => null
@@ -270,6 +302,7 @@ const ViewTabContent: React.FC<ViewTabContentProps> = ({
     uiSpecification: uiSpec,
     formData: formData.data,
     hrid: formData.context.hrid,
+    context: recordContext,
     tools: {
       getAttachmentService,
       getDataEngine,
@@ -327,6 +360,7 @@ const ViewTabContent: React.FC<ViewTabContentProps> = ({
         data={formData.data}
         formId={formData.formId}
         uiSpec={uiSpec}
+        context={recordContext}
       />
       {
         // Edit button below progress bar
@@ -684,6 +718,7 @@ export const ViewRecordPage: React.FC = () => {
           <ViewTabContent
             notebook={notebook}
             formData={formData}
+            recordId={recordId}
             onEditRecord={() => {
               nav(getEditRecordRoute({...notebook, recordId, mode: 'parent'}));
             }}

--- a/docs/user/authoring/conditions.md
+++ b/docs/user/authoring/conditions.md
@@ -108,3 +108,29 @@ refers to.
 
 The 'Add Another Condition' button below a complex condition will add a new clause
 into an existing 'or' or 'and' condition.
+
+## Referencing Parent and Linked Record Values
+
+Conditions can compare against values from outside the current record,
+using the same references available in Templated Strings and computed
+fields.
+
+When the form is a child of another form, a condition can test a field
+on the record's parent. These appear in the condition's field picker as
+_Parent › Field Name_, and are stored using the `_PARENT.` prefix, e.g.
+`_PARENT.Site-Name`.
+
+When the form holds a
+[Related Records](../field-types/relationship-fields/related-records.md)
+field with a **Linked** relation that allows only a single link, a
+condition can test a field on the linked record. These appear in the
+field picker as _Link Field Name › Field Name_.
+
+All operators work with these references exactly as they do with the
+form's own fields. When the referenced value is not available — the
+record has no parent, no record is linked, or the field is empty — the
+condition behaves as it would for an empty local field: for example,
+**equal** does not match and **not-equal** does.
+
+While a record is being edited, conditions re-evaluate automatically if
+the linked record is changed.

--- a/docs/user/field-types/number-fields/computed-number-field.md
+++ b/docs/user/field-types/number-fields/computed-number-field.md
@@ -105,6 +105,9 @@ the record is next opened or saved; if the parent changes in the
 meantime, the stored value reflects the parent as of the record's last
 save.
 
+The same reference can be used in
+[field and section conditions](../../authoring/conditions.md).
+
 ### Referencing Linked Record Values
 
 When the form holds a
@@ -129,6 +132,9 @@ blank. The value updates while editing whenever the link is changed,
 and otherwise re-derives when the record is opened or saved — if the
 linked record changes in the meantime, the stored value reflects it as
 of this record's last save.
+
+The same reference can be used in
+[field and section conditions](../../authoring/conditions.md).
 
 ### Shared Field Options
 

--- a/docs/user/field-types/text-fields/computed-text-field.md
+++ b/docs/user/field-types/text-fields/computed-text-field.md
@@ -107,6 +107,9 @@ the record is next opened or saved; if the parent changes in the
 meantime, the stored value reflects the parent as of the record's last
 save.
 
+The same reference can be used in
+[field and section conditions](../../authoring/conditions.md).
+
 ### Referencing Linked Record Values
 
 When the form holds a
@@ -131,6 +134,9 @@ blank. The value updates while editing whenever the link is changed,
 and otherwise re-derives when the record is opened or saved — if the
 linked record changes in the meantime, the stored value reflects it as
 of this record's last save.
+
+The same reference can be used in
+[field and section conditions](../../authoring/conditions.md).
 
 ### Shared Field Options
 

--- a/docs/user/field-types/text-fields/templated-string.md
+++ b/docs/user/field-types/text-fields/templated-string.md
@@ -86,6 +86,9 @@ If a record has no parent (for example, it was created directly from
 the record list), the parent reference renders as empty text and the
 rest of the template is unaffected.
 
+The same reference can be used in
+[field and section conditions](../../authoring/conditions.md).
+
 ### Referencing Linked Record Values
 
 When the form holds a
@@ -114,6 +117,9 @@ whenever the record is next opened or saved. If the parent is edited
 in the meantime, the stored value reflects the parent as of the
 record's last save — the same behaviour as the
 [Parent Field Value](../display-fields/parent-field-value.md) field.
+
+The same reference can be used in
+[field and section conditions](../../authoring/conditions.md).
 
 ### Shared Field Options
 

--- a/library/data-model/src/derivedFields/conditionValues.ts
+++ b/library/data-model/src/derivedFields/conditionValues.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: conditionValues.ts
+ * Description:
+ *   Builds the values object that field and section conditions evaluate
+ *   against: the form's own values plus raw parent and related record values
+ *   under their reference keys (_PARENT.<Field-ID> and
+ *   <Rel-Field-ID>.<Field-ID>).
+ */
+
+import {ValuesObject} from '../uiSpecification';
+import {encodeParentRef} from '../uiSpecification/parentReferences';
+import {encodeRelatedRef} from '../uiSpecification/relatedForms';
+import {RecordContext} from './recordContext';
+
+/**
+ * Merges parent and related record values from the record context into the
+ * form values, keyed as condition references. Values are raw (no coercion),
+ * so conditions treat them exactly as local field values: a field absent
+ * from the parent or linked record is absent from the result, giving each
+ * operator its usual missing-field behaviour. Local field IDs cannot contain
+ * dots and the _PARENT. prefix is reserved, so keys cannot collide.
+ */
+export function buildConditionValues({
+  values,
+  context,
+}: {
+  values: ValuesObject;
+  context?: RecordContext;
+}): ValuesObject {
+  const merged: ValuesObject = {...values};
+  if (context?.parentValues) {
+    for (const fieldId of Object.keys(context.parentValues)) {
+      merged[encodeParentRef(fieldId)] = context.parentValues[fieldId];
+    }
+  }
+  if (context?.relatedValues) {
+    for (const relFieldId of Object.keys(context.relatedValues)) {
+      const relValues = context.relatedValues[relFieldId];
+      for (const fieldId of Object.keys(relValues)) {
+        merged[encodeRelatedRef(relFieldId, fieldId)] = relValues[fieldId];
+      }
+    }
+  }
+  return merged;
+}

--- a/library/data-model/src/derivedFields/index.ts
+++ b/library/data-model/src/derivedFields/index.ts
@@ -1,4 +1,5 @@
 export * from './computedFields';
+export * from './conditionValues';
 export * from './parentFieldScan';
 export * from './recordContext';
 export * from './resolveParentField';

--- a/library/data-model/src/uiSpecification/relatedForms.ts
+++ b/library/data-model/src/uiSpecification/relatedForms.ts
@@ -94,6 +94,10 @@ export const getRelatedRecordFields = ({
   return fields;
 };
 
+/** Encodes a related reference (<Rel-Field-ID>.<Field-ID>). */
+export const encodeRelatedRef = (relFieldId: string, fieldId: string): string =>
+  `${relFieldId}${RELATED_REFERENCE_SEPARATOR}${fieldId}`;
+
 /**
  * Splits a dotted reference at its first separator into the Related Records
  * field ID and the field on the linked form. Null when there is no separator

--- a/library/data-model/tests/conditionValues.test.ts
+++ b/library/data-model/tests/conditionValues.test.ts
@@ -1,0 +1,163 @@
+import {
+  buildConditionValues,
+  compileExpression,
+  encodeParentRef,
+  encodeRelatedRef,
+} from '../src';
+
+describe('buildConditionValues', () => {
+  it('returns form values unchanged when there is no context', () => {
+    const values = {'Field-A': 1, 'Field-B': 'x'};
+    expect(buildConditionValues({values})).toEqual(values);
+  });
+
+  it('returns form values unchanged when context has no parent or related values', () => {
+    const values = {'Field-A': 1};
+    const context = {createdBy: 'someone', createdTime: 123};
+    expect(buildConditionValues({values, context})).toEqual(values);
+  });
+
+  it('merges parent values under _PARENT keys', () => {
+    const result = buildConditionValues({
+      values: {'Field-A': 1},
+      context: {parentValues: {'Site-Name': 'North', 'Grid-Square': 'A7'}},
+    });
+    expect(result).toEqual({
+      'Field-A': 1,
+      [encodeParentRef('Site-Name')]: 'North',
+      [encodeParentRef('Grid-Square')]: 'A7',
+    });
+  });
+
+  it('merges related values under dotted keys per link field', () => {
+    const result = buildConditionValues({
+      values: {'Field-A': 1},
+      context: {
+        relatedValues: {
+          'Core-Calibration': {'Cutter-Mass-g': 102.5},
+          'Other-Link': {Status: 'done'},
+        },
+      },
+    });
+    expect(result).toEqual({
+      'Field-A': 1,
+      [encodeRelatedRef('Core-Calibration', 'Cutter-Mass-g')]: 102.5,
+      [encodeRelatedRef('Other-Link', 'Status')]: 'done',
+    });
+  });
+
+  it('merges parent and related values together', () => {
+    const result = buildConditionValues({
+      values: {'Field-A': 1},
+      context: {
+        parentValues: {'Site-Name': 'North'},
+        relatedValues: {'Core-Calibration': {'Cutter-Mass-g': 102.5}},
+      },
+    });
+    expect(result[encodeParentRef('Site-Name')]).toBe('North');
+    expect(result[encodeRelatedRef('Core-Calibration', 'Cutter-Mass-g')]).toBe(
+      102.5
+    );
+    expect(result['Field-A']).toBe(1);
+  });
+
+  it('handles empty parent and related objects', () => {
+    const result = buildConditionValues({
+      values: {'Field-A': 1},
+      context: {parentValues: {}, relatedValues: {'Link-Field': {}}},
+    });
+    expect(result).toEqual({'Field-A': 1});
+  });
+
+  it('does not mutate the input values object', () => {
+    const values = {'Field-A': 1};
+    buildConditionValues({
+      values,
+      context: {parentValues: {'Site-Name': 'North'}},
+    });
+    expect(values).toEqual({'Field-A': 1});
+  });
+
+  it('copies values raw, without coercion', () => {
+    const result = buildConditionValues({
+      values: {},
+      context: {parentValues: {Tags: ['a', 'b'], Count: '3'}},
+    });
+    expect(result[encodeParentRef('Tags')]).toEqual(['a', 'b']);
+    // string stays a string, unlike expression coercion
+    expect(result[encodeParentRef('Count')]).toBe('3');
+  });
+});
+
+describe('conditions evaluated over merged values', () => {
+  const parentRef = encodeParentRef('Grid-Square');
+  const relatedRef = encodeRelatedRef('Core-Calibration', 'Status');
+
+  const merged = (
+    context?: Parameters<typeof buildConditionValues>[0]['context']
+  ) => buildConditionValues({values: {'Local-Field': 'yes'}, context});
+
+  it('equal matches a parent value', () => {
+    const fn = compileExpression({
+      operator: 'equal',
+      field: parentRef,
+      value: 'A7',
+    });
+    expect(fn(merged({parentValues: {'Grid-Square': 'A7'}}))).toBe(true);
+    expect(fn(merged({parentValues: {'Grid-Square': 'B2'}}))).toBe(false);
+  });
+
+  it('equal is false when there is no parent', () => {
+    const fn = compileExpression({
+      operator: 'equal',
+      field: parentRef,
+      value: 'A7',
+    });
+    expect(fn(merged())).toBe(false);
+  });
+
+  it('not-equal is true when there is no parent, matching missing-field semantics', () => {
+    const fn = compileExpression({
+      operator: 'not-equal',
+      field: parentRef,
+      value: 'A7',
+    });
+    expect(fn(merged())).toBe(true);
+  });
+
+  it('string-contains works on a related value', () => {
+    const fn = compileExpression({
+      operator: 'string-contains',
+      field: relatedRef,
+      value: 'cali',
+    });
+    expect(
+      fn(merged({relatedValues: {'Core-Calibration': {Status: 'calibrated'}}}))
+    ).toBe(true);
+    expect(fn(merged())).toBe(false);
+  });
+
+  it('contains works on a parent array value', () => {
+    const ref = encodeParentRef('Tags');
+    const fn = compileExpression({
+      operator: 'contains',
+      field: ref,
+      value: 'wet',
+    });
+    expect(fn(merged({parentValues: {Tags: ['wet', 'clay']}}))).toBe(true);
+    expect(fn(merged({parentValues: {Tags: ['dry']}}))).toBe(false);
+    expect(fn(merged())).toBe(false);
+  });
+
+  it('and combines local and parent references', () => {
+    const fn = compileExpression({
+      operator: 'and',
+      conditions: [
+        {operator: 'equal', field: 'Local-Field', value: 'yes'},
+        {operator: 'equal', field: parentRef, value: 'A7'},
+      ],
+    });
+    expect(fn(merged({parentValues: {'Grid-Square': 'A7'}}))).toBe(true);
+    expect(fn(merged({parentValues: {'Grid-Square': 'B2'}}))).toBe(false);
+  });
+});

--- a/library/forms/lib/formModule/formManagers/EditableFormManager.tsx
+++ b/library/forms/lib/formModule/formManagers/EditableFormManager.tsx
@@ -38,6 +38,7 @@ import {FormBreadcrumbs} from './navigation/NavigationBreadcrumbs';
 import {onChangeTemplatedFields} from './templatedFields';
 import {onChangeComputedFields} from './computedFields';
 import {
+  buildConditionValues,
   resolveParentValues,
   resolveRelatedValues,
   linkedRecordId,
@@ -167,7 +168,10 @@ export const EditableFormManager: React.FC<
   // ---------------------------------------------------------------------------
   const [visibleMap, setVisibleMap] = useState<FieldVisibilityMap>(
     currentlyVisibleMap({
-      values: formDataExtractor({fullData: props.initialData ?? {}}),
+      values: buildConditionValues({
+        values: formDataExtractor({fullData: props.initialData ?? {}}),
+        context: buildContext(),
+      }),
       uiSpec: dataEngine.uiSpec,
       viewsetId: props.formId,
     })
@@ -250,12 +254,15 @@ export const EditableFormManager: React.FC<
   const updateVisibility = useCallback(() => {
     setVisibleMap(
       currentlyVisibleMap({
-        values: formDataExtractor({fullData: form.state.values}),
+        values: buildConditionValues({
+          values: formDataExtractor({fullData: form.state.values}),
+          context: buildContext(),
+        }),
         uiSpec: dataEngine.uiSpec,
         viewsetId: props.formId,
       })
     );
-  }, [dataEngine.uiSpec, props.formId]);
+  }, [dataEngine.uiSpec, props.formId, buildContext]);
 
   const debouncedUpdateVisibility = useMemo(
     () => debounce(updateVisibility, VISIBILITY_DEBOUNCE_MS),
@@ -425,7 +432,9 @@ export const EditableFormManager: React.FC<
         existingSchema: validationSchema.current,
         formId: props.formId,
         uiSpec: dataEngine.uiSpec,
-        data,
+        // Merge parent/related values so visibility-aware recompilation
+        // sees conditions on them.
+        data: buildConditionValues({values: data, context: buildContext()}),
         config: {visibleBehaviour: 'ignore'},
       });
 
@@ -551,6 +560,9 @@ export const EditableFormManager: React.FC<
         setHasPendingSave(true);
         debouncedSave();
       }
+      // Conditions may reference parent values directly - refresh visibility
+      // now that they are resolved.
+      updateVisibility();
     });
     return () => {
       cancelled = true;

--- a/library/forms/lib/formModule/formManagers/components/FormProgress.tsx
+++ b/library/forms/lib/formModule/formManagers/components/FormProgress.tsx
@@ -1,6 +1,8 @@
 import {
+  buildConditionValues,
   CompiledUiSpecModel,
   currentlyVisibleMap,
+  RecordContext,
   UiSpecModel,
 } from '@faims3/data-model';
 import {useStore} from '@tanstack/react-form';
@@ -41,6 +43,8 @@ interface StaticFormProgressProps {
   data: FaimsFormData;
   uiSpec: CompiledUiSpecModel;
   formId: string;
+  /** Record context so conditions can see parent/related values. */
+  context?: RecordContext;
 }
 
 /**
@@ -48,7 +52,10 @@ interface StaticFormProgressProps {
  */
 export const StaticFormProgress: React.FC<StaticFormProgressProps> = props => {
   const visMap = currentlyVisibleMap({
-    values: formDataExtractor({fullData: props.data}),
+    values: buildConditionValues({
+      values: formDataExtractor({fullData: props.data}),
+      context: props.context,
+    }),
     uiSpec: props.uiSpec,
     viewsetId: props.formId,
   });

--- a/library/forms/lib/rendering/DataView.tsx
+++ b/library/forms/lib/rendering/DataView.tsx
@@ -1,4 +1,5 @@
 import {
+  buildConditionValues,
   currentlyVisibleFields,
   FieldSummary,
   getNotebookFieldTypes,
@@ -50,10 +51,13 @@ export const DataView: React.FC<DataViewProps> = props => {
   const visibleFields = useMemo(() => {
     return currentlyVisibleFields({
       uiSpec: props.uiSpecification,
-      values: formDataExtractor({fullData: props.formData}),
+      values: buildConditionValues({
+        values: formDataExtractor({fullData: props.formData}),
+        context: props.context,
+      }),
       viewsetId: props.viewsetId,
     });
-  }, [props.uiSpecification, props.hydratedRecord]);
+  }, [props.uiSpecification, props.hydratedRecord, props.context]);
 
   return (
     <Stack spacing={2} sx={{padding: 2}}>

--- a/library/forms/lib/rendering/types.ts
+++ b/library/forms/lib/rendering/types.ts
@@ -6,6 +6,7 @@ import {
   FormUpdateData,
   HydratedRecordDocument,
   IAttachmentService,
+  RecordContext,
 } from '@faims3/data-model';
 import {MapConfig} from '../components/maps/types';
 
@@ -51,6 +52,8 @@ export interface DataViewProps {
   trace: DataViewTraceEntry[];
   // Controls/triggers
   tools: DataViewTools;
+  /** Record context so conditions can see parent/related values. */
+  context?: RecordContext;
 }
 
 // A renderer function component

--- a/library/forms/lib/validationModule/validation.test.ts
+++ b/library/forms/lib/validationModule/validation.test.ts
@@ -4,6 +4,9 @@ import {
   getFieldNamesForViewset,
   normalizeNotebookUiSpecification,
   type CompiledNotebookUiSpec,
+  buildConditionValues,
+  encodeParentRef,
+  encodeRelatedRef,
 } from '@faims3/data-model';
 import {describe, expect, it} from 'vitest';
 import {z} from 'zod';
@@ -104,6 +107,67 @@ describe('FormValidation', () => {
           config: {visibleBehaviour: 'ignore'},
         })
       ).toThrow('Data is required when visibleBehaviour is not "include"');
+    });
+  });
+
+  describe('getRelevantFields with parent and related references', () => {
+    // Clone the sample spec and repoint the conditional field's condition at
+    // a parent reference, then a related reference.
+    const specWithCondition = (field: string) => {
+      const {uiSpec: clone} = normalizeNotebookUiSpecification(
+        JSON.parse(JSON.stringify(sampleNotebook))
+      );
+      clone.fields['Female-conditional'].condition = {
+        operator: 'equal',
+        field,
+        value: 'match',
+      };
+      compileUiSpecConditionals(clone);
+      return clone as CompiledNotebookUiSpec;
+    };
+
+    it('includes a field conditioned on a parent value when context matches', () => {
+      const spec = specWithCondition(encodeParentRef('Grid-Square'));
+      const data = buildConditionValues({
+        values: SAMPLE_VALID_DATA,
+        context: {parentValues: {'Grid-Square': 'match'}},
+      });
+      const result = FormValidation.getRelevantFields({
+        uiSpec: spec,
+        formId: 'Person',
+        data,
+        config: {visibleBehaviour: 'ignore'},
+      });
+      expect(result).toContain('Female-conditional');
+    });
+
+    it('excludes a field conditioned on a parent value when there is no context', () => {
+      const spec = specWithCondition(encodeParentRef('Grid-Square'));
+      const data = buildConditionValues({values: SAMPLE_VALID_DATA});
+      const result = FormValidation.getRelevantFields({
+        uiSpec: spec,
+        formId: 'Person',
+        data,
+        config: {visibleBehaviour: 'ignore'},
+      });
+      expect(result).not.toContain('Female-conditional');
+    });
+
+    it('includes a field conditioned on a related value when context matches', () => {
+      const spec = specWithCondition(
+        encodeRelatedRef('Core-Calibration', 'Status')
+      );
+      const data = buildConditionValues({
+        values: SAMPLE_VALID_DATA,
+        context: {relatedValues: {'Core-Calibration': {Status: 'match'}}},
+      });
+      const result = FormValidation.getRelevantFields({
+        uiSpec: spec,
+        formId: 'Person',
+        data,
+        config: {visibleBehaviour: 'ignore'},
+      });
+      expect(result).toContain('Female-conditional');
     });
   });
 

--- a/web/src/designer/components/condition/ConditionRuleInputs.tsx
+++ b/web/src/designer/components/condition/ConditionRuleInputs.tsx
@@ -396,10 +396,11 @@ export type ConditionRuleInputsProps = {
 export const ConditionRuleInputs = (props: ConditionRuleInputsProps) => {
   const {rule, onChange, field, view, showLabels} = props;
 
-  const {allFields, fieldSearchScope} = useConditionRuleFieldContext({
-    field,
-    view,
-  });
+  const {allFields, fieldSearchScope, referenceEntries} =
+    useConditionRuleFieldContext({
+      field,
+      view,
+    });
 
   // Reference the operator input so the dropdown can match its width.
   const operatorControlRef = useRef<HTMLDivElement>(null);
@@ -466,6 +467,7 @@ export const ConditionRuleInputs = (props: ConditionRuleInputsProps) => {
           value={rule.field || null}
           onChange={fieldId => updateField(fieldId || '')}
           scope={fieldSearchScope}
+          extraEntries={referenceEntries}
           data-testid="field-input"
           label={showLabels ? 'Field' : undefined}
           placeholder="Field"

--- a/web/src/designer/components/condition/ConditionSummary.tsx
+++ b/web/src/designer/components/condition/ConditionSummary.tsx
@@ -27,6 +27,7 @@ import {
   type ConditionType,
 } from '../../types/condition';
 import {conditionBooleanOperatorColours} from '../designer-style';
+import {getConditionFieldLabel} from '../../../hooks/use-condition-field-context';
 
 /**
  * Renders a read-only preview of the current condition.
@@ -48,7 +49,7 @@ export const ConditionSummary = (props: ConditionSummaryProps) => {
    */
   const getFieldName = (fieldId: string | undefined) => {
     if (!fieldId) return 'Unknown field';
-    return allFields[fieldId] ? getFieldLabel(allFields[fieldId]) : fieldId;
+    return getConditionFieldLabel(fieldId, allFields);
   };
 
   return (

--- a/web/src/designer/components/field-selector/FieldSearchAutocomplete.tsx
+++ b/web/src/designer/components/field-selector/FieldSearchAutocomplete.tsx
@@ -8,6 +8,7 @@ import Autocomplete, {AutocompleteProps} from '@mui/material/Autocomplete';
 import {useEffect, useMemo} from 'react';
 import {
   buildFieldSearchEntry,
+  FieldSearchEntry,
   FieldSearchFilters,
   FieldSearchResult,
   FieldSearchScope,
@@ -87,6 +88,7 @@ export type FieldSearchAutocompleteProps = {
   clearOnEscape?: boolean;
   /** Clear the search input after a field is selected (for insert/picker use cases). */
   clearOnSelect?: boolean;
+  extraEntries?: FieldSearchEntry[];
 };
 
 /**
@@ -109,6 +111,7 @@ export const FieldSearchAutocomplete = ({
   size = 'medium',
   clearOnEscape = true,
   clearOnSelect = false,
+  extraEntries,
 }: FieldSearchAutocompleteProps) => {
   const allFields = useAppSelector(selectUiFields);
   const views = useAppSelector(selectUiViews);
@@ -118,12 +121,27 @@ export const FieldSearchAutocomplete = ({
       scope,
       filters,
       limit,
+      extraEntries,
     });
 
   const selectedResult = useMemo((): FieldSearchResult | null => {
     if (!value) return null;
     const fromResults = results.find(r => r.fieldId === value);
     if (fromResults) return fromResults;
+    // A selected reference entry (parent/related) isn't in the store -
+    // synthesize its row from the entry itself.
+    const fromExtra = extraEntries?.find(e => e.fieldId === value);
+    if (fromExtra) {
+      return {
+        fieldId: value,
+        field: fromExtra.field,
+        label: fromExtra.label,
+        helperText: fromExtra.helperText,
+        viewSetLabel: fromExtra.viewSetLabel,
+        sectionLabel: fromExtra.sectionLabel,
+        score: 0,
+      };
+    }
     // Selected id may be outside current search results — synthesize a display row.
     const field = allFields[value];
     if (!field) {

--- a/web/src/designer/features/field-search/fieldSearch.test.ts
+++ b/web/src/designer/features/field-search/fieldSearch.test.ts
@@ -143,4 +143,38 @@ describe('weightedFieldSearch', () => {
     const results = weightedFieldSearch(entries, 'field-b');
     expect(results[0]?.fieldId).toBe('field-b');
   });
+
+  test('lists synthetic reference entries alongside store fields for empty query', () => {
+    const parentEntry = {
+      ...buildFieldSearchEntry('field-a', allFields['field-a']),
+      fieldId: '_PARENT.Site-Name',
+      id: '_PARENT.Site-Name',
+      label: 'Parent › Site Name',
+      viewSetLabel: 'Parent record',
+      sectionLabel: '',
+    };
+    const entries = [
+      buildFieldSearchEntry('field-b', allFields['field-b']),
+      parentEntry,
+    ];
+    const results = weightedFieldSearch(entries, '');
+    expect(results.map(r => r.fieldId)).toContain('_PARENT.Site-Name');
+  });
+
+  test('matches synthetic reference entries by label', () => {
+    const relatedEntry = {
+      ...buildFieldSearchEntry('field-a', allFields['field-a']),
+      fieldId: 'Core-Calibration.Cutter-Mass-g',
+      id: 'Core-Calibration.Cutter-Mass-g',
+      label: 'Core Calibration › Cutter Mass g',
+      viewSetLabel: 'Linked record',
+      sectionLabel: '',
+    };
+    const entries = [
+      buildFieldSearchEntry('field-b', allFields['field-b']),
+      relatedEntry,
+    ];
+    const results = weightedFieldSearch(entries, 'cutter mass');
+    expect(results[0]?.fieldId).toBe('Core-Calibration.Cutter-Mass-g');
+  });
 });

--- a/web/src/designer/features/field-search/types.ts
+++ b/web/src/designer/features/field-search/types.ts
@@ -66,4 +66,7 @@ export type UseFieldSearchOptions = {
   limit?: number;
   /** Debounce delay before running fuzzy search (default 200ms). */
   debounceMs?: number;
+  /** Extra synthetic entries (e.g. parent/related references) appended after
+   * scope resolution. Not subject to scope or filters. */
+  extraEntries?: FieldSearchEntry[];
 };

--- a/web/src/designer/features/field-search/useFieldSearch.ts
+++ b/web/src/designer/features/field-search/useFieldSearch.ts
@@ -42,6 +42,7 @@ export const useFieldSearch = (
     filters,
     limit = 50,
     debounceMs = DEFAULT_DEBOUNCE_MS,
+    extraEntries,
   } = options;
   const [query, setQuery] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
@@ -72,8 +73,11 @@ export const useFieldSearch = (
   );
 
   const entries = useMemo(
-    () => buildFieldSearchEntries(candidateIds, allFields, views, viewsets),
-    [candidateIds, allFields, views, viewsets]
+    () => [
+      ...buildFieldSearchEntries(candidateIds, allFields, views, viewsets),
+      ...(extraEntries ?? []),
+    ],
+    [candidateIds, allFields, views, viewsets, extraEntries]
   );
 
   const results = useMemo(
@@ -86,6 +90,6 @@ export const useFieldSearch = (
     setQuery,
     searchQuery,
     results,
-    candidateCount: candidateIds.length,
+    candidateCount: candidateIds.length + (extraEntries?.length ?? 0),
   };
 };

--- a/web/src/hooks/use-condition-field-context.ts
+++ b/web/src/hooks/use-condition-field-context.ts
@@ -13,6 +13,32 @@ import {
 import {useAppSelector} from '@/designer/state/hooks';
 import {selectUiViews, selectUiViewSets} from '@/designer/store/selectors';
 import {useMemo} from 'react';
+import {getFieldLabel} from '@/lib/conditionUtils';
+import type {FieldType} from '@/designer/state/initial';
+
+/**
+ * Display label for a condition field reference: local field, parent
+ * reference (_PARENT.X) or related reference (Rel.X). Falls back to the
+ * raw ID when nothing resolves.
+ */
+export const getConditionFieldLabel = (
+  fieldId: string,
+  allFields: Record<string, FieldType>
+): string => {
+  const local = allFields[fieldId];
+  if (local) return getFieldLabel(local) ?? fieldId;
+  const labelFor = (id: string) =>
+    (allFields[id]?.['component-parameters']?.label as string) ?? id;
+  const parentField = decodeParentRef(fieldId);
+  if (parentField !== null) {
+    return `Parent › ${labelFor(parentField)}`;
+  }
+  const parts = splitRelatedReference(fieldId);
+  if (parts) {
+    return `${labelFor(parts.relFieldId)} › ${labelFor(parts.fieldId)}`;
+  }
+  return fieldId;
+};
 
 /**
  * Gets the field search scope and selectable field state for a condition rule.

--- a/web/src/hooks/use-condition-field-context.ts
+++ b/web/src/hooks/use-condition-field-context.ts
@@ -1,6 +1,14 @@
 import {
+  buildParentFieldTypes,
+  buildRelatedFieldTypes,
+  decodeParentRef,
+  splitRelatedReference,
+  UiSpecModel,
+} from '@faims3/data-model';
+import {
   FieldSearchScope,
   resolveFieldIdsInScope,
+  FieldSearchEntry,
 } from '@/designer/features/field-search';
 import {useAppSelector} from '@/designer/state/hooks';
 import {selectUiViews, selectUiViewSets} from '@/designer/store/selectors';
@@ -43,6 +51,81 @@ export const useConditionRuleFieldContext = (props: {
     return {kind: 'all'};
   }, [props.view, props.field]);
 
+  // Resolve the form this condition belongs to, matching the scope logic:
+  // a section condition names its section; a field condition names a field
+  // whose section we look up.
+  const viewsetId = useMemo(() => {
+    let sectionId = props.view;
+    if (!sectionId && props.field) {
+      sectionId = Object.keys(views).find(v =>
+        views[v].fields.includes(props.field!)
+      );
+    }
+    if (!sectionId) return undefined;
+    return Object.keys(viewsets).find(vs =>
+      viewsets[vs].views.includes(sectionId!)
+    );
+  }, [props.view, props.field, views, viewsets]);
+
+  const fieldLabelFor = (fieldId: string) =>
+    (allFields[fieldId]?.['component-parameters']?.label as string) ?? fieldId;
+
+  // Parent and linked-record references selectable in conditions, plus an
+  // overlay resolving each reference to its underlying field definition so
+  // operator filtering and value editors treat them like local fields.
+  const {referenceEntries, referenceFieldDefs} = useMemo(() => {
+    const entries: FieldSearchEntry[] = [];
+    const defs: typeof allFields = {};
+    if (!viewsetId)
+      return {referenceEntries: entries, referenceFieldDefs: defs};
+    const uiSpecification = {
+      fields: allFields,
+      views,
+      viewsets,
+    } as unknown as UiSpecModel;
+
+    const {types: parentTypes} = buildParentFieldTypes({
+      uiSpecification,
+      formId: viewsetId,
+    });
+    for (const ref of parentTypes.keys()) {
+      const fieldId = decodeParentRef(ref);
+      if (!fieldId || !allFields[fieldId]) continue;
+      defs[ref] = allFields[fieldId];
+      entries.push({
+        fieldId: ref,
+        field: allFields[fieldId],
+        label: `Parent › ${fieldLabelFor(fieldId)}`,
+        id: ref,
+        helperText: '',
+        advancedHelperText: '',
+        viewSetLabel: 'Parent record',
+        sectionLabel: '',
+      });
+    }
+
+    const {types: relatedTypes} = buildRelatedFieldTypes({
+      uiSpecification,
+      formId: viewsetId,
+    });
+    for (const ref of relatedTypes.keys()) {
+      const parts = splitRelatedReference(ref);
+      if (!parts || !allFields[parts.fieldId]) continue;
+      defs[ref] = allFields[parts.fieldId];
+      entries.push({
+        fieldId: ref,
+        field: allFields[parts.fieldId],
+        label: `${fieldLabelFor(parts.relFieldId)} › ${fieldLabelFor(parts.fieldId)}`,
+        id: ref,
+        helperText: '',
+        advancedHelperText: '',
+        viewSetLabel: 'Linked record',
+        sectionLabel: '',
+      });
+    }
+    return {referenceEntries: entries, referenceFieldDefs: defs};
+  }, [viewsetId, allFields, views, viewsets]);
+
   const selectableFieldCount = useMemo(
     () =>
       resolveFieldIdsInScope(allFields, views, viewsets, fieldSearchScope)
@@ -51,8 +134,9 @@ export const useConditionRuleFieldContext = (props: {
   );
 
   return {
-    allFields,
+    allFields: {...allFields, ...referenceFieldDefs},
     fieldSearchScope,
-    selectableFieldCount,
+    referenceEntries,
+    selectableFieldCount: selectableFieldCount + referenceEntries.length,
   };
 };


### PR DESCRIPTION
## Ticket

#2278

## Description

Follow-up to #2235 (parent references) and #2256 (related references), extending the same `_PARENT.Field` and `Link-Field.Field` references to the conditional logic controlling field and section visibility. A child record can now show or hide fields and sections based on a value from its parent record or from a record linked through a single-link Related Records field.

Conditions already evaluate against a flat values map with per-operator missing-value semantics, so the condition compiler is untouched: a new `buildConditionValues` helper merges raw parent and related record values (from the same `RecordContext` used by templates and computed fields) into that map under their reference keys. Every operator then behaves on a reference exactly as on a local field, including when the value is unavailable — no parent, no linked record, or an empty field.

## Proposed Changes

- **data-model**: `buildConditionValues` merges parent/related values into condition evaluation; `encodeRelatedRef` added beside the existing reference helpers
- **forms**: merged values wired into `EditableFormManager` (initial visibility, refresh after parent/related resolution and on mid-edit link changes, validation recompilation); `StaticFormProgress` and `DataView` accept an optional record context
- **app**: the read-only record view resolves parent/related values and passes them to the data view and progress bar
- **web (designer)**: the condition editor's field picker offers grouped *Parent › Field* and *Link Field › Field* entries via an `extraEntries` extension to the shared field search; references resolve to their underlying field definitions so operator narrowing and option-aware value inputs (e.g. a parent Select offering its own options) work unchanged; condition summaries render reference labels
- **docs**: Referencing Parent and Linked Record Values section on the conditions authoring page, with pointers from the Templated String, Computed Number, and Computed Text pages

## How to Test

Automated: 14 new data-model tests (merge semantics plus end-to-end operator evaluation over merged values), 3 new forms validation tests, 2 new field-search tests; all existing suites green.

Manual, on a notebook with a parent form (with a Select field), a child form, and a single-link Related Records field:

1. In the designer, add a condition to a child-form field — the field picker lists *Parent › …* and *Link Field › …* entries; selecting a parent Select narrows operators to equal/not-equal and offers its options in the value dropdown:

<img width="1205" height="459" alt="condition editor" src="https://github.com/user-attachments/assets/e0abdcec-5b04-4040-a594-cd787afcb5c5" />

2. In the app, create a parent with the matching value and add a child record — the conditioned field is visible immediately at mount; under a non-matching parent it is hidden.
3. Link/relink the related record mid-edit — the link-conditioned field appears and disappears without saving.
4. A record with no parent or link behaves as an empty local field would; a hidden required field does not block saving; the read-only View tab and progress bar match the edit view.

Note: the pre-existing `PlanTemplateManager` "flag off" test fails whenever `VITE_ENABLE_PLANS_IN_DESIGNER` is unset (default true) — it fails identically on clean `main`; the test should stub the flag rather than read the ambient environment.

## Additional Information

Cross-form dependency tracking (delete/rename warnings when a referenced field changes on the parent or linked form) does not cover these references — the same pre-existing gap as for `_PARENT`/linked references in templates and computed fields from #2235/#2256. A consolidated follow-up issue may be worth filing.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.