### PR TITLE
fix(app): stop the injected notebook view components remounting on every record poll

### DIFF
--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -31,7 +31,7 @@ import CircularLoading from '../ui/circular_loading';
 import {getNotebookView, PlanChooser, resolvePlanViews} from './plans';
 import {recordsClaimedBy} from './plans/planViewRecords';
 import {useRecordAudit} from '../../../utils/apiHooks/notebooks';
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import {config} from '../../../buildconfig';
 import {useQueryClient} from '@tanstack/react-query';
 import {NotebookViewComponentProps} from './types';
@@ -280,6 +280,38 @@ function NotebookViewWithSpec({
     [records.allRecords, activePlan]
   );
 
+  // Read at render time so the map still follows the plan's records without
+  // the component itself having to change identity when they do.
+  const planRecordsRef = useRef(planRecords);
+  planRecordsRef.current = planRecords;
+
+  // Held apart from the props memo, and keyed only on what they actually read.
+  // A component defined inside that memo is a new element type on every
+  // recompute, and the record list polls, so the subtree under each of these
+  // used to unmount and remount every few seconds, closing an open dialog.
+  const components: NotebookViewComponentProps['components'] = useMemo(
+    () => ({
+      NotebookSettings: () => <NotebookSettings uiSpec={uiSpecification} />,
+      MetadataDisplayComponent: () => (
+        <MetadataDisplayComponent
+          project={project}
+          templateId={project.templateId}
+        />
+      ),
+      OverviewMap: ({records: plotted}) => (
+        <OverviewMap
+          // The plan's own records unless the view asks for others, so
+          // tapping a pin cannot open a record the list beside it says is
+          // not there.
+          records={{allRecords: plotted ?? planRecordsRef.current}}
+          project_id={project.projectId}
+          uiSpec={uiSpecification}
+        />
+      ),
+    }),
+    [project, uiSpecification]
+  );
+
   const props: NotebookViewComponentProps = useMemo(
     () => ({
       project,
@@ -314,25 +346,7 @@ function NotebookViewWithSpec({
         otherRecords: records.otherRecords,
         syncStatus: recordStatus.data ?? {status: {}, recordHashes: {}},
       },
-      components: {
-        NotebookSettings: () => <NotebookSettings uiSpec={uiSpecification} />,
-        MetadataDisplayComponent: () => (
-          <MetadataDisplayComponent
-            project={project}
-            templateId={project.templateId}
-          />
-        ),
-        OverviewMap: ({records: plotted}) => (
-          <OverviewMap
-            // The plan's own records unless the view asks for others, so
-            // tapping a pin cannot open a record the list beside it says is
-            // not there.
-            records={{allRecords: plotted ?? planRecords}}
-            project_id={project.projectId}
-            uiSpec={uiSpecification}
-          />
-        ),
-      },
+      components,
     }),
     [
       project,
@@ -348,6 +362,7 @@ function NotebookViewWithSpec({
       recordStatus.data,
       planRecords,
       activePlan,
+      components,
     ]
   );
 

--- a/app/src/gui/components/notebook/notebookView.tsx
+++ b/app/src/gui/components/notebook/notebookView.tsx
@@ -31,7 +31,7 @@ import CircularLoading from '../ui/circular_loading';
 import {getNotebookView, PlanChooser, resolvePlanViews} from './plans';
 import {recordsClaimedBy} from './plans/planViewRecords';
 import {useRecordAudit} from '../../../utils/apiHooks/notebooks';
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {config} from '../../../buildconfig';
 import {useQueryClient} from '@tanstack/react-query';
 import {NotebookViewComponentProps} from './types';
@@ -280,36 +280,50 @@ function NotebookViewWithSpec({
     [records.allRecords, activePlan]
   );
 
-  // Read at render time so the map still follows the plan's records without
-  // the component itself having to change identity when they do.
-  const planRecordsRef = useRef(planRecords);
-  planRecordsRef.current = planRecords;
+  // Each of these is a component the views render, so React compares them by
+  // reference: rebuild one and the subtree under it unmounts, losing its
+  // state. Held apart from the props memo, which recomputes whenever the
+  // record list polls, and keyed on only what each one actually reads.
+  const NotebookSettingsView = useMemo(
+    () => () => <NotebookSettings uiSpec={uiSpecification} />,
+    [uiSpecification]
+  );
 
-  // Held apart from the props memo, and keyed only on what they actually read.
-  // A component defined inside that memo is a new element type on every
-  // recompute, and the record list polls, so the subtree under each of these
-  // used to unmount and remount every few seconds, closing an open dialog.
-  const components: NotebookViewComponentProps['components'] = useMemo(
-    () => ({
-      NotebookSettings: () => <NotebookSettings uiSpec={uiSpecification} />,
-      MetadataDisplayComponent: () => (
-        <MetadataDisplayComponent
-          project={project}
-          templateId={project.templateId}
-        />
-      ),
-      OverviewMap: ({records: plotted}) => (
+  const MetadataView = useMemo(
+    () => () => (
+      <MetadataDisplayComponent
+        project={project}
+        templateId={project.templateId}
+      />
+    ),
+    [project]
+  );
+
+  // Alone among the three in reading the records, so alone in still being
+  // rebuilt when they change. Capturing them in a ref instead would buy the
+  // map a stable identity by reading a value React had not committed.
+  const OverviewMapView = useMemo(
+    () =>
+      ({records: plotted}: {records?: MinimalRecordMetadata[]}) => (
         <OverviewMap
           // The plan's own records unless the view asks for others, so
           // tapping a pin cannot open a record the list beside it says is
           // not there.
-          records={{allRecords: plotted ?? planRecordsRef.current}}
+          records={{allRecords: plotted ?? planRecords}}
           project_id={project.projectId}
           uiSpec={uiSpecification}
         />
       ),
+    [planRecords, project.projectId, uiSpecification]
+  );
+
+  const components: NotebookViewComponentProps['components'] = useMemo(
+    () => ({
+      NotebookSettings: NotebookSettingsView,
+      MetadataDisplayComponent: MetadataView,
+      OverviewMap: OverviewMapView,
     }),
-    [project, uiSpecification]
+    [NotebookSettingsView, MetadataView, OverviewMapView]
   );
 
   const props: NotebookViewComponentProps = useMemo(

--- a/app/src/gui/components/notebook/notebookViewComponents.test.tsx
+++ b/app/src/gui/components/notebook/notebookViewComponents.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * The components a notebook view hands to its plan views have to keep their
+ * identity while the notebook re-renders. React compares element types by
+ * reference, so a component rebuilt on every render is a new type and the
+ * whole subtree under it unmounts, losing whatever state it held. The record
+ * list polls, so that used to happen every few seconds and closed any dialog
+ * the user had open.
+ */
+import '@testing-library/jest-dom';
+import {
+  NotebookDefinition,
+  ProjectStatus,
+  type MinimalRecordMetadata,
+} from '@faims3/data-model';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {cleanup, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {NotebookRouteProvider} from '../../../context/notebookRoute';
+import {NotebookViewTabProvider} from '../../../context/notebookViewTab';
+import {Project} from '../../../context/slices/projectSlice';
+import {NotebookView} from './notebookView';
+
+const {navigate, routeParams, allRecords, settingsMounts} = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  routeParams: {
+    current: {} as {serverId?: string; projectId?: string; planId?: string},
+  },
+  allRecords: {current: [] as Array<{recordId: string}>},
+  // One entry per mount of the settings component, so a remount is visible
+  settingsMounts: {current: 0},
+}));
+
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual<object>('react-router-dom')),
+  useNavigate: () => navigate,
+  useParams: () => routeParams.current,
+}));
+
+// The plan view renders the injected settings component and offers a way to
+// change the records, which is what the poll does in the running app.
+vi.mock('./plans', async () => {
+  const actual = await vi.importActual<object>('./plans');
+  const React = await import('react');
+  return {
+    ...actual,
+    getNotebookView: () => (props: any) =>
+      React.createElement(
+        'div',
+        null,
+        React.createElement(
+          'span',
+          {'data-testid': 'handed-records'},
+          props.records.notebookRecords
+            .map((record: MinimalRecordMetadata) => record.recordId)
+            .join(' ')
+        ),
+        React.createElement(props.components.NotebookSettings)
+      ),
+  };
+});
+
+const uiSpecification = {
+  viewsets: {},
+  views: {},
+  fields: {},
+  visible_types: [],
+  settings: {showQrCodeButton: false},
+};
+
+vi.mock('../../../context/store', () => ({
+  useAppDispatch: () => vi.fn(),
+  useAppSelector: () => ({username: 'testuser'}),
+}));
+vi.mock('../../../context/slices/authSlice', () => ({
+  selectActiveUser: vi.fn(),
+}));
+vi.mock('../../../context/slices/alertSlice', () => ({addAlert: vi.fn()}));
+vi.mock('../../../context/slices/helpers/compiledSpecService', () => ({
+  compiledSpecService: {getSpec: () => uiSpecification},
+}));
+vi.mock('../../../utils/customHooks', () => ({
+  invalidateProjectHydration: vi.fn(),
+  invalidateProjectRecordList: vi.fn(),
+  useIsAuthorisedTo: () => false,
+  useIsRecordDownloadUnderway: () => false,
+  useRecordList: () => ({
+    allRecords: allRecords.current,
+    myRecords: [],
+    otherRecords: [],
+    isLoading: false,
+    canReadAllRecords: true,
+  }),
+}));
+vi.mock('../../../utils/apiHooks/notebooks', () => ({
+  useRecordAudit: () => ({data: undefined}),
+}));
+vi.mock('../../../utils/database', () => ({localGetDataDb: () => ({})}));
+vi.mock('./DefaultNotebookView', () => ({
+  default: () => <div>default notebook view</div>,
+}));
+vi.mock('./MetadataDisplay', () => ({MetadataDisplayComponent: () => null}));
+vi.mock('./OverviewMap', () => ({OverviewMap: () => null}));
+
+// Stands in for the settings panel: it counts its mounts and holds the open
+// state of a dialog, which is the state a remount destroys.
+vi.mock('./settings', async () => {
+  const React = await import('react');
+  const CountedSettings = () => {
+    const [isOpen, setOpen] = React.useState(false);
+    React.useEffect(() => {
+      settingsMounts.current += 1;
+    }, []);
+    return React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'button',
+        {onClick: () => setOpen(true)},
+        'open dialog'
+      ),
+      isOpen
+        ? React.createElement('span', {'data-testid': 'dialog'}, 'open')
+        : null
+    );
+  };
+  return {default: CountedSettings};
+});
+
+const plans = [{planId: 'lab', planType: 'Counted', label: 'Lab'}];
+
+const project = {
+  projectId: 'proj',
+  serverId: 'srv',
+  name: 'One plan',
+  status: ProjectStatus.OPEN,
+  isActivated: true,
+  uiSpecificationId: 'spec',
+  uiDefinition: {plans} as unknown as NotebookDefinition,
+} as Project;
+
+const renderNotebook = () => {
+  routeParams.current = {serverId: 'srv', projectId: 'proj', planId: 'lab'};
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <NotebookRouteProvider>
+        <NotebookViewTabProvider>
+          <NotebookView project={project} />
+        </NotebookViewTabProvider>
+      </NotebookRouteProvider>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  navigate.mockClear();
+  allRecords.current = [{recordId: 'first'}];
+  settingsMounts.current = 0;
+});
+afterEach(() => cleanup());
+
+describe('components handed to a plan view', () => {
+  it('keeps an open dialog open when the record list changes', async () => {
+    const {rerender} = renderNotebook();
+    await userEvent.click(screen.getByRole('button', {name: 'open dialog'}));
+    expect(screen.getByTestId('dialog')).toBeInTheDocument();
+
+    // What the poll does: the same list arrives as a new array
+    allRecords.current = [{recordId: 'first'}, {recordId: 'second'}];
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <NotebookRouteProvider>
+          <NotebookViewTabProvider>
+            <NotebookView project={project} />
+          </NotebookViewTabProvider>
+        </NotebookRouteProvider>
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByTestId('handed-records')).toHaveTextContent('second');
+    expect(screen.getByTestId('dialog')).toBeInTheDocument();
+  });
+
+  it('mounts the settings component once across a record change', async () => {
+    const {rerender} = renderNotebook();
+    expect(settingsMounts.current).toBe(1);
+
+    allRecords.current = [{recordId: 'first'}, {recordId: 'second'}];
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <NotebookRouteProvider>
+          <NotebookViewTabProvider>
+            <NotebookView project={project} />
+          </NotebookViewTabProvider>
+        </NotebookRouteProvider>
+      </QueryClientProvider>
+    );
+
+    expect(settingsMounts.current).toBe(1);
+  });
+});


### PR DESCRIPTION
## Ticket

#2312

## Description

`notebookView` built the three components it injects into a notebook view inside the `props` useMemo. A component rebuilt on each recompute is a new element type, so React unmounted and remounted the subtree under it. An open settings dialog closed itself while the user was reading it.

## Proposed Changes

- The three injected components are memoised one by one, each keyed on what it actually reads, rather than together inside the props memo.
- `NotebookSettings` and `MetadataDisplayComponent` read neither the records nor anything else that polls, so they now keep their identity.
- `OverviewMap` does read the records, so it is still rebuilt when they change. `useRecordList` shares its array structurally, so a poll returning the same records rebuilds nothing.
- A test asserting the settings component survives a record change with its state intact.

## How to Test

Open a notebook, go to Settings, open the deactivate dialog and leave it open. Before this change it closed on its own within about ten seconds. `npx vitest --run src/gui/components/notebook` from `app/`.

## Additional Information

`OverviewMap` keeps a `selectedFeature` that it clears only when the user closes the popover, so a pin for a record that has since gone can outlive it. That predates this change and is untouched here.

An earlier commit on this branch gave `OverviewMap` a stable identity by holding the records in a ref. Review pointed out that reads a value React has not committed, so a concurrent render could plot records from an abandoned pass. The second commit replaces it.

## Checklist

- [x] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] I have added tests for new code if appropriate
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
