### PR TITLE
feat: let a plan view fetch the status reports it wants

### DIFF
--- a/app/src/gui/components/notebook/notebookView.test.tsx
+++ b/app/src/gui/components/notebook/notebookView.test.tsx
@@ -112,7 +112,6 @@ vi.mock('../../../utils/customHooks', () => ({
   invalidateProjectRecordList: vi.fn(),
   useIsAuthorisedTo: () => false,
   useIsRecordDownloadUnderway: () => false,
-  usePlanRecordStatusReports: () => new Map(),
   // Records the query it was asked for, which is what filters the whole notebook
   useRecordList: ({query}: {query: string}) => {
     queries.current.push(query);

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -25,7 +25,6 @@ import {
   invalidateProjectRecordList,
   useIsAuthorisedTo,
   useIsRecordDownloadUnderway,
-  usePlanRecordStatusReports,
   useRecordList,
 } from '../../../utils/customHooks';
 import CircularLoading from '../ui/circular_loading';
@@ -267,15 +266,6 @@ function NotebookViewWithSpec({
   const planTab = usePlanTab();
   const tab = activePlan ? planTab : notebookTab;
 
-  // Completion roll-up per record the plan on screen claims, for its cell's
-  // status; only that plan's view can display it, so the walks stop at its own
-  const planRecordStatusReports = usePlanRecordStatusReports({
-    projectId: project.projectId,
-    uiSpecification,
-    records: records.allRecords,
-    planId: activePlan?.plan.planId,
-  });
-
   // Every record the plan on screen claims. Scoping once here hands a plan view
   // and the map beside it one answer, rather than each scoping again. Without a
   // plan nothing reads these: the chooser and the default view take no props.
@@ -323,7 +313,6 @@ function NotebookViewWithSpec({
         myRecords: records.myRecords,
         otherRecords: records.otherRecords,
         syncStatus: recordStatus.data ?? {status: {}, recordHashes: {}},
-        planRecordStatusReports,
       },
       components: {
         NotebookSettings: () => <NotebookSettings uiSpec={uiSpecification} />,
@@ -357,7 +346,6 @@ function NotebookViewWithSpec({
       isDownloadingRecords,
       records,
       recordStatus.data,
-      planRecordStatusReports,
       planRecords,
       activePlan,
     ]

--- a/app/src/gui/components/notebook/types.ts
+++ b/app/src/gui/components/notebook/types.ts
@@ -1,7 +1,6 @@
 import {
   type CompiledNotebookUiSpec,
   type MinimalRecordMetadata,
-  type RecordStatusReport,
   type RegisteredPlan,
 } from '@faims3/data-model';
 import {Project} from '../../../context/slices/projectSlice';
@@ -45,9 +44,6 @@ interface RecordListProps {
   otherRecords: MinimalRecordMetadata[];
   // The current sync status of the records in the notebook
   syncStatus: RecordStatus;
-  // Recursive completion report per record claiming a plan reference
-  // (recordId -> report); entries appear as each record's report computes
-  planRecordStatusReports: ReadonlyMap<string, RecordStatusReport>;
 }
 
 interface StatusProps {

--- a/app/src/utils/customHooks.tsx
+++ b/app/src/utils/customHooks.tsx
@@ -174,8 +174,10 @@ export function buildStatusReportKey({
 }
 
 /**
- * Recursive status reports for every record the plan on screen claims, for
- * plan views that display per-record completion. One query per claiming
+ * Recursive status reports for every record the plan on screen claims, for a
+ * plan view that displays per-record completion. Called by the view that wants
+ * them rather than by the notebook, so a view that does not is not walking
+ * every record. One query per claiming
  * record, on the Status tab's own key, so reports land incrementally and
  * either surface serves the other's cache. A report spans the record's whole
  * child subtree, so any head-revision change in the notebook invalidates every


### PR DESCRIPTION
## Ticket

Closes #2302.

## Description

The notebook computed a status report for every record the plan on screen claimed and handed the result to the view. A view that does not want them walked every record anyway, and a view that wants them for records the plan does not claim, such as children of a claiming record, could not have them.

## Proposed Changes

- `planRecordStatusReports` comes off the notebook view props, and the notebook stops calling `usePlanRecordStatusReports`.
- The hook stays exported for the view that wants to call it.

## How to Test

`pnpm --filter @faims3/app test`. No visible change: nothing in the app displays these reports yet.

## Additional Information

Per [your comment on #2281](https://github.com/FAIMS/FAIMS3/pull/2281#discussion_r3954502068): "let the view take care of it if needed, if we find it generally useful we can promote it to here." That leaves the hook with no caller in this repo until a view uses it.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

