### PR TITLE
feat: create a linked record as one engine operation

### DIFF
--- a/app/src/gui/components/notebook/notebookView.test.tsx
+++ b/app/src/gui/components/notebook/notebookView.test.tsx
@@ -46,7 +46,10 @@ const {
   // What the fake data engine was asked to write, and what it holds already
   engine: {
     updates: [] as Array<Record<string, {data: unknown}>>,
+    modes: [] as string[],
     existing: undefined as unknown,
+    // Whether writing the parent's link fails after the child is written
+    failLink: false,
   },
   // The parent field the mock view's button hangs its child off
   childField: {current: 'many-layers'},
@@ -385,6 +388,9 @@ describe('NotebookView createChildRecord', () => {
     authorised.current = true;
     childField.current = fieldId;
     engine.existing = existing;
+    // The link is written onto the parent, so the parent has to be a record
+    // this user can see and edit
+    allRecords.current = [{recordId: 'parent-1', createdBy: 'testuser'}];
     renderNotebook({planId: 'field'});
     await userEvent.click(screen.getByText('add a child'));
     return engine.updates[0]?.[fieldId]?.data;
@@ -451,8 +457,38 @@ describe('NotebookView createChildRecord', () => {
     // the user looking for something that is there.
     engine.failLink = true;
     authorised.current = true;
+    allRecords.current = [{recordId: 'parent-1', createdBy: 'testuser'}];
     renderNotebook({planId: 'field'});
     await userEvent.click(screen.getByText('add a child'));
+    expect(addAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Record was created but could not be linked to its parent',
+      })
+    );
+  });
+
+  it('refuses a parent the user cannot see', async () => {
+    authorised.current = true;
+    childField.current = 'many-layers';
+    allRecords.current = [];
+    renderNotebook({planId: 'field'});
+    await userEvent.click(screen.getByText('add a child'));
+    expect(engine.updates).toEqual([]);
+    expect(addAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'You do not have permission to add to that record',
+      })
+    );
+  });
+
+  it('refuses to replace the link a single-link field already holds', async () => {
+    // Overwriting drops the parent's side while the old child keeps its parent
+    // edge, leaving the two disagreeing about the same relationship.
+    const written = await addChild('single-test', {
+      record_id: 'child-0',
+      relation_type_vocabPair: ['has child', 'is child of'],
+    });
+    expect(written).toBeUndefined();
     expect(addAlert).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Record was created but could not be linked to its parent',

--- a/app/src/gui/components/notebook/notebookView.test.tsx
+++ b/app/src/gui/components/notebook/notebookView.test.tsx
@@ -4,6 +4,8 @@ import {
   NotebookDefinition,
   planReferenceFor,
   ProjectStatus,
+  readRelatedLinks,
+  withRelatedLink,
 } from '@faims3/data-model';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {cleanup, render, screen} from '@testing-library/react';
@@ -62,6 +64,37 @@ vi.mock('@faims3/data-model', async () => {
     DataEngine: class {
       form = {
         createRecord: async () => ({record: {_id: 'child-1'}}),
+        // The engine derives the relation from the field; the mock spec gives
+        // 'single-test' one link and every other field many. The real link
+        // helpers do the shaping, so the tests below check what the app
+        // actually stores rather than a restatement of it.
+        createRelatedRecord: async ({
+          parentFieldId,
+          parentFieldValue,
+        }: {
+          parentFieldId: string;
+          parentFieldValue: unknown;
+        }) => {
+          const isMultiple = parentFieldId !== 'single-test';
+          const links = readRelatedLinks(parentFieldValue);
+          if (!isMultiple && links.length > 0) {
+            throw new Error(
+              `Field ${parentFieldId} already holds a record and takes only one`
+            );
+          }
+          const link = {
+            record_id: 'child-1',
+            relation_type_vocabPair: ['has child', 'is child of'] as [
+              string,
+              string,
+            ],
+          };
+          return {
+            record: {_id: 'child-1'},
+            link,
+            linked: withRelatedLink({links, link, isMultiple}),
+          };
+        },
         getExistingFormData: async () => ({
           revisionId: 'rev-1',
           data: {[childField.current]: {data: engine.existing}},

--- a/app/src/gui/components/notebook/notebookView.test.tsx
+++ b/app/src/gui/components/notebook/notebookView.test.tsx
@@ -131,6 +131,16 @@ vi.mock('./plans', async () => {
         ),
         React.createElement(
           'span',
+          {'data-testid': 'editable-records'},
+          props.records.notebookRecords
+            .filter((record: MinimalRecordMetadata) =>
+              props.actions.canEditRecord(record)
+            )
+            .map((record: MinimalRecordMetadata) => record.recordId)
+            .join(' ')
+        ),
+        React.createElement(
+          'span',
           {'data-testid': 'handed-records'},
           props.records.planRecords
             .map((record: MinimalRecordMetadata) => record.recordId)
@@ -221,11 +231,16 @@ const plans = [
   {planId: 'lab', planType: 'Counted', label: 'Lab'},
 ];
 
+// The survey's own state, which a closed survey takes out of every write
+const projectStatus = {current: ProjectStatus.OPEN};
+
 const project = {
   projectId: 'proj',
   serverId: 'srv',
   name: 'Two plans',
-  status: ProjectStatus.OPEN,
+  get status() {
+    return projectStatus.current;
+  },
   isActivated: true,
   uiSpecificationId: 'spec',
   uiDefinition: {plans} as unknown as NotebookDefinition,
@@ -269,6 +284,7 @@ beforeEach(() => {
   engine.existing = undefined;
   engine.failLink = false;
   childField.current = 'many-layers';
+  projectStatus.current = ProjectStatus.OPEN;
 });
 afterEach(() => cleanup());
 
@@ -301,6 +317,24 @@ describe('NotebookView navigation', () => {
     for (const call of navigate.mock.calls) {
       expect(call[1]).toEqual({replace: true});
     }
+  });
+});
+
+describe('NotebookView canEditRecord', () => {
+  it('lets a view edit a record the user is authorised for', () => {
+    authorised.current = true;
+    allRecords.current = [{recordId: 'r1', createdBy: 'testuser'}];
+    renderNotebook({planId: 'field'});
+    expect(screen.getByTestId('editable-records')).toHaveTextContent('r1');
+  });
+
+  it('edits nothing while the survey is closed', () => {
+    // A closed survey takes no writes, whoever the user is.
+    authorised.current = true;
+    projectStatus.current = ProjectStatus.CLOSED;
+    allRecords.current = [{recordId: 'r1', createdBy: 'testuser'}];
+    renderNotebook({planId: 'field'});
+    expect(screen.getByTestId('editable-records')).toHaveTextContent('');
   });
 });
 

--- a/app/src/gui/components/notebook/notebookView.test.tsx
+++ b/app/src/gui/components/notebook/notebookView.test.tsx
@@ -61,6 +61,9 @@ vi.mock('@faims3/data-model', async () => {
   const actual = await vi.importActual<object>('@faims3/data-model');
   return {
     ...actual,
+    // notebookView asks the shared helper, so the tests drive it here rather
+    // than through the permission hook it no longer calls.
+    canEditProjectRecord: () => authorised.current,
     DataEngine: class {
       form = {
         createRecord: async () => ({record: {_id: 'child-1'}}),
@@ -212,7 +215,7 @@ const uiSpecification = {
 
 vi.mock('../../../context/store', () => ({
   useAppDispatch: () => vi.fn(),
-  useAppSelector: () => ({username: 'testuser'}),
+  useAppSelector: () => ({username: 'testuser', parsedToken: {}}),
 }));
 vi.mock('../../../context/slices/authSlice', () => ({
   selectActiveUser: vi.fn(),

--- a/app/src/gui/components/notebook/notebookView.test.tsx
+++ b/app/src/gui/components/notebook/notebookView.test.tsx
@@ -13,27 +13,74 @@ import * as ROUTES from '../../../constants/routes';
 import {NotebookRouteProvider} from '../../../context/notebookRoute';
 import {NotebookViewTabProvider} from '../../../context/notebookViewTab';
 import {Project} from '../../../context/slices/projectSlice';
+import {addAlert} from '../../../context/slices/alertSlice';
 import {NotebookView} from './notebookView';
 
-const {navigate, routeParams, allRecords, plotAll, queries} = vi.hoisted(
-  () => ({
-    navigate: vi.fn(),
-    routeParams: {
-      current: {} as {
-        serverId?: string;
-        projectId?: string;
-        planId?: string;
-      },
+const {
+  navigate,
+  routeParams,
+  allRecords,
+  plotAll,
+  queries,
+  authorised,
+  engine,
+  childField,
+} = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  routeParams: {
+    current: {} as {
+      serverId?: string;
+      projectId?: string;
+      planId?: string;
     },
-    allRecords: {
-      current: [] as Array<{recordId: string; planReference?: string}>,
+  },
+  allRecords: {
+    current: [] as Array<{recordId: string; planReference?: string}>,
+  },
+  // Whether the view asks the map for the whole notebook rather than its plan's
+  plotAll: {current: false},
+  // Every search the record list was asked for, newest last
+  queries: {current: [] as string[]},
+  // Whether the user may add records; createChildRecord refuses without it
+  authorised: {current: false},
+  // What the fake data engine was asked to write, and what it holds already
+  engine: {
+    updates: [] as Array<Record<string, {data: unknown}>>,
+    existing: undefined as unknown,
+  },
+  // The parent field the mock view's button hangs its child off
+  childField: {current: 'many-layers'},
+}));
+
+vi.mock('@faims3/data-model', async () => {
+  const actual = await vi.importActual<object>('@faims3/data-model');
+  return {
+    ...actual,
+    DataEngine: class {
+      form = {
+        createRecord: async () => ({record: {_id: 'child-1'}}),
+        getExistingFormData: async () => ({
+          revisionId: 'rev-1',
+          data: {[childField.current]: {data: engine.existing}},
+        }),
+        createRevision: async () => {
+          if (engine.failLink) throw new Error('link failed');
+          return {_id: 'rev-2'};
+        },
+        updateRevision: async ({
+          update,
+          mode,
+        }: {
+          update: Record<string, {data: unknown}>;
+          mode: string;
+        }) => {
+          engine.updates.push(update);
+          engine.modes.push(mode);
+        },
+      };
     },
-    // Whether the view asks the map for the whole notebook rather than its plan's
-    plotAll: {current: false},
-    // Every search the record list was asked for, newest last
-    queries: {current: [] as string[]},
-  })
-);
+  };
+});
 
 vi.mock('react-router-dom', async () => ({
   ...(await vi.importActual<object>('react-router-dom')),
@@ -63,6 +110,18 @@ vi.mock('./plans', async () => {
           'search'
         ),
         React.createElement(
+          'button',
+          {
+            onClick: () =>
+              props.actions.createChildRecord({
+                formType: 'Density',
+                parentRecordId: 'parent-1',
+                parentFieldId: childField.current,
+              }),
+          },
+          'add a child'
+        ),
+        React.createElement(
           'span',
           {'data-testid': 'view-tab'},
           props.tab.current ?? 'none'
@@ -88,10 +147,19 @@ vi.mock('./plans', async () => {
   };
 });
 
+const relatedField = (multiple: boolean) => ({
+  'component-namespace': 'faims-custom',
+  'component-name': 'RelatedRecordSelector',
+  'component-parameters': {related_type: 'Density', multiple},
+});
+
 const uiSpecification = {
   viewsets: {},
   views: {},
-  fields: {},
+  fields: {
+    'many-layers': relatedField(true),
+    'single-test': relatedField(false),
+  },
   visible_types: [],
   settings: {showQrCodeButton: false},
 };
@@ -110,7 +178,7 @@ vi.mock('../../../context/slices/helpers/compiledSpecService', () => ({
 vi.mock('../../../utils/customHooks', () => ({
   invalidateProjectHydration: vi.fn(),
   invalidateProjectRecordList: vi.fn(),
-  useIsAuthorisedTo: () => false,
+  useIsAuthorisedTo: () => authorised.current,
   useIsRecordDownloadUnderway: () => false,
   usePlanRecordStatusReports: () => new Map(),
   // Records the query it was asked for, which is what filters the whole notebook
@@ -192,6 +260,12 @@ beforeEach(() => {
   allRecords.current = [];
   plotAll.current = false;
   queries.current = [];
+  authorised.current = false;
+  engine.updates = [];
+  engine.modes = [];
+  engine.existing = undefined;
+  engine.failLink = false;
+  childField.current = 'many-layers';
 });
 afterEach(() => cleanup());
 
@@ -301,6 +375,88 @@ describe('NotebookView record scoping', () => {
     renderNotebook({planId: 'lab'});
     expect(screen.getByTestId('plotted-records')).toHaveTextContent(
       'mine theirs'
+    );
+  });
+});
+
+describe('NotebookView createChildRecord', () => {
+  /** Render, click the mock view's child button, and return what was written. */
+  const addChild = async (fieldId: string, existing?: unknown) => {
+    authorised.current = true;
+    childField.current = fieldId;
+    engine.existing = existing;
+    renderNotebook({planId: 'field'});
+    await userEvent.click(screen.getByText('add a child'));
+    return engine.updates[0]?.[fieldId]?.data;
+  };
+
+  it('appends to a field that holds several links', async () => {
+    const written = await addChild('many-layers', [
+      {
+        record_id: 'child-0',
+        relation_type_vocabPair: ['has child', 'is child of'],
+      },
+    ]);
+    expect(written).toEqual([
+      {
+        record_id: 'child-0',
+        relation_type_vocabPair: ['has child', 'is child of'],
+      },
+      {
+        record_id: 'child-1',
+        relation_type_vocabPair: ['has child', 'is child of'],
+      },
+    ]);
+  });
+
+  it('writes the link through a new revision, which any edited record needs', async () => {
+    // The head revision of a record with history already has a parent, and the
+    // 'new' mode refuses that, so the link never lands.
+    await addChild('many-layers');
+    expect(engine.modes).toEqual(['parent']);
+  });
+
+  it('writes one link, not a list of one, to a single-link field', async () => {
+    // A list in a single-link field leaves a value the parent's own form
+    // cannot read back, so the record looks unlinked wherever it is opened.
+    const written = await addChild('single-test');
+    expect(written).toEqual({
+      record_id: 'child-1',
+      relation_type_vocabPair: ['has child', 'is child of'],
+    });
+  });
+
+  it('keeps a link stored as one bare entry rather than a list', async () => {
+    // A related-record value is legitimately a list or a single entry, so
+    // reading one entry as none would drop the link it holds.
+    const written = await addChild('many-layers', {
+      record_id: 'child-0',
+      relation_type_vocabPair: ['has child', 'is child of'],
+    });
+    expect(written).toEqual([
+      {
+        record_id: 'child-0',
+        relation_type_vocabPair: ['has child', 'is child of'],
+      },
+      {
+        record_id: 'child-1',
+        relation_type_vocabPair: ['has child', 'is child of'],
+      },
+    ]);
+  });
+
+  it('says the record was created when only the link failed', async () => {
+    // The child is written first, so a failure after it leaves a record that
+    // exists but is not listed on its parent; saying it was not created sends
+    // the user looking for something that is there.
+    engine.failLink = true;
+    authorised.current = true;
+    renderNotebook({planId: 'field'});
+    await userEvent.click(screen.getByText('add a child'));
+    expect(addAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Record was created but could not be linked to its parent',
+      })
     );
   });
 });

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -12,6 +12,7 @@ import {
   FormUpdateData,
   MinimalRecordMetadata,
   ProjectStatus,
+  relatedRecordAvpEntries,
 } from '@faims3/data-model';
 import NotebookComponent from '.';
 import {addAlert} from '../../../context/slices/alertSlice';
@@ -232,6 +233,128 @@ function NotebookViewWithSpec({
     ]
   );
 
+  /**
+   * Create a child record of an existing record and navigate to its edit page.
+   *
+   * Writes both halves of the link the related record field would have
+   * written: the `parent` edge on the new record, and the new record's entry
+   * in the parent's related-record field, so a view that creates a child
+   * leaves the parent form reading as it would after an in-form create.
+   *
+   * @param formType The viewset of the new child record
+   * @param parentRecordId The record the child hangs off
+   * @param parentFieldId The parent's related-record field holding the link
+   */
+  const createChildRecord = useCallback(
+    async ({
+      formType,
+      parentRecordId,
+      parentFieldId,
+    }: {
+      formType: string;
+      parentRecordId: string;
+      parentFieldId: string;
+    }) => {
+      if (!(activeUser && isAllowedToAddRecords)) return;
+
+      // The pair a Child related-record field stores, the parent's view first.
+      const relationTypeVocabPair: [string, string] = [
+        'has child',
+        'is child of',
+      ];
+      let isChildCreated = false;
+      try {
+        const engine = dataEngine();
+        const {record} = await engine.form.createRecord({
+          formId: formType,
+          createdBy: activeUser.username,
+          relationship: {
+            parent: [
+              {
+                recordId: parentRecordId,
+                fieldId: parentFieldId,
+                relationTypeVocabPair,
+              },
+            ],
+          },
+        });
+        isChildCreated = true;
+
+        // Read the head rather than trusting the record list, which the
+        // notebook polls and can be a revision behind.
+        const existing = await engine.form.getExistingFormData({
+          recordId: parentRecordId,
+        });
+        // A related-record value is a list or a single bare entry, so read it
+        // the way every other reader does.
+        const currentValue = existing.data?.[parentFieldId]?.data;
+        const links =
+          currentValue === undefined || currentValue === null
+            ? []
+            : relatedRecordAvpEntries(currentValue);
+        const link = {
+          record_id: record._id,
+          relation_type_vocabPair: relationTypeVocabPair,
+        };
+        // A single-link field stores one link, not a list of one.
+        const isMultipleLink =
+          uiSpecification.fields[parentFieldId]?.['component-parameters']
+            ?.multiple === true;
+        const revision = await engine.form.createRevision({
+          recordId: parentRecordId,
+          revisionId: existing.revisionId,
+          createdBy: activeUser.username,
+        });
+        // updateRevision replaces the revision's whole field map, so the
+        // parent's other values go back with it rather than being dropped.
+        await engine.form.updateRevision({
+          revisionId: revision._id,
+          recordId: parentRecordId,
+          update: {
+            ...existing.data,
+            [parentFieldId]: {
+              ...existing.data?.[parentFieldId],
+              data: isMultipleLink ? [...links, link] : link,
+            },
+          },
+          mode: 'parent',
+          updatedBy: activeUser.username,
+          bumpRecordUpdatedAt: true,
+        });
+
+        navigate(
+          ROUTES.getEditRecordRoute({
+            ...notebook,
+            recordId: record._id,
+            mode: 'new',
+          })
+        );
+      } catch (err) {
+        // Surface and resolve, like createRecord. The child is written before
+        // the parent's link, so a failure after it leaves a record that exists
+        // but is not listed on its parent.
+        console.error('Failed to create child record', formType, err);
+        dispatch(
+          addAlert({
+            message: isChildCreated
+              ? 'Record was created but could not be linked to its parent'
+              : 'Record could not be created',
+            severity: 'error',
+          })
+        );
+      }
+    },
+    [
+      activeUser,
+      isAllowedToAddRecords,
+      dataEngine,
+      navigate,
+      notebook,
+      uiSpecification,
+      dispatch,
+    ]
+  );
+
   // View/Edit an existing record by navigating to the record view page
   const navigateToRecord = useCallback(
     (record: MinimalRecordMetadata) => {
@@ -300,6 +423,7 @@ function NotebookViewWithSpec({
         refreshRecordList,
         setQuery,
         createRecord,
+        createChildRecord,
         navigateToRecord,
       },
       status: {
@@ -351,6 +475,7 @@ function NotebookViewWithSpec({
       refreshRecordList,
       setQuery,
       createRecord,
+      createChildRecord,
       navigateToRecord,
       tab,
       isAllowedToAddRecords,

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -100,13 +100,20 @@ function NotebookViewWithSpec({
     action: Action.EDIT_ALL_PROJECT_RECORDS,
     resourceId: project.projectId,
   });
-  /** Whether the active user may edit this record: their own, or anyone's. */
+  /** Whether the active user may edit this record: the project open, and the
+   * record their own or anyone's. */
   const canEditRecord = useCallback(
     (record: MinimalRecordMetadata) =>
-      record.createdBy === activeUser?.username
+      project.status === ProjectStatus.OPEN &&
+      (record.createdBy === activeUser?.username
         ? isAllowedToEditOwnRecords
-        : isAllowedToEditOthersRecords,
-    [activeUser, isAllowedToEditOwnRecords, isAllowedToEditOthersRecords]
+        : isAllowedToEditOthersRecords),
+    [
+      activeUser,
+      project.status,
+      isAllowedToEditOwnRecords,
+      isAllowedToEditOthersRecords,
+    ]
   );
 
   const isAllowedToAddRecords =

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -92,6 +92,15 @@ function NotebookViewWithSpec({
   const [query, setQuery] = useState<string>('');
   const queryClient = useQueryClient();
 
+  const isAllowedToEditOwnRecords = useIsAuthorisedTo({
+    action: Action.EDIT_MY_PROJECT_RECORDS,
+    resourceId: project.projectId,
+  });
+  const isAllowedToEditOthersRecords = useIsAuthorisedTo({
+    action: Action.EDIT_ALL_PROJECT_RECORDS,
+    resourceId: project.projectId,
+  });
+
   const isAllowedToAddRecords =
     useIsAuthorisedTo({
       action: Action.CREATE_PROJECT_RECORD,
@@ -257,6 +266,27 @@ function NotebookViewWithSpec({
     }) => {
       if (!(activeUser && isAllowedToAddRecords)) return;
 
+      // The link is written onto the parent, so editing it must be allowed as
+      // well as creating the child. A record absent from the list is one this
+      // user cannot see, which is not one to write to either.
+      const parentRecord = records.allRecords.find(
+        record => record.recordId === parentRecordId
+      );
+      const mayEditParent =
+        parentRecord &&
+        (parentRecord.createdBy === activeUser.username
+          ? isAllowedToEditOwnRecords
+          : isAllowedToEditOthersRecords);
+      if (!mayEditParent) {
+        dispatch(
+          addAlert({
+            message: 'You do not have permission to add to that record',
+            severity: 'error',
+          })
+        );
+        return;
+      }
+
       // The pair a Child related-record field stores, the parent's view first.
       const relationTypeVocabPair: [string, string] = [
         'has child',
@@ -300,6 +330,13 @@ function NotebookViewWithSpec({
         const isMultipleLink =
           uiSpecification.fields[parentFieldId]?.['component-parameters']
             ?.multiple === true;
+        if (!isMultipleLink && links.length > 0) {
+          // Overwriting would drop the parent's side of the existing link
+          // while its child kept the parent edge, leaving the two disagreeing.
+          throw new Error(
+            `Field ${parentFieldId} already holds a record and takes only one`
+          );
+        }
         const revision = await engine.form.createRevision({
           recordId: parentRecordId,
           revisionId: existing.revisionId,
@@ -347,6 +384,9 @@ function NotebookViewWithSpec({
     [
       activeUser,
       isAllowedToAddRecords,
+      isAllowedToEditOwnRecords,
+      isAllowedToEditOthersRecords,
+      records.allRecords,
       dataEngine,
       navigate,
       notebook,

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -5,6 +5,7 @@
 
 import {
   Action,
+  canEditProjectRecord,
   CompiledNotebookUiSpec,
   DatabaseInterface,
   DataDocument,
@@ -91,28 +92,19 @@ function NotebookViewWithSpec({
   const [query, setQuery] = useState<string>('');
   const queryClient = useQueryClient();
 
-  const isAllowedToEditOwnRecords = useIsAuthorisedTo({
-    action: Action.EDIT_MY_PROJECT_RECORDS,
-    resourceId: project.projectId,
-  });
-  const isAllowedToEditOthersRecords = useIsAuthorisedTo({
-    action: Action.EDIT_ALL_PROJECT_RECORDS,
-    resourceId: project.projectId,
-  });
   /** Whether the active user may edit this record: the project open, and the
    * record their own or anyone's. */
   const canEditRecord = useCallback(
     (record: MinimalRecordMetadata) =>
+      !!activeUser &&
       project.status === ProjectStatus.OPEN &&
-      (record.createdBy === activeUser?.username
-        ? isAllowedToEditOwnRecords
-        : isAllowedToEditOthersRecords),
-    [
-      activeUser,
-      project.status,
-      isAllowedToEditOwnRecords,
-      isAllowedToEditOthersRecords,
-    ]
+      canEditProjectRecord({
+        decodedToken: activeUser.parsedToken,
+        projectId: project.projectId,
+        recordCreatedBy: record.createdBy,
+        actingUserId: activeUser.username,
+      }),
+    [activeUser, project.status, project.projectId]
   );
 
   const isAllowedToAddRecords =

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -12,7 +12,6 @@ import {
   FormUpdateData,
   MinimalRecordMetadata,
   ProjectStatus,
-  relatedRecordAvpEntries,
 } from '@faims3/data-model';
 import NotebookComponent from '.';
 import {addAlert} from '../../../context/slices/alertSlice';
@@ -263,11 +262,9 @@ function NotebookViewWithSpec({
    */
   const createChildRecord = useCallback(
     async ({
-      formType,
       parentRecordId,
       parentFieldId,
     }: {
-      formType: string;
       parentRecordId: string;
       parentFieldId: string;
     }) => {
@@ -288,54 +285,25 @@ function NotebookViewWithSpec({
         return;
       }
 
-      // The pair a Child related-record field stores, the parent's view first.
-      const relationTypeVocabPair: [string, string] = [
-        'has child',
-        'is child of',
-      ];
       let isChildCreated = false;
       try {
         const engine = dataEngine();
-        const {record} = await engine.form.createRecord({
-          formId: formType,
-          createdBy: activeUser.username,
-          relationship: {
-            parent: [
-              {
-                recordId: parentRecordId,
-                fieldId: parentFieldId,
-                relationTypeVocabPair,
-              },
-            ],
-          },
-        });
-        isChildCreated = true;
-
         // Read the head rather than trusting the record list, which the
         // notebook polls and can be a revision behind.
         const existing = await engine.form.getExistingFormData({
           recordId: parentRecordId,
         });
-        // A related-record value is a list or a single bare entry.
-        const currentValue = existing.data?.[parentFieldId]?.data;
-        const links =
-          currentValue === undefined || currentValue === null
-            ? []
-            : relatedRecordAvpEntries(currentValue);
-        const link = {
-          record_id: record._id,
-          relation_type_vocabPair: relationTypeVocabPair,
-        };
-        const isMultipleLink =
-          uiSpecification.fields[parentFieldId]?.['component-parameters']
-            ?.multiple === true;
-        if (!isMultipleLink && links.length > 0) {
-          // Overwriting would drop the parent's side of the existing link
-          // while its child kept the parent edge, leaving the two disagreeing.
-          throw new Error(
-            `Field ${parentFieldId} already holds a record and takes only one`
-          );
-        }
+        // The engine derives the related form, the relation and its vocab pair
+        // from the field, writes the new row's own edge, and hands back what
+        // this field must hold. No open form here, so that goes in a revision.
+        const {record, linked} = await engine.form.createRelatedRecord({
+          parentRecordId,
+          parentFieldId,
+          createdBy: activeUser.username,
+          parentFieldValue: existing.data?.[parentFieldId]?.data,
+        });
+        isChildCreated = true;
+
         const revision = await engine.form.createRevision({
           recordId: parentRecordId,
           revisionId: existing.revisionId,
@@ -350,7 +318,7 @@ function NotebookViewWithSpec({
             ...existing.data,
             [parentFieldId]: {
               ...existing.data?.[parentFieldId],
-              data: isMultipleLink ? [...links, link] : link,
+              data: linked,
             },
           },
           mode: 'parent',
@@ -368,7 +336,7 @@ function NotebookViewWithSpec({
       } catch (err) {
         // Surface and resolve, like createRecord. The child is written first,
         // so a later failure leaves a record not listed on its parent.
-        console.error('Failed to create child record', formType, err);
+        console.error('Failed to create child record', parentFieldId, err);
         dispatch(
           addAlert({
             message: isChildCreated
@@ -387,7 +355,6 @@ function NotebookViewWithSpec({
       dataEngine,
       navigate,
       notebook,
-      uiSpecification,
       dispatch,
     ]
   );

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -100,6 +100,14 @@ function NotebookViewWithSpec({
     action: Action.EDIT_ALL_PROJECT_RECORDS,
     resourceId: project.projectId,
   });
+  /** Whether the active user may edit this record: their own, or anyone's. */
+  const canEditRecord = useCallback(
+    (record: MinimalRecordMetadata) =>
+      record.createdBy === activeUser?.username
+        ? isAllowedToEditOwnRecords
+        : isAllowedToEditOthersRecords,
+    [activeUser, isAllowedToEditOwnRecords, isAllowedToEditOthersRecords]
+  );
 
   const isAllowedToAddRecords =
     useIsAuthorisedTo({
@@ -243,16 +251,8 @@ function NotebookViewWithSpec({
   );
 
   /**
-   * Create a child record of an existing record and navigate to its edit page.
-   *
-   * Writes both halves of the link the related record field would have
-   * written: the `parent` edge on the new record, and the new record's entry
-   * in the parent's related-record field, so a view that creates a child
-   * leaves the parent form reading as it would after an in-form create.
-   *
-   * @param formType The viewset of the new child record
-   * @param parentRecordId The record the child hangs off
-   * @param parentFieldId The parent's related-record field holding the link
+   * Create a child record and navigate to its edit page, writing both halves of
+   * the link so the parent form reads as it would after an in-form create.
    */
   const createChildRecord = useCallback(
     async ({
@@ -266,18 +266,12 @@ function NotebookViewWithSpec({
     }) => {
       if (!(activeUser && isAllowedToAddRecords)) return;
 
-      // The link is written onto the parent, so editing it must be allowed as
-      // well as creating the child. A record absent from the list is one this
-      // user cannot see, which is not one to write to either.
+      // The link is written onto the parent, so editing it must be allowed
+      // too, and a record absent from the list is one this user cannot see.
       const parentRecord = records.allRecords.find(
         record => record.recordId === parentRecordId
       );
-      const mayEditParent =
-        parentRecord &&
-        (parentRecord.createdBy === activeUser.username
-          ? isAllowedToEditOwnRecords
-          : isAllowedToEditOthersRecords);
-      if (!mayEditParent) {
+      if (!parentRecord || !canEditRecord(parentRecord)) {
         dispatch(
           addAlert({
             message: 'You do not have permission to add to that record',
@@ -315,8 +309,7 @@ function NotebookViewWithSpec({
         const existing = await engine.form.getExistingFormData({
           recordId: parentRecordId,
         });
-        // A related-record value is a list or a single bare entry, so read it
-        // the way every other reader does.
+        // A related-record value is a list or a single bare entry.
         const currentValue = existing.data?.[parentFieldId]?.data;
         const links =
           currentValue === undefined || currentValue === null
@@ -326,7 +319,6 @@ function NotebookViewWithSpec({
           record_id: record._id,
           relation_type_vocabPair: relationTypeVocabPair,
         };
-        // A single-link field stores one link, not a list of one.
         const isMultipleLink =
           uiSpecification.fields[parentFieldId]?.['component-parameters']
             ?.multiple === true;
@@ -367,9 +359,8 @@ function NotebookViewWithSpec({
           })
         );
       } catch (err) {
-        // Surface and resolve, like createRecord. The child is written before
-        // the parent's link, so a failure after it leaves a record that exists
-        // but is not listed on its parent.
+        // Surface and resolve, like createRecord. The child is written first,
+        // so a later failure leaves a record not listed on its parent.
         console.error('Failed to create child record', formType, err);
         dispatch(
           addAlert({
@@ -384,8 +375,7 @@ function NotebookViewWithSpec({
     [
       activeUser,
       isAllowedToAddRecords,
-      isAllowedToEditOwnRecords,
-      isAllowedToEditOthersRecords,
+      canEditRecord,
       records.allRecords,
       dataEngine,
       navigate,
@@ -465,6 +455,7 @@ function NotebookViewWithSpec({
         createRecord,
         createChildRecord,
         navigateToRecord,
+        canEditRecord,
       },
       status: {
         // Never-loaded, not merely in-flight: the hook's isLoading stays true
@@ -517,6 +508,7 @@ function NotebookViewWithSpec({
       createRecord,
       createChildRecord,
       navigateToRecord,
+      canEditRecord,
       tab,
       isAllowedToAddRecords,
       isDownloadingRecords,

--- a/app/src/gui/components/notebook/types.ts
+++ b/app/src/gui/components/notebook/types.ts
@@ -81,6 +81,14 @@ interface ActionProps {
     data: Record<string, any>,
     planReference?: string
   ) => Promise<void>;
+  // Create a child record of an existing record, linked from one of that
+  // record's related-record fields, and navigate to it. Writes both halves of
+  // the link, so the parent form reads as it would after an in-form create.
+  createChildRecord: (args: {
+    formType: string;
+    parentRecordId: string;
+    parentFieldId: string;
+  }) => Promise<void>;
   // Navigate to the view page for the given record
   navigateToRecord: (record: MinimalRecordMetadata) => void;
 }

--- a/app/src/gui/components/notebook/types.ts
+++ b/app/src/gui/components/notebook/types.ts
@@ -81,9 +81,8 @@ interface ActionProps {
     data: Record<string, any>,
     planReference?: string
   ) => Promise<void>;
-  // Create a child record of an existing record, linked from one of that
-  // record's related-record fields, and navigate to it. Writes both halves of
-  // the link, so the parent form reads as it would after an in-form create.
+  // Create a child record linked from one of the parent's related-record
+  // fields, and navigate to it. Writes both halves of the link.
   createChildRecord: (args: {
     formType: string;
     parentRecordId: string;
@@ -91,6 +90,8 @@ interface ActionProps {
   }) => Promise<void>;
   // Navigate to the view page for the given record
   navigateToRecord: (record: MinimalRecordMetadata) => void;
+  // Whether the user may edit this record; createChildRecord refuses if not.
+  canEditRecord: (record: MinimalRecordMetadata) => boolean;
 }
 
 // Components that might be used in the notebook display

--- a/app/src/gui/components/notebook/types.ts
+++ b/app/src/gui/components/notebook/types.ts
@@ -84,7 +84,6 @@ interface ActionProps {
   // Create a child record linked from one of the parent's related-record
   // fields, and navigate to it. Writes both halves of the link.
   createChildRecord: (args: {
-    formType: string;
     parentRecordId: string;
     parentFieldId: string;
   }) => Promise<void>;

--- a/library/data-model/src/databaseEngine/engine.ts
+++ b/library/data-model/src/databaseEngine/engine.ts
@@ -5,6 +5,8 @@ import {
   CompiledNotebookUiSpec,
   getHridFieldMap,
   HridFieldMap,
+  relatedRecordSelectorComponentParamsSchema,
+  RELATED_RECORD_SELECTOR,
 } from '../uiSpecification';
 import {differenceSets, randomUuid} from '../utils';
 import * as Exceptions from './exceptions';
@@ -57,10 +59,15 @@ import {
   RevisionMetadataQueryResult,
   TimestampBumpOptions,
   toMinimalRevisionMetadata,
+  RelatedRecordFieldAvpEntry,
+  RelatedRecordFieldAvpValue,
 } from './types';
 import {
   normalizeRelationshipInstances,
+  readRelatedLinks,
+  relationTypeToPair,
   toDbRelationshipInstances,
+  withRelatedLink,
 } from './utils';
 import {
   hasUpdatedTimeFilter,
@@ -1495,6 +1502,87 @@ class FormOperations {
       const revOk = Number.isNaN(revMs) ? 0 : revMs;
       return revOk >= latestOk ? rev : latest;
     })._id;
+  }
+
+  /**
+   * Create a record related to `parentRecordId` through one of its
+   * RelatedRecord fields, and hand back the value that field must then hold.
+   * Writing it belongs to the caller: an open form writes it through the form,
+   * a view without one writes a revision.
+   */
+  async createRelatedRecord({
+    parentRecordId,
+    parentFieldId,
+    createdBy,
+    parentFieldValue,
+  }: {
+    parentRecordId: string;
+    parentFieldId: string;
+    createdBy: string;
+    /** What the parent's field holds now, so a link the field cannot take is
+     * refused before a record is written rather than orphaning one. */
+    parentFieldValue: unknown;
+  }): Promise<{
+    record: ExistingRecordDBDocument;
+    revision: ExistingRevisionDBDocument;
+    // Always a real pair: the op mints it rather than reading a stored one,
+    // which may be the empty tuple a legacy row carries.
+    link: RelatedRecordFieldAvpEntry & {
+      relation_type_vocabPair: [string, string];
+    };
+    /** What the parent's field must hold now, in the shape it stores. */
+    linked: RelatedRecordFieldAvpValue;
+  }> {
+    // Gate on the component before the parameters, the way every other
+    // related-field scan here does: a plain field carrying a `related_type`
+    // key is not a selector.
+    const field = this.uiSpec.fields[parentFieldId];
+    const params =
+      field?.['component-namespace'] === RELATED_RECORD_SELECTOR.namespace &&
+      field['component-name'] === RELATED_RECORD_SELECTOR.name
+        ? relatedRecordSelectorComponentParamsSchema.safeParse(
+            field['component-parameters']
+          )
+        : undefined;
+    if (!params?.success) {
+      throw new Error(
+        `Field ${parentFieldId} is not a related-record field of this notebook`
+      );
+    }
+    const {related_type, relation_type, multiple} = params.data;
+    // Both checks run before anything is written: a record created and then
+    // refused its link is an orphan the parent does not list.
+    const links = readRelatedLinks(parentFieldValue);
+    if (!multiple && links.length > 0) {
+      throw new Error(
+        `Field ${parentFieldId} already holds a record and takes only one`
+      );
+    }
+    const relationTypeVocabPair = relationTypeToPair(relation_type);
+    // Child hangs the new row off `parent`, Linked off `linked`.
+    const edge = {
+      fieldId: parentFieldId,
+      recordId: parentRecordId,
+      relationTypeVocabPair,
+    };
+    const {record, revision} = await this.createRecord({
+      createdBy,
+      formId: related_type,
+      relationship:
+        relation_type === 'faims-core::Child'
+          ? {parent: [edge]}
+          : {linked: [edge]},
+    });
+    const link = {
+      record_id: record._id,
+      relation_type_vocabPair: relationTypeVocabPair,
+    };
+    return {
+      record,
+      revision,
+      link,
+      linked: withRelatedLink({links, link, isMultiple: multiple}),
+    };
   }
 
   /**

--- a/library/data-model/src/databaseEngine/utils.ts
+++ b/library/data-model/src/databaseEngine/utils.ts
@@ -1,4 +1,12 @@
-import {FormRelationshipInstance, RelationshipInstance} from './types';
+import type {RelatedType} from '../uiSpecification/types';
+import {
+  relatedRecordAvpEntries,
+  relatedRecordFieldAvpValueSchema,
+  type FormRelationshipInstance,
+  type RelatedRecordFieldAvpEntry,
+  type RelatedRecordFieldAvpValue,
+  type RelationshipInstance,
+} from './types';
 
 // If there is no vocab pair - we use this as a placeholder
 export const DEFAULT_VOCAB_PAIR: [string, string] = [
@@ -37,3 +45,41 @@ export const toDbRelationshipInstances = (
     relation_type_vocabPair: inst.relationTypeVocabPair,
   }));
 };
+
+/**
+ * The vocab pair a relation type carries, the parent's view first. Authored
+ * notebooks do not name one, so the relation type is the whole input.
+ */
+export const relationTypeToPair = (relationType: string): [string, string] =>
+  relationType === 'faims-core::Child'
+    ? ['has child', 'is child of']
+    : ['is linked to', 'is linked from'];
+
+/**
+ * The links a related-record field currently holds. A field storing one holds
+ * a bare entry rather than a list of one, so both shapes read alike here.
+ * Throws on a value it cannot read: appending to that would drop the links
+ * already in it, and refusing is better than writing over them.
+ */
+export const readRelatedLinks = (
+  /** The field's stored value, straight off the revision, so of no known shape. */
+  current: unknown
+): RelatedRecordFieldAvpEntry[] => {
+  if (current === undefined || current === null) return [];
+  const parsed = relatedRecordFieldAvpValueSchema.safeParse(current);
+  if (!parsed.success) {
+    throw new Error('Field holds a related-record value that cannot be read');
+  }
+  return relatedRecordAvpEntries(parsed.data);
+};
+
+/** The value a field holds once `link` joins `links`, in the shape it stores. */
+export const withRelatedLink = ({
+  links,
+  link,
+  isMultiple,
+}: {
+  links: RelatedRecordFieldAvpEntry[];
+  link: RelatedRecordFieldAvpEntry;
+  isMultiple: boolean;
+}): RelatedRecordFieldAvpValue => (isMultiple ? [...links, link] : link);

--- a/library/data-model/tests/engine.form.test.ts
+++ b/library/data-model/tests/engine.form.test.ts
@@ -273,6 +273,141 @@ describe('Form Operations', () => {
     });
   });
 
+  describe('createRelatedRecord', () => {
+    /** An engine whose spec carries one Child field and one Linked field. */
+    const relatedEngine = () =>
+      new DataEngine({
+        dataDb: db,
+        uiSpec: {
+          ...(uiSpec as unknown as CompiledNotebookUiSpec),
+          fields: {
+            ...(uiSpec as unknown as CompiledNotebookUiSpec).fields,
+            samples: {
+              'component-namespace': 'faims-custom',
+              'component-name': 'RelatedRecordSelector',
+              'component-parameters': {
+                label: 'Samples',
+                related_type: 'Sample',
+                relation_type: 'faims-core::Child',
+                multiple: true,
+              },
+            },
+            peer: {
+              'component-namespace': 'faims-custom',
+              'component-name': 'RelatedRecordSelector',
+              'component-parameters': {
+                label: 'Peer',
+                related_type: 'Site',
+                relation_type: 'faims-core::Linked',
+                multiple: false,
+              },
+            },
+          },
+        } as unknown as CompiledNotebookUiSpec,
+      });
+
+    it('takes the related form and the relation from the field, not the caller', async () => {
+      const {record, link, linked} =
+        await relatedEngine().form.createRelatedRecord({
+          parentRecordId: 'parent-1',
+          parentFieldId: 'samples',
+          createdBy: 'alice',
+          parentFieldValue: undefined,
+        });
+      expect(record.type).toBe('Sample');
+      expect(link).toEqual({
+        record_id: record._id,
+        relation_type_vocabPair: ['has child', 'is child of'],
+      });
+      expect(linked).toEqual([link]);
+    });
+
+    it('hangs a Child off parent and a Linked off linked', async () => {
+      const engineWithRelations = relatedEngine();
+      const child = await engineWithRelations.form.createRelatedRecord({
+        parentRecordId: 'parent-1',
+        parentFieldId: 'samples',
+        createdBy: 'alice',
+        parentFieldValue: undefined,
+      });
+      expect(child.revision.relationship?.parent).toBeDefined();
+      expect(child.revision.relationship?.linked).toBeUndefined();
+
+      const peer = await engineWithRelations.form.createRelatedRecord({
+        parentRecordId: 'parent-1',
+        parentFieldId: 'peer',
+        createdBy: 'alice',
+        parentFieldValue: undefined,
+      });
+      expect(peer.revision.relationship?.linked).toBeDefined();
+      expect(peer.revision.relationship?.parent).toBeUndefined();
+      expect(peer.link.relation_type_vocabPair).toEqual([
+        'is linked to',
+        'is linked from',
+      ]);
+      // A field taking one holds a bare entry, not a list of one.
+      expect(peer.linked).toEqual(peer.link);
+    });
+
+    it('refuses a field that holds no relation', async () => {
+      await expect(
+        relatedEngine().form.createRelatedRecord({
+          parentRecordId: 'parent-1',
+          parentFieldId: 'First',
+          createdBy: 'alice',
+          parentFieldValue: undefined,
+        })
+      ).rejects.toThrow(/not a related-record field/);
+    });
+
+    it('appends to the links the field already holds', async () => {
+      const existing = {
+        record_id: 'sample-0',
+        relation_type_vocabPair: ['has child', 'is child of'],
+      };
+      const {link, linked} = await relatedEngine().form.createRelatedRecord({
+        parentRecordId: 'parent-1',
+        parentFieldId: 'samples',
+        createdBy: 'alice',
+        parentFieldValue: [existing],
+      });
+      expect(linked).toEqual([existing, link]);
+    });
+
+    it('writes no record when the field already holds the one link it takes', async () => {
+      const engineWithRelations = relatedEngine();
+      const before = (await db.allDocs({})).rows.length;
+      await expect(
+        engineWithRelations.form.createRelatedRecord({
+          parentRecordId: 'parent-1',
+          parentFieldId: 'peer',
+          createdBy: 'alice',
+          parentFieldValue: {
+            record_id: 'site-0',
+            relation_type_vocabPair: ['is linked to', 'is linked from'],
+          },
+        })
+      ).rejects.toThrow(/takes only one/);
+      // The refusal must come before the write, or the new row is an orphan
+      // its parent never lists.
+      expect((await db.allDocs({})).rows.length).toBe(before);
+    });
+
+    it('writes no record when the field holds a value it cannot read', async () => {
+      const engineWithRelations = relatedEngine();
+      const before = (await db.allDocs({})).rows.length;
+      await expect(
+        engineWithRelations.form.createRelatedRecord({
+          parentRecordId: 'parent-1',
+          parentFieldId: 'samples',
+          createdBy: 'alice',
+          parentFieldValue: 'legacy-id',
+        })
+      ).rejects.toThrow(/cannot be read/);
+      expect((await db.allDocs({})).rows.length).toBe(before);
+    });
+  });
+
   describe('createRevision', () => {
     test('should create child revision from parent', async () => {
       // Create initial record and revision

--- a/library/data-model/tests/relatedLinks.test.ts
+++ b/library/data-model/tests/relatedLinks.test.ts
@@ -1,0 +1,55 @@
+import {
+  readRelatedLinks,
+  relationTypeToPair,
+  withRelatedLink,
+} from '../src/databaseEngine/utils';
+
+const link = {
+  record_id: 'child-1',
+  relation_type_vocabPair: ['has child', 'is child of'] as [string, string],
+};
+
+describe('relationTypeToPair', () => {
+  it('names both ends of a child relation, the parent first', () => {
+    expect(relationTypeToPair('faims-core::Child')).toEqual([
+      'has child',
+      'is child of',
+    ]);
+  });
+
+  it('names both ends of a link', () => {
+    expect(relationTypeToPair('faims-core::Linked')).toEqual([
+      'is linked to',
+      'is linked from',
+    ]);
+  });
+});
+
+describe('readRelatedLinks', () => {
+  it('reads an empty field as holding nothing', () => {
+    expect(readRelatedLinks(undefined)).toEqual([]);
+    expect(readRelatedLinks(null)).toEqual([]);
+  });
+
+  it('reads a single stored entry as the list of one it stands for', () => {
+    expect(readRelatedLinks(link)).toEqual([link]);
+  });
+
+  it('refuses a value it cannot read, rather than reporting no links', () => {
+    // Reporting none would let the caller write over links already there.
+    expect(() => readRelatedLinks('legacy-id')).toThrow(/cannot be read/);
+  });
+});
+
+describe('withRelatedLink', () => {
+  it('appends where the field holds many', () => {
+    const existing = {...link, record_id: 'child-0'};
+    expect(
+      withRelatedLink({links: [existing], link, isMultiple: true})
+    ).toEqual([existing, link]);
+  });
+
+  it('writes one bare entry where the field takes one, not a list of one', () => {
+    expect(withRelatedLink({links: [], link, isMultiple: false})).toEqual(link);
+  });
+});

--- a/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
+++ b/library/forms/lib/fieldRegistry/fields/RelatedRecord/index.tsx
@@ -555,37 +555,18 @@ const FullRelatedRecordField = (props: FullRelatedRecordFieldProps) => {
     error: createError,
   } = useMutation({
     mutationFn: async () => {
-      // New record carries the edge: Child → `parent` on the new row; Linked →
-      // `linked` on the new row.
-      let relationship: FormRelationship;
-      const relation = {
-        fieldId: props.fieldId,
-        recordId: props.config.recordId,
-        relationTypeVocabPair: relationTypeToPair(props.relation_type),
-      };
-      if (props.relation_type === 'faims-core::Child') {
-        relationship = {
-          parent: [relation],
-        };
-      } else {
-        relationship = {
-          linked: [relation],
-        };
-      }
-
-      const res = await props.config.dataEngine().form.createRecord({
+      // The engine derives the related form, the relation and its vocab pair
+      // from this field, and writes the new row's own edge.
+      const res = await props.config.dataEngine().form.createRelatedRecord({
+        parentRecordId: props.config.recordId,
+        parentFieldId: props.fieldId,
         createdBy: props.config.user,
-        formId: props.related_type,
-        relationship,
+        parentFieldValue: props.value,
       });
 
-      props.setFieldData([
-        ...normalizedLinks,
-        {
-          record_id: res.record._id,
-          relation_type_vocabPair: relationTypeToPair(props.relation_type),
-        },
-      ] satisfies RelatedFieldValue);
+      // The parent's side goes through the open form, not a revision: a
+      // revision written under it would be lost to the commit below.
+      props.setFieldData(res.linked as RelatedFieldValue);
 
       // Persist the parent form so the new link is saved before we navigate
       // away.

--- a/library/forms/lib/fieldRegistry/fields/RelatedRecord/utils.ts
+++ b/library/forms/lib/fieldRegistry/fields/RelatedRecord/utils.ts
@@ -2,12 +2,6 @@
 // Utility Functions
 // ============================================================================
 
-import type {RelatedType} from '@faims3/data-model';
-
-export function relationTypeToPair(type: RelatedType): [string, string] {
-  if (type === 'faims-core::Child') {
-    return ['has child', 'is child of'];
-  } else {
-    return ['is linked to', 'is linked from'];
-  }
-}
+// One definition, in the engine, so this field and a view creating a related
+// record from outside a form agree on what a relation stores.
+export {relationTypeToPair} from '@faims3/data-model';

--- a/library/forms/lib/formModule/formManagers/navigation/useNavigationDataPrep.ts
+++ b/library/forms/lib/formModule/formManagers/navigation/useNavigationDataPrep.ts
@@ -1,6 +1,5 @@
 import {
   AvpUpdateMode,
-  FormRelationship,
   getFieldLabel,
   getFormLabel,
   getViewsetForField,
@@ -9,11 +8,9 @@ import {
 import {useQuery, UseQueryResult} from '@tanstack/react-query';
 import {useMemo} from 'react';
 import {
-  RelatedFieldValue,
   relatedFieldValueSchema,
   relatedRecordPropsSchema,
 } from '../../../fieldRegistry/fields/RelatedRecord/types';
-import {relationTypeToPair} from '../../../fieldRegistry/fields/RelatedRecord/utils';
 import {getImpliedNavigationRelationships} from '../../utils';
 import {FormNavigationContext, FullFormConfig} from '../types';
 import {
@@ -289,46 +286,19 @@ export function useNavigationDataPreparation({
           return;
         }
 
-        // Build the relationship for the new child
-        const relationType =
-          head.relationType === 'parent'
-            ? 'faims-core::Child'
-            : 'faims-core::Linked';
-
-        const relation = {
-          fieldId: head.fieldId,
-          recordId: head.recordId,
-          relationTypeVocabPair: relationTypeToPair(relationType),
-        };
-
-        let relationship: FormRelationship;
-        if (head.relationType === 'parent') {
-          relationship = {parent: [relation]};
-        } else {
-          relationship = {linked: [relation]};
-        }
-
-        // Create the new sibling record
-        const res = await dataEngine.form.createRecord({
+        // The engine derives the related form, the relation and its vocab
+        // pair from the field, writes the new row's own edge, and hands back
+        // what the parent's field must hold.
+        const res = await dataEngine.form.createRelatedRecord({
+          parentRecordId: head.recordId,
+          parentFieldId: head.fieldId,
           createdBy: config.user,
-          formId: formId,
-          relationship,
+          parentFieldValue: relevantFieldValue,
         });
 
-        // Update parent's field value to include new child
-        const normalizedRelationships = !relevantFieldValue
-          ? []
-          : Array.isArray(relevantFieldValue)
-            ? relevantFieldValue
-            : [relevantFieldValue];
-
-        parentFormData.data[head.fieldId].data = [
-          ...normalizedRelationships,
-          {
-            record_id: res.record._id,
-            relation_type_vocabPair: relationTypeToPair(relationType),
-          },
-        ] satisfies RelatedFieldValue;
+        // The AVP blob, not the field's stricter form value: a link already
+        // stored with the legacy empty vocab pair comes back through here.
+        parentFormData.data[head.fieldId].data = res.linked;
 
         // Update parent revision
         await dataEngine.form.updateRevision({


### PR DESCRIPTION
## Ticket

None.

## Description

Three places each built "create a record and link it to its parent" by hand: the notebook view's new action, the related-record field's create button, and the navigation "create another" path. Each hardcoded a parent/child edge and its vocab pair, and only one honoured the field's `multiple`.

## Proposed Changes

- `createRelatedRecord` on the data engine: reads the field, derives the related form, the relation and its vocab pair, refuses a link the field cannot take, creates the record with the right edge, and returns the value the parent's field must then hold.
- All three callers use it. Writing the parent's side stays with each, because a form writes it through the open form and then commits, while a view with no open form writes a revision.
- `relationTypeToPair` moves to the engine and the field's copy re-exports it.
- `canEditRecord` on the notebook view's actions calls `canEditProjectRecord` rather than rebuilding it.

## How to Test

`pnpm --filter @faims3/data-model test` and `pnpm --filter @faims3/app test`. Through the UI, creating from a related-record field and from a view should both leave the parent listing the new record.

## Additional Information

Both refusals happen before the record is written, so a link the field cannot take no longer strands a child its parent never lists. The child is still written before the parent's link, so a failure between the two is reported as created-but-not-linked.

A `multiple: false` field could previously collect a second record through the field's create button, since that path always appended a list. It now refuses like the others.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
