### PR TITLE
fix: control-center-header-overflow

### DIFF
--- a/web/src/components/logo.tsx
+++ b/web/src/components/logo.tsx
@@ -9,11 +9,17 @@ export default function Logo() {
       <div className="shrink-0">
         <LogoIcon size={48} />
       </div>
-      <div className="flex flex-col text-left text-sm leading-none min-w-0 flex-1">
-        <span className="truncate font-semibold" title={config.appName}>
+      <div className="flex flex-col text-left text-sm leading-none min-w-0 flex-1 gap-1">
+        <span
+          className="whitespace-normal break-words font-semibold"
+          title={config.appName}
+        >
           {config.appName}
         </span>
-        <span className="truncate text-xs" title={config.websiteTitle}>
+        <span
+          className="whitespace-normal break-words text-xs"
+          title={config.websiteTitle}
+        >
           {config.websiteTitle}
         </span>
       </div>

--- a/web/src/components/logo.tsx
+++ b/web/src/components/logo.tsx
@@ -5,13 +5,17 @@ import {config} from '@/constants';
  */
 export default function Logo() {
   return (
-    <div className="flex items-center gap-2">
-      <div>
+    <div className="flex min-w-0 items-center gap-2">
+      <div className="shrink-0">
         <LogoIcon size={48} />
       </div>
-      <div className="flex flex-col text-left text-sm leading-none">
-        <span className="truncate font-semibold">{config.appName}</span>
-        <span className="truncate text-xs">{config.websiteTitle}</span>
+      <div className="flex flex-col text-left text-sm leading-none min-w-0 flex-1">
+        <span className="truncate font-semibold" title={config.appName}>
+          {config.appName}
+        </span>
+        <span className="truncate text-xs" title={config.websiteTitle}>
+          {config.websiteTitle}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
# fix: control-center-header-overflow

## Description

Fix the web logo title overflow.

<img width="318" height="360" alt="image" src="https://github.com/user-attachments/assets/090614d8-78fa-4ca7-a361-98638e5bd061" />

Should look like:

<img width="403" height="369" alt="image" src="https://github.com/user-attachments/assets/77ac7d70-6a1f-47ea-9b48-6b64fdb4201e" />
