### PR TITLE
chore: drop the unused DESIGNER_URL setting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,6 @@
 
     "ANDROID_APP_PUBLIC_URL": "https://play.google.com/store/apps/details?id=org.fedarch.faims3",
     "IOS_APP_PUBLIC_URL": "https://apps.apple.com/au/app/fieldmark/id1592632372",
-    "DESIGNER_URL": "https://designer.testing.fieldmark.app",
 
     "EMAIL_SERVICE_TYPE": "MOCK",
     "EMAIL_FROM_ADDRESS": "notifications@example.com",

--- a/api/.env.dist
+++ b/api/.env.dist
@@ -40,8 +40,6 @@ WEB_APP_PUBLIC_URL=http://localhost:3000
 # Optional public store / download links for mobile builds
 # ANDROID_APP_PUBLIC_URL=
 # IOS_APP_PUBLIC_URL=
-# Optional designer / Control Centre URL when distinct from WEB_APP_PUBLIC_URL
-# DESIGNER_URL=http://localhost:3001
 
 # You will need to generate these
 FAIMS_COOKIE_SECRET=output of $(uuidgen) or similar

--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -104,8 +104,6 @@ const EnvSchema = z
     ANDROID_APP_PUBLIC_URL: configHelpers.stringDefault(''),
     /** Public URL / store link for the iOS app build (optional). */
     IOS_APP_PUBLIC_URL: configHelpers.stringDefault(''),
-    /** Public URL of the designer / Control Centre when separate from WEB_APP. */
-    DESIGNER_URL: configHelpers.stringDefault(''),
     /** Internal (cluster/localhost) CouchDB URL used by the API process. */
     COUCHDB_INTERNAL_URL: configHelpers.urlNoTrailingSlash(
       DEFAULT_COUCHDB_URL,
@@ -522,7 +520,6 @@ const EnvSchema = z
       webAppPublicUrl: env.WEB_APP_PUBLIC_URL,
       androidAppUrl: env.ANDROID_APP_PUBLIC_URL,
       iosAppUrl: env.IOS_APP_PUBLIC_URL,
-      designerUrl: env.DESIGNER_URL,
       couchdbInternalUrl: env.COUCHDB_INTERNAL_URL,
       couchdbPublicUrl: env.COUCHDB_PUBLIC_URL,
       conductorKeyId,

--- a/api/src/corsAllowlist.ts
+++ b/api/src/corsAllowlist.ts
@@ -22,8 +22,8 @@ const httpOrigin = (value: string | undefined): string | undefined => {
 };
 
 /**
- * Origins Conductor may CORS-allow: Conductor, Control Centre, Designer,
- * the field app, and http(s) entries from {@link config.redirectWhitelist}.
+ * Origins Conductor may CORS-allow: Conductor, the web app, the new
+ * Conductor, and http(s) entries from {@link config.redirectWhitelist}.
  */
 export const buildCorsAllowlist = (): string[] => {
   const candidates = [


### PR DESCRIPTION
# chore: drop the unused DESIGNER_URL setting

## Ticket

None.

## Description

`config.designerUrl` was parsed from `DESIGNER_URL` and projected onto the config object, but read by nothing anywhere in the repo.

Its last would-be consumer was the CORS allowlist. Commit 36451d57a created `api/src/corsAllowlist.ts` with `config.designerUrl` in the candidate list, and commit 10306738a removed it again inside the same PR. That left the setting dead, and left the `buildCorsAllowlist` doc comment advertising a Designer origin the function never reads.

There is no separate designer package any more; it is part of `@faims3/web`.

## Proposed Changes

- `api/src/buildconfig.ts`: removed the `DESIGNER_URL` schema entry and the `designerUrl` config projection.
- `api/.env.dist`: removed the `DESIGNER_URL` entry.
- `.devcontainer/devcontainer.json`: removed the `DESIGNER_URL` entry.
- `api/src/corsAllowlist.ts`: the `buildCorsAllowlist` doc comment now names the settings the function actually reads.

## How to Test

On this branch, all three pass:

```
pnpm exec turbo build
pnpm exec turbo typecheck
pnpm exec oxfmt --check .
```

Setting `DESIGNER_URL` in the environment is harmless either way, since the schema uses `.strip()`.

## Additional Information

No behaviour change: nothing read the setting before this PR.

## Checklist

- [x] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] I have added tests for new code if appropriate
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
